### PR TITLE
Update Pointer Events IDL to Level 3 Editor's Draft.

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1033,10 +1033,12 @@ interface PipeOptions {
 }
 
 interface PointerEventInit extends MouseEventInit {
+    coalescedEvents?: PointerEvent[];
     height?: number;
     isPrimary?: boolean;
     pointerId?: number;
     pointerType?: string;
+    predictedEvents?: PointerEvent[];
     pressure?: number;
     tangentialPressure?: number;
     tiltX?: number;
@@ -11747,6 +11749,8 @@ interface PointerEvent extends MouseEvent {
     readonly tiltY: number;
     readonly twist: number;
     readonly width: number;
+    getCoalescedEvents(): PointerEvent[];
+    getPredictedEvents(): PointerEvent[];
 }
 
 declare var PointerEvent: {

--- a/inputfiles/idl/Pointer Events.widl
+++ b/inputfiles/idl/Pointer Events.widl
@@ -9,10 +9,13 @@ dictionary PointerEventInit : MouseEventInit {
     long        twist = 0;
     DOMString   pointerType = "";
     boolean     isPrimary = false;
+    sequence<PointerEvent> coalescedEvents = [];
+    sequence<PointerEvent> predictedEvents = [];
 };
 
-[Constructor(DOMString type, optional PointerEventInit eventInitDict), Exposed=Window]
+[Exposed=Window]
 interface PointerEvent : MouseEvent {
+    constructor(DOMString type, optional PointerEventInit eventInitDict = {});
     readonly        attribute long        pointerId;
     readonly        attribute double      width;
     readonly        attribute double      height;
@@ -23,6 +26,8 @@ interface PointerEvent : MouseEvent {
     readonly        attribute long        twist;
     readonly        attribute DOMString   pointerType;
     readonly        attribute boolean     isPrimary;
+    sequence<PointerEvent> getCoalescedEvents();
+    sequence<PointerEvent> getPredictedEvents();
 };
 
 partial interface Element {

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -423,7 +423,7 @@
         "title": "Permissions"
     },
     {
-        "url": "https://www.w3.org/TR/pointerevents2/",
+        "url": "https://www.w3.org/TR/pointerevents3/",
         "title": "Pointer Events"
     },
     {


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/37990

Level 3 Editor's Draft URL: https://w3c.github.io/pointerevents/

This version includes a definition for getCoalescedEvents, which is supported
in [Chrome 58, Edge 79, and Firefox 59][mdn-compat].

It also adds definitions for getPredictedEvents and pointerrawupdate which are
not yet supported in any browser.

[mdn-compat]: https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/getCoalescedEvents