### PR TITLE
feat: add resize-observer typs

### DIFF
--- a/inputfiles/idl/Resize Observer.widl
+++ b/inputfiles/idl/Resize Observer.widl
@@ -1,0 +1,39 @@
+enum ResizeObserverBoxOptions {
+    "border-box", "content-box", "device-pixel-content-box"
+};
+
+dictionary ResizeObserverOptions {
+    ResizeObserverBoxOptions box = "content-box";
+};
+
+[Exposed=(Window),
+ Constructor(ResizeObserverCallback callback)]
+interface ResizeObserver {
+    void observe(Element target, optional ResizeObserverOptions options);
+    void unobserve(Element target);
+    void disconnect();
+};
+
+callback ResizeObserverCallback = void (sequence<ResizeObserverEntry> entries, ResizeObserver observer);
+
+[Exposed=Window]
+interface ResizeObserverEntry {
+    readonly attribute Element target;
+    readonly attribute DOMRectReadOnly contentRect;
+    readonly attribute sequence<ResizeObserverSize> borderBoxSize;
+    readonly attribute sequence<ResizeObserverSize> contentBoxSize;
+    readonly attribute sequence<ResizeObserverSize> devicePixelContentBoxSize;
+};
+
+interface ResizeObserverSize {
+    readonly attribute unrestricted double inlineSize;
+    readonly attribute unrestricted double blockSize;
+};
+
+[Constructor(Element target)
+]
+interface ResizeObservation {
+    readonly attribute Element target;
+    readonly attribute ResizeObserverBoxOptions observedBox;
+    readonly attribute sequence<ResizeObserverSize> lastReportedSizes;
+};

--- a/inputfiles/idl/Resize Observer.widl
+++ b/inputfiles/idl/Resize Observer.widl
@@ -14,7 +14,7 @@ interface ResizeObserver {
     void disconnect();
 };
 
-callback ResizeObserverCallback = void (sequence<ResizeObserverEntry> entries, ResizeObserver observer);
+callback ResizeObserverCallback = void (FrozenArray<ResizeObserverEntry> entries, ResizeObserver observer);
 
 [Exposed=Window]
 interface ResizeObserverEntry {

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -431,6 +431,10 @@
         "title": "Referrer Policy"
     },
     {
+        "url": "https://www.w3.org/TR/resize-observer/",
+        "title": "Resize Observer"
+    },
+    {
         "url": "https://w3c.github.io/resource-timing/",
         "title": "Resource Timing"
     },


### PR DESCRIPTION
However, i got an error when generating the types for Resize Observer:
```
  bareMessage: 'Attributes cannot accept sequence types',
  context: 'Syntax error at line 23, since `interface ResizeObserverEntry`:\n' +
    ' attribute sequence<ResizeObserverSize> borderBoxSize;\n' +
```

fixes https://github.com/microsoft/TypeScript/issues/37861