### PR TITLE
Added event handlers for gamepadconnected GamepadEvent

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -18374,6 +18374,8 @@ interface WindowEventMap extends GlobalEventHandlersEventMap, WindowEventHandler
     "ended": Event;
     "error": ErrorEvent;
     "focus": FocusEvent;
+    "gamepadconnected": GamepadEvent;
+    "gamepaddisconnected": GamepadEvent;
     "hashchange": HashChangeEvent;
     "input": Event;
     "invalid": Event;
@@ -18477,6 +18479,8 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
     ondevicemotion: ((this: Window, ev: DeviceMotionEvent) => any) | null;
     ondeviceorientation: ((this: Window, ev: DeviceOrientationEvent) => any) | null;
     ondeviceorientationabsolute: ((this: Window, ev: DeviceOrientationEvent) => any) | null;
+    ongamepadconnected: ((this: Window, ev: GamepadEvent) => any) | null;
+    ongamepaddisconnected: ((this: Window, ev: GamepadEvent) => any) | null;
     onmousewheel: ((this: Window, ev: Event) => any) | null;
     onmsgesturechange: ((this: Window, ev: Event) => any) | null;
     onmsgesturedoubletap: ((this: Window, ev: Event) => any) | null;
@@ -19517,6 +19521,8 @@ declare var ondevicelight: ((this: Window, ev: DeviceLightEvent) => any) | null;
 declare var ondevicemotion: ((this: Window, ev: DeviceMotionEvent) => any) | null;
 declare var ondeviceorientation: ((this: Window, ev: DeviceOrientationEvent) => any) | null;
 declare var ondeviceorientationabsolute: ((this: Window, ev: DeviceOrientationEvent) => any) | null;
+declare var ongamepadconnected: ((this: Window, ev: GamepadEvent) => any) | null;
+declare var ongamepaddisconnected: ((this: Window, ev: GamepadEvent) => any) | null;
 declare var onmousewheel: ((this: Window, ev: Event) => any) | null;
 declare var onmsgesturechange: ((this: Window, ev: Event) => any) | null;
 declare var onmsgesturedoubletap: ((this: Window, ev: Event) => any) | null;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -428,6 +428,20 @@
                         "customElements": {
                             "name": "customElements",
                             "type": "CustomElementRegistry"
+                        },
+                        "ongamepadconnected": {
+                            "name": "ongamepadconnected",
+                            "type-original": "EventHandler",
+                            "nullable": 1,
+                            "type": "EventHandlerNonNull",
+                            "event-handler": "gamepadconnected"
+                        },
+                        "ongamepaddisconnected": {
+                            "name": "ongamepaddisconnected",
+                            "type-original": "EventHandler",
+                            "nullable": 1,
+                            "type": "EventHandlerNonNull",
+                            "event-handler": "gamepaddisconnected"
                         }
                     }
                 },


### PR DESCRIPTION
Added event handlers ongamepadconnected and ongamepaddisconnected to add their corresponding events to lib.dom.d.ts and resolve [this issue](https://github.com/microsoft/TypeScript/issues/39425). The event handler names were taken from [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/ongamepadconnected).