### PR TITLE
feat: StorageEstimateUsageDetails

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1726,9 +1726,17 @@ interface StereoPannerOptions extends AudioNodeOptions {
     pan?: number;
 }
 
+interface StorageEstimateUsageDetails {
+    caches?: number;
+    indexedDB?: number;
+    serviceWorkerRegistrations?: number;
+    [key: string]: number;
+}
+
 interface StorageEstimate {
     quota?: number;
     usage?: number;
+    usageDetails?: StorageEstimateUsageDetails
 }
 
 interface StorageEventInit extends EventInit {


### PR DESCRIPTION
This PR adds `usageDetails` to `StorageEstimate` with its own interface `StorageEstimateUsageDetails`.

This is already supported in Chrome and discussions are being had about this at [WhatWG](https://github.com/whatwg/storage/pull/69).

Try this in Chrome:

```javascript
const quota = await navigator.storage.estimate()
console.log(quota)

{
  quota: 74378659430,
  usage: 385967396,
  usageDetails: {
    caches: 335832064,
    indexedDB: 50090672,
    serviceWorkerRegistrations: 44660
  }
}
```

I added `[key: string]: number` because I'm not sure what other keys can be in the `usageDetails` object.

Read more about [StorageEstimate](https://developer.mozilla.org/en-US/docs/Web/API/StorageEstimate).

Should I also update `webworker.generated.d.ts`?