### PR TITLE
Add WebRTC Stats spec

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1239,17 +1239,36 @@ interface RTCIceCandidatePair {
 interface RTCIceCandidatePairStats extends RTCStats {
     availableIncomingBitrate?: number;
     availableOutgoingBitrate?: number;
+    bytesDiscardedOnSend?: number;
     bytesReceived?: number;
     bytesSent?: number;
+    circuitBreakerTriggerCount?: number;
+    consentExpiredTimestamp?: number;
+    consentRequestsSent?: number;
+    currentRoundTripTime?: number;
+    currentRtt?: number;
+    firstRequestTimestamp?: number;
+    lastPacketReceivedTimestamp?: number;
+    lastPacketSentTimestamp?: number;
+    lastRequestTimestamp?: number;
+    lastResponseTimestamp?: number;
     localCandidateId?: string;
     nominated?: boolean;
+    packetsDiscardedOnSend?: number;
+    packetsReceived?: number;
+    packetsSent?: number;
     priority?: number;
-    readable?: boolean;
     remoteCandidateId?: string;
-    roundTripTime?: number;
+    requestsReceived?: number;
+    requestsSent?: number;
+    responsesReceived?: number;
+    responsesSent?: number;
+    retransmissionsReceived?: number;
+    retransmissionsSent?: number;
     state?: RTCStatsIceCandidatePairState;
+    totalRoundTripTime?: number;
+    totalRtt?: number;
     transportId?: string;
-    writable?: boolean;
 }
 
 interface RTCIceGatherOptions {
@@ -1487,9 +1506,9 @@ interface RTCSsrcRange {
 }
 
 interface RTCStats {
-    id: string;
-    timestamp: number;
-    type: RTCStatsType;
+    id?: string;
+    timestamp?: number;
+    type?: RTCStatsType;
 }
 
 interface RTCStatsEventInit extends EventInit {
@@ -1507,13 +1526,21 @@ interface RTCTrackEventInit extends EventInit {
 }
 
 interface RTCTransportStats extends RTCStats {
-    activeConnection?: boolean;
     bytesReceived?: number;
     bytesSent?: number;
+    dtlsCipher?: string;
+    dtlsState?: RTCDtlsTransportState;
+    iceRole?: RTCIceRole;
     localCertificateId?: string;
+    packetsReceived?: number;
+    packetsSent?: number;
     remoteCertificateId?: string;
     rtcpTransportStatsId?: string;
+    selectedCandidatePairChanges?: number;
     selectedCandidatePairId?: string;
+    srtpCipher?: string;
+    tlsGroup?: string;
+    tlsVersion?: string;
 }
 
 interface ReadableStreamReadDoneResult<T> {
@@ -20080,9 +20107,9 @@ type RTCRtpTransceiverDirection = "inactive" | "recvonly" | "sendonly" | "sendre
 type RTCSctpTransportState = "closed" | "connected" | "connecting";
 type RTCSdpType = "answer" | "offer" | "pranswer" | "rollback";
 type RTCSignalingState = "closed" | "have-local-offer" | "have-local-pranswer" | "have-remote-offer" | "have-remote-pranswer" | "stable";
-type RTCStatsIceCandidatePairState = "cancelled" | "failed" | "frozen" | "inprogress" | "succeeded" | "waiting";
+type RTCStatsIceCandidatePairState = "failed" | "frozen" | "in-progress" | "succeeded" | "waiting";
 type RTCStatsIceCandidateType = "host" | "peerreflexive" | "relayed" | "serverreflexive";
-type RTCStatsType = "candidatepair" | "datachannel" | "inboundrtp" | "localcandidate" | "outboundrtp" | "remotecandidate" | "session" | "track" | "transport";
+type RTCStatsType = "candidate-pair" | "certificate" | "codec" | "csrc" | "data-channel" | "ice-server" | "inbound-rtp" | "local-candidate" | "media-source" | "outbound-rtp" | "peer-connection" | "receiver" | "remote-candidate" | "remote-inbound-rtp" | "remote-outbound-rtp" | "sctp-transport" | "sender" | "stream" | "track" | "transceiver" | "transport";
 type ReadyState = "closed" | "ended" | "open";
 type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "same-origin" | "strict-origin" | "strict-origin-when-cross-origin" | "unsafe-url";
 type RequestCache = "default" | "force-cache" | "no-cache" | "no-store" | "only-if-cached" | "reload";

--- a/inputfiles/idl/WebRTC Stats.widl
+++ b/inputfiles/idl/WebRTC Stats.widl
@@ -1,0 +1,449 @@
+    dictionary RTCStats {
+DOMHighResTimeStamp timestamp;
+RTCStatsType        type;
+DOMString           id;
+    };
+
+enum RTCStatsType {
+"codec",
+"inbound-rtp",
+"outbound-rtp",
+"remote-inbound-rtp",
+"remote-outbound-rtp",
+"media-source",
+"csrc",
+"peer-connection",
+"data-channel",
+"stream",
+"track",
+"transceiver",
+"sender",
+"receiver",
+"transport",
+"sctp-transport",
+"candidate-pair",
+"local-candidate",
+"remote-candidate",
+"certificate",
+"ice-server"
+};
+
+dictionary RTCRtpStreamStats : RTCStats {
+             unsigned long       ssrc;
+             DOMString           kind;
+             DOMString           transportId;
+             DOMString           codecId;
+};
+
+dictionary RTCCodecStats : RTCStats {
+             unsigned long payloadType;
+             RTCCodecType  codecType;
+             DOMString     transportId;
+             DOMString     mimeType;
+             unsigned long clockRate;
+             unsigned long channels;
+             DOMString     sdpFmtpLine;
+};
+
+enum RTCCodecType {
+    "encode",
+    "decode",
+};
+
+dictionary RTCReceivedRtpStreamStats : RTCRtpStreamStats {
+             unsigned long long   packetsReceived;
+             long long            packetsLost;
+             double               jitter;
+             unsigned long long   packetsDiscarded;
+             unsigned long long   packetsRepaired;
+             unsigned long long   burstPacketsLost;
+             unsigned long long   burstPacketsDiscarded;
+             unsigned long        burstLossCount;
+             unsigned long        burstDiscardCount;
+             double               burstLossRate;
+             double               burstDiscardRate;
+             double               gapLossRate;
+             double               gapDiscardRate;
+             unsigned long        framesDropped;
+             unsigned long        partialFramesLost;
+             unsigned long        fullFramesLost;
+
+};
+
+dictionary RTCInboundRtpStreamStats : RTCReceivedRtpStreamStats {
+             DOMString            trackId;
+             DOMString            receiverId;
+             DOMString            remoteId;
+             unsigned long        framesDecoded;
+             unsigned long        keyFramesDecoded;
+             unsigned long        frameWidth;
+             unsigned long        frameHeight;
+             unsigned long        frameBitDepth;
+             double               framesPerSecond;
+             unsigned long long   qpSum;
+             double               totalDecodeTime;
+             double               totalInterFrameDelay;
+             double               totalSquaredInterFrameDelay;
+             boolean              voiceActivityFlag;
+             DOMHighResTimeStamp  lastPacketReceivedTimestamp;
+             double               averageRtcpInterval;
+             unsigned long long   headerBytesReceived;
+             unsigned long long   fecPacketsReceived;
+             unsigned long long   fecPacketsDiscarded;
+             unsigned long long   bytesReceived;
+             unsigned long long   packetsFailedDecryption;
+             unsigned long long   packetsDuplicated;
+             record<USVString, unsigned long long> perDscpPacketsReceived;
+             unsigned long        nackCount;
+             unsigned long        firCount;
+             unsigned long        pliCount;
+             unsigned long        sliCount;
+             DOMHighResTimeStamp  estimatedPlayoutTimestamp;
+             double               jitterBufferDelay;
+             unsigned long long   jitterBufferEmittedCount;
+             unsigned long long   totalSamplesReceived;
+             unsigned long long   samplesDecodedWithSilk;
+             unsigned long long   samplesDecodedWithCelt;
+             unsigned long long   concealedSamples;
+             unsigned long long   silentConcealedSamples;
+             unsigned long long   concealmentEvents;
+             unsigned long long   insertedSamplesForDeceleration;
+             unsigned long long   removedSamplesForAcceleration;
+             double               audioLevel;
+             double               totalAudioEnergy;
+             double               totalSamplesDuration;
+             unsigned long        framesReceived;
+             DOMString            decoderImplementation;
+            };
+
+dictionary RTCRemoteInboundRtpStreamStats : RTCReceivedRtpStreamStats {
+             DOMString            localId;
+             double               roundTripTime;
+             double               totalRoundTripTime;
+             double               fractionLost;
+             unsigned long long   reportsReceived;
+             unsigned long long   roundTripTimeMeasurements;
+};
+
+dictionary RTCSentRtpStreamStats : RTCRtpStreamStats {
+             unsigned long      packetsSent;
+             unsigned long long bytesSent;
+};
+
+dictionary RTCOutboundRtpStreamStats : RTCSentRtpStreamStats {
+             DOMString            trackId;
+             DOMString            mediaSourceId;
+             DOMString            senderId;
+             DOMString            remoteId;
+             DOMString            rid;
+             DOMHighResTimeStamp  lastPacketSentTimestamp;
+             unsigned long long   headerBytesSent;
+             unsigned long        packetsDiscardedOnSend;
+             unsigned long long   bytesDiscardedOnSend;
+             unsigned long        fecPacketsSent;
+             unsigned long long   retransmittedPacketsSent;
+             unsigned long long   retransmittedBytesSent;
+             double               targetBitrate;
+             unsigned long long   totalEncodedBytesTarget;
+             unsigned long        frameWidth;
+             unsigned long        frameHeight;
+             unsigned long        frameBitDepth;
+             double               framesPerSecond;
+             unsigned long        framesSent;
+             unsigned long        hugeFramesSent;
+             unsigned long        framesEncoded;
+             unsigned long        keyFramesEncoded;
+             unsigned long        framesDiscardedOnSend;
+             unsigned long long   qpSum;
+             unsigned long long   totalSamplesSent;
+             unsigned long long   samplesEncodedWithSilk;
+             unsigned long long   samplesEncodedWithCelt;
+             boolean              voiceActivityFlag;
+             double               totalEncodeTime;
+             double               totalPacketSendDelay;
+             double               averageRtcpInterval;
+             RTCQualityLimitationReason                 qualityLimitationReason;
+             record<DOMString, double> qualityLimitationDurations;
+             unsigned long        qualityLimitationResolutionChanges;
+             record<USVString, unsigned long long> perDscpPacketsSent;
+             unsigned long        nackCount;
+             unsigned long        firCount;
+             unsigned long        pliCount;
+             unsigned long        sliCount;
+             DOMString            encoderImplementation;
+};
+
+enum RTCQualityLimitationReason {
+            "none",
+            "cpu",
+            "bandwidth",
+            "other",
+          };
+
+dictionary RTCRemoteOutboundRtpStreamStats : RTCSentRtpStreamStats {
+             DOMString           localId;
+             DOMHighResTimeStamp remoteTimestamp;
+             unsigned long long  reportsSent;
+};
+
+dictionary RTCMediaSourceStats : RTCStats {
+             DOMString       trackIdentifier;
+             DOMString       kind;
+};
+
+dictionary RTCAudioSourceStats : RTCMediaSourceStats {
+              double              audioLevel;
+              double              totalAudioEnergy;
+              double              totalSamplesDuration;
+              double              echoReturnLoss;
+              double              echoReturnLossEnhancement;
+};
+
+dictionary RTCVideoSourceStats : RTCMediaSourceStats {
+             unsigned long   width;
+             unsigned long   height;
+             unsigned long   bitDepth;
+             unsigned long   frames;
+             unsigned long   framesPerSecond;
+};
+
+dictionary RTCRtpContributingSourceStats : RTCStats {
+             unsigned long contributorSsrc;
+             DOMString     inboundRtpStreamId;
+             unsigned long packetsContributedTo;
+             double        audioLevel;
+};
+
+dictionary RTCPeerConnectionStats : RTCStats {
+            unsigned long dataChannelsOpened;
+            unsigned long dataChannelsClosed;
+            unsigned long dataChannelsRequested;
+            unsigned long dataChannelsAccepted;
+};
+
+dictionary RTCRtpTransceiverStats {
+    DOMString senderId;
+    DOMString receiverId;
+    DOMString mid;
+};
+
+dictionary RTCMediaHandlerStats : RTCStats {
+             DOMString           trackIdentifier;
+             boolean             remoteSource;
+             boolean             ended;
+             DOMString           kind;
+             RTCPriorityType     priority;
+};
+
+dictionary RTCVideoHandlerStats : RTCMediaHandlerStats {
+};
+
+dictionary RTCVideoSenderStats : RTCVideoHandlerStats {
+             DOMString           mediaSourceId;
+};
+
+dictionary RTCSenderVideoTrackAttachmentStats : RTCVideoSenderStats {
+};
+
+dictionary RTCVideoReceiverStats : RTCVideoHandlerStats {
+};
+
+dictionary RTCAudioHandlerStats : RTCMediaHandlerStats {
+};
+
+dictionary RTCAudioSenderStats : RTCAudioHandlerStats {
+             DOMString           mediaSourceId;
+};
+
+dictionary RTCSenderAudioTrackAttachmentStats : RTCAudioSenderStats {
+};
+
+dictionary RTCAudioReceiverStats : RTCAudioHandlerStats {
+};
+
+dictionary RTCDataChannelStats : RTCStats {
+             DOMString           label;
+             DOMString           protocol;
+             long                dataChannelIdentifier;
+             DOMString           transportId;
+             RTCDataChannelState state;
+             unsigned long       messagesSent;
+             unsigned long long  bytesSent;
+             unsigned long       messagesReceived;
+             unsigned long long  bytesReceived;
+};
+
+dictionary RTCTransportStats : RTCStats {
+             unsigned long long    packetsSent;
+             unsigned long long    packetsReceived;
+             unsigned long long    bytesSent;
+             unsigned long long    bytesReceived;
+             DOMString             rtcpTransportStatsId;
+             RTCIceRole            iceRole;
+             RTCDtlsTransportState dtlsState;
+             DOMString             selectedCandidatePairId;
+             DOMString             localCertificateId;
+             DOMString             remoteCertificateId;
+             DOMString             tlsVersion;
+             DOMString             dtlsCipher;
+             DOMString             srtpCipher;
+             DOMString             tlsGroup;
+             unsigned long         selectedCandidatePairChanges;
+};
+
+dictionary RTCSctpTransportStats : RTCStats {
+    double smoothedRoundTripTime;
+};
+
+dictionary RTCIceCandidateStats : RTCStats {
+             DOMString                transportId;
+             DOMString?               address;
+             long                     port;
+             DOMString                protocol;
+             RTCIceCandidateType      candidateType;
+             long                     priority;
+             DOMString                url;
+             DOMString                relayProtocol;
+};
+
+dictionary RTCIceCandidatePairStats : RTCStats {
+             DOMString                     transportId;
+             DOMString                     localCandidateId;
+             DOMString                     remoteCandidateId;
+             RTCStatsIceCandidatePairState state;
+             boolean                       nominated;
+             unsigned long long            packetsSent;
+             unsigned long long            packetsReceived;
+             unsigned long long            bytesSent;
+             unsigned long long            bytesReceived;
+             DOMHighResTimeStamp           lastPacketSentTimestamp;
+             DOMHighResTimeStamp           lastPacketReceivedTimestamp;
+             DOMHighResTimeStamp           firstRequestTimestamp;
+             DOMHighResTimeStamp           lastRequestTimestamp;
+             DOMHighResTimeStamp           lastResponseTimestamp;
+             double                        totalRoundTripTime;
+             double                        currentRoundTripTime;
+             double                        availableOutgoingBitrate;
+             double                        availableIncomingBitrate;
+             unsigned long                 circuitBreakerTriggerCount;
+             unsigned long long            requestsReceived;
+             unsigned long long            requestsSent;
+             unsigned long long            responsesReceived;
+             unsigned long long            responsesSent;
+             unsigned long long            retransmissionsReceived;
+             unsigned long long            retransmissionsSent;
+             unsigned long long            consentRequestsSent;
+             DOMHighResTimeStamp           consentExpiredTimestamp;
+             unsigned long                 packetsDiscardedOnSend;
+             unsigned long long            bytesDiscardedOnSend;
+};
+
+enum RTCStatsIceCandidatePairState {
+    "frozen",
+    "waiting",
+    "in-progress",
+    "failed",
+    "succeeded"
+};
+
+dictionary RTCCertificateStats : RTCStats {
+             DOMString fingerprint;
+             DOMString fingerprintAlgorithm;
+             DOMString base64Certificate;
+             DOMString issuerCertificateId;
+};
+
+dictionary RTCIceServerStats : RTCStats {
+             DOMString url;
+             long port;
+             DOMString protocol;
+             unsigned long totalRequestsSent;
+             unsigned long totalResponsesReceived;
+             double totalRoundTripTime;
+  };
+
+dictionary RTCMediaStreamStats : RTCStats {
+  DOMString streamIdentifier;
+  sequence<DOMString> trackIds;
+};
+
+dictionary RTCReceiverVideoTrackAttachmentStats : RTCVideoReceiverStats {};
+
+dictionary RTCReceiverAudioTrackAttachmentStats : RTCAudioReceiverStats {};
+
+partial dictionary RTCCodecStats {
+    DOMString implementation;
+};
+
+partial dictionary RTCIceCandidateStats {
+    boolean deleted = false;
+    boolean isRemote;
+};
+
+partial dictionary RTCIceCandidatePairStats {
+    double totalRtt;
+    double currentRtt;
+    unsigned long long priority;
+};
+
+partial dictionary RTCRtpStreamStats {
+    DOMString mediaType;
+    double averageRTCPInterval;
+};
+
+partial dictionary RTCInboundRtpStreamStats {
+    double fractionLost;
+};
+
+partial dictionary RTCAudioHandlerStats {
+    double audioLevel;
+    double totalAudioEnergy;
+    double totalSamplesDuration;
+    boolean voiceActivityFlag;
+};
+
+partial dictionary RTCAudioSenderStats {
+    unsigned long long totalSamplesSent;
+    double echoReturnLoss;
+    double echoReturnLossEnhancement;
+};
+
+partial dictionary RTCAudioReceiverStats {
+    DOMHighResTimeStamp estimatedPlayoutTimestamp;
+    double jitterBufferDelay;
+    unsigned long long jitterBufferEmittedCount;
+    unsigned long long totalSamplesReceived;
+    unsigned long long concealedSamples;
+    unsigned long long silentConcealedSamples;
+    unsigned long long concealmentEvents;
+    unsigned long long insertedSamplesForDeceleration;
+    unsigned long long removedSamplesForAcceleration;
+    double audioLevel;
+    double totalAudioEnergy;
+    double totalSamplesDuration;
+};
+
+partial dictionary RTCVideoHandlerStats {
+    unsigned long frameWidth;
+    unsigned long frameHeight;
+    double framesPerSecond;
+};
+
+partial dictionary RTCVideoSenderStats {
+    unsigned long keyFramesSent;
+    unsigned long framesCaptured;
+    unsigned long framesSent;
+    unsigned long hugeFramesSent;
+};
+
+partial dictionary RTCVideoReceiverStats {
+    unsigned long keyFramesReceived;
+    DOMHighResTimeStamp estimatedPlayoutTimestamp;
+    double jitterBufferDelay;
+    unsigned long long jitterBufferEmittedCount;
+    unsigned long framesReceived;
+    unsigned long framesDecoded;
+    unsigned long framesDropped;
+    unsigned long partialFramesLost;
+    unsigned long fullFramesLost;
+};

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -643,6 +643,10 @@
         "title": "WebRTC"
     },
     {
+        "url": "https://www.w3.org/TR/webrtc-stats",
+        "title": "WebRTC Stats"
+    },
+    {
         "url": "https://www.w3.org/TR/web-share/",
         "title": "Web Share"
     },


### PR DESCRIPTION
This proposes bringing in the WebRTC Stats spec. The driver here is updating the `RTCStatsType` enum values, as described in https://github.com/microsoft/TypeScript/issues/36650, but there are other changes that the README-recommended `fetch-idl` process brings in as well. 

My initial thinking was that getting all the spec updates in is preferable, but I'm also not totally sure where browser adoption is for this spec, so I'm not sure what level belongs in TypeScript. Could isolate to just `RTCStatsType` to mitigate risk.

Side note: importing this spec via the README instructions did require a bit of editing to remove the text "WebIDL" in front of each WebIDL block, due to a `.idlHeader` element with that text appearing inside the `.idl` code block. It looks like a number of other specs have a similar thing going on:
- `Gamepad`
- `Push`
- `Screen Orientation`
- `Selection`
- `Web Share`
- and this one, `WebRTC Stats`

I'm happy to open a separate issue to suggest some kind of filtering to avoid similar manual IDL-editing effort in the future if that makes sense - just let me know.