### PR TITLE
Update overridingTypes.json

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7350,7 +7350,7 @@ interface HTMLInputElement extends HTMLElement {
      * @param end The offset into the text field for the end of the selection.
      * @param direction The direction in which the selection is performed.
      */
-    setSelectionRange(start: number, end: number, direction?: "forward" | "backward" | "none"): void;
+    setSelectionRange(start: number | null, end: number | null, direction?: "forward" | "backward" | "none"): void;
     /**
      * Decrements a range input control's value by the value given by the Step attribute. If the optional parameter is used, it will decrement the input control's step value multiplied by the parameter's value.
      * @param n Value to decrement the value by.
@@ -8856,7 +8856,7 @@ interface HTMLTextAreaElement extends HTMLElement {
      * @param end The offset into the text field for the end of the selection.
      * @param direction The direction in which the selection is performed.
      */
-    setSelectionRange(start: number, end: number, direction?: "forward" | "backward" | "none"): void;
+    setSelectionRange(start: number | null, end: number | null, direction?: "forward" | "backward" | "none"): void;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTextAreaElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTextAreaElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1280,7 +1280,7 @@
                         "setSelectionRange": {
                             "name": "setSelectionRange",
                             "override-signatures": [
-                                "setSelectionRange(start: number, end: number, direction?: \"forward\" | \"backward\" | \"none\"): void"
+                                "setSelectionRange(start: number | null, end: number | null, direction?: \"forward\" | \"backward\" | \"none\"): void"
                             ]
                         }
                     }
@@ -1467,7 +1467,7 @@
                         "setSelectionRange": {
                             "name": "setSelectionRange",
                             "override-signatures": [
-                                "setSelectionRange(start: number, end: number, direction?: \"forward\" | \"backward\" | \"none\"): void"
+                                "setSelectionRange(start: number | null, end: number | null, direction?: \"forward\" | \"backward\" | \"none\"): void"
                             ]
                         }
                     }


### PR DESCRIPTION
Fix setSelectionRange types as `null` is a valid argument and comes from selectionStart and selectionEnd types as well