### PR TITLE
Update Web Speech API to match idl

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -15374,7 +15374,6 @@ interface StorageEvent extends Event {
      * Returns the URL of the document whose storage item changed.
      */
     readonly url: string;
-    initStorageEvent(type: string, bubbles?: boolean, cancelable?: boolean, key?: string | null, oldValue?: string | null, newValue?: string | null, url?: string, storageArea?: Storage | null): void;
 }
 
 declare var StorageEvent: {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -15105,7 +15105,7 @@ interface SpeechRecognitionEventMap {
     "audioend": Event;
     "audiostart": Event;
     "end": Event;
-    "error": ErrorEvent;
+    "error": SpeechRecognitionErrorEvent;
     "nomatch": SpeechRecognitionEvent;
     "result": SpeechRecognitionEvent;
     "soundend": Event;
@@ -15124,7 +15124,7 @@ interface SpeechRecognition extends EventTarget {
     onaudioend: ((this: SpeechRecognition, ev: Event) => any) | null;
     onaudiostart: ((this: SpeechRecognition, ev: Event) => any) | null;
     onend: ((this: SpeechRecognition, ev: Event) => any) | null;
-    onerror: ((this: SpeechRecognition, ev: ErrorEvent) => any) | null;
+    onerror: ((this: SpeechRecognition, ev: SpeechRecognitionErrorEvent) => any) | null;
     onnomatch: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => any) | null;
     onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => any) | null;
     onsoundend: ((this: SpeechRecognition, ev: Event) => any) | null;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1700,6 +1700,16 @@ interface ShareData {
     url?: string;
 }
 
+interface SpeechRecognitionErrorEventInit extends EventInit {
+    error: SpeechRecognitionErrorCode;
+    message?: string;
+}
+
+interface SpeechRecognitionEventInit extends EventInit {
+    resultIndex?: number;
+    results: SpeechRecognitionResultList;
+}
+
 interface SpeechSynthesisErrorEventInit extends SpeechSynthesisEventInit {
     error: SpeechSynthesisErrorCode;
 }
@@ -4680,6 +4690,7 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
     createEvent(eventInterface: "SVGZoomEvents"): SVGZoomEvent;
     createEvent(eventInterface: "SecurityPolicyViolationEvent"): SecurityPolicyViolationEvent;
     createEvent(eventInterface: "ServiceWorkerMessageEvent"): ServiceWorkerMessageEvent;
+    createEvent(eventInterface: "SpeechRecognitionErrorEvent"): SpeechRecognitionErrorEvent;
     createEvent(eventInterface: "SpeechRecognitionEvent"): SpeechRecognitionEvent;
     createEvent(eventInterface: "SpeechSynthesisErrorEvent"): SpeechSynthesisErrorEvent;
     createEvent(eventInterface: "SpeechSynthesisEvent"): SpeechSynthesisEvent;
@@ -4929,6 +4940,7 @@ interface DocumentEvent {
     createEvent(eventInterface: "SVGZoomEvents"): SVGZoomEvent;
     createEvent(eventInterface: "SecurityPolicyViolationEvent"): SecurityPolicyViolationEvent;
     createEvent(eventInterface: "ServiceWorkerMessageEvent"): ServiceWorkerMessageEvent;
+    createEvent(eventInterface: "SpeechRecognitionErrorEvent"): SpeechRecognitionErrorEvent;
     createEvent(eventInterface: "SpeechRecognitionEvent"): SpeechRecognitionEvent;
     createEvent(eventInterface: "SpeechSynthesisErrorEvent"): SpeechSynthesisErrorEvent;
     createEvent(eventInterface: "SpeechSynthesisEvent"): SpeechSynthesisEvent;
@@ -15144,6 +15156,16 @@ declare var SpeechRecognitionAlternative: {
     new(): SpeechRecognitionAlternative;
 };
 
+interface SpeechRecognitionErrorEvent extends Event {
+    readonly error: SpeechRecognitionErrorCode;
+    readonly message: string;
+}
+
+declare var SpeechRecognitionErrorEvent: {
+    prototype: SpeechRecognitionErrorEvent;
+    new(type: string, eventInitDict: SpeechRecognitionErrorEventInit): SpeechRecognitionErrorEvent;
+};
+
 interface SpeechRecognitionEvent extends Event {
     readonly resultIndex: number;
     readonly results: SpeechRecognitionResultList;
@@ -15151,7 +15173,7 @@ interface SpeechRecognitionEvent extends Event {
 
 declare var SpeechRecognitionEvent: {
     prototype: SpeechRecognitionEvent;
-    new(): SpeechRecognitionEvent;
+    new(type: string, eventInitDict: SpeechRecognitionEventInit): SpeechRecognitionEvent;
 };
 
 interface SpeechRecognitionResult {
@@ -15352,6 +15374,7 @@ interface StorageEvent extends Event {
      * Returns the URL of the document whose storage item changed.
      */
     readonly url: string;
+    initStorageEvent(type: string, bubbles?: boolean, cancelable?: boolean, key?: string | null, oldValue?: string | null, newValue?: string | null, url?: string, storageArea?: Storage | null): void;
 }
 
 declare var StorageEvent: {
@@ -20102,6 +20125,7 @@ type SelectionMode = "end" | "preserve" | "select" | "start";
 type ServiceWorkerState = "activated" | "activating" | "installed" | "installing" | "parsed" | "redundant";
 type ServiceWorkerUpdateViaCache = "all" | "imports" | "none";
 type ShadowRootMode = "closed" | "open";
+type SpeechRecognitionErrorCode = "aborted" | "audio-capture" | "bad-grammar" | "language-not-supported" | "network" | "no-speech" | "not-allowed" | "service-not-allowed";
 type SpeechSynthesisErrorCode = "audio-busy" | "audio-hardware" | "canceled" | "interrupted" | "invalid-argument" | "language-unavailable" | "network" | "not-allowed" | "synthesis-failed" | "synthesis-unavailable" | "text-too-long" | "voice-unavailable";
 type TextTrackKind = "captions" | "chapters" | "descriptions" | "metadata" | "subtitles";
 type TextTrackMode = "disabled" | "hidden" | "showing";

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -986,7 +986,7 @@
                         },
                         {
                             "name": "error",
-                            "type": "ErrorEvent"
+                            "type": "SpeechRecognitionErrorEvent"
                         },
                         {
                             "name": "end",

--- a/inputfiles/idl/Web Speech API.widl
+++ b/inputfiles/idl/Web Speech API.widl
@@ -10,9 +10,9 @@ interface SpeechRecognition : EventTarget {
     attribute unsigned long maxAlternatives;
 
     // methods to drive the speech interaction
-    void start();
-    void stop();
-    void abort();
+    undefined start();
+    undefined stop();
+    undefined abort();
 
     // event methods
     attribute EventHandler onaudiostart;
@@ -99,9 +99,9 @@ interface SpeechGrammarList {
     constructor();
     readonly attribute unsigned long length;
     getter SpeechGrammar item(unsigned long index);
-    void addFromURI(DOMString src,
+    undefined addFromURI(DOMString src,
                     optional float weight = 1.0);
-    void addFromString(DOMString string,
+    undefined addFromString(DOMString string,
                     optional float weight = 1.0);
 };
 
@@ -113,10 +113,10 @@ interface SpeechSynthesis : EventTarget {
 
     attribute EventHandler onvoiceschanged;
 
-    void speak(SpeechSynthesisUtterance utterance);
-    void cancel();
-    void pause();
-    void resume();
+    undefined speak(SpeechSynthesisUtterance utterance);
+    undefined cancel();
+    undefined pause();
+    undefined resume();
     sequence<SpeechSynthesisVoice> getVoices();
 };
 

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -283,17 +283,6 @@
                     }
                 }
             },
-            "SpeechRecognitionEvent": {
-                "constructor": null
-            },
-            "SpeechRecognitionErrorEvent": null,
-            "StorageEvent": {
-                "methods": {
-                    "method": {
-                        "initStorageEvent": null
-                    }
-                }
-            },
             "SVGElementInstance": {
                 "properties": {
                     "property": {

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -283,6 +283,13 @@
                     }
                 }
             },
+            "StorageEvent": {
+                "methods": {
+                    "method": {
+                        "initStorageEvent": null
+                    }
+                }
+            },
             "SVGElementInstance": {
                 "properties": {
                     "property": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ function emitDom() {
         const idl: string = fs.readFileSync(path.join(inputFolder, "idl", filename), { encoding: "utf-8" });
         const commentsMapFilePath = path.join(inputFolder, "idl", title + ".commentmap.json");
         const commentsMap: Record<string, string> = fs.existsSync(commentsMapFilePath) ? require(commentsMapFilePath) : {};
-        commentCleanup(commentsMap)
+        commentCleanup(commentsMap);
         const result = convert(idl, commentsMap);
         if (deprecated) {
             mapToArray(result.browser.interfaces!.interface).forEach(markAsDeprecated);


### PR DESCRIPTION
Changed the type of the SpeechRecognition event handler for error from ErrorEvent to SpeechRecognitionErrorEvent to match the [API](https://wicg.github.io/speech-api). This adds the types `SpeechRecognitionErrorEvent` and `SpeechRecognitionErrorCode` back in and resolves [this issue](https://github.com/microsoft/TypeScript/issues/37046). 

If it's a potential problem, this reverses some of the changes made [here](https://github.com/microsoft/TypeScript-DOM-lib-generator/commit/1f859ddee3b17f409837694ff89d8d0e7d70f13f).