### PR TITLE
Add conditional return type for Clients.matchAll

### DIFF
--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -900,7 +900,7 @@ declare var Client: {
 interface Clients {
     claim(): Promise<void>;
     get(id: string): Promise<Client | undefined>;
-    matchAll(options?: ClientQueryOptions): Promise<ReadonlyArray<Client>>;
+    matchAll<T extends ClientQueryOptions>(options?: T): Promise<ReadonlyArray<T extends { type: "window" } ? WindowClient : Client>>;
     openWindow(url: string): Promise<WindowClient | null>;
 }
 

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -900,7 +900,7 @@ declare var Client: {
 interface Clients {
     claim(): Promise<void>;
     get(id: string): Promise<Client | undefined>;
-    matchAll<T extends ClientQueryOptions>(options?: T): Promise<ReadonlyArray<T extends { type: "window" } ? WindowClient : Client>>;
+    matchAll<T extends ClientQueryOptions>(options?: T): Promise<ReadonlyArray<T["type"] extends "window" ? WindowClient : Client>>;
     openWindow(url: string): Promise<WindowClient | null>;
 }
 

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2566,7 +2566,7 @@
                         },
                         "matchAll": {
                             "override-signatures": [
-                                "matchAll<T extends ClientQueryOptions>(options?: T): Promise<ReadonlyArray<T extends { type: \"window\" } ? WindowClient : Client>>"
+                                "matchAll<T extends ClientQueryOptions>(options?: T): Promise<ReadonlyArray<T[\"type\"] extends \"window\" ? WindowClient : Client>>"
                             ]
                         }
                     }

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2563,6 +2563,11 @@
                             "override-signatures": [
                                 "get(id: string): Promise<Client | undefined>"
                             ]
+                        },
+                        "matchAll": {
+                            "override-signatures": [
+                                "matchAll<T extends ClientQueryOptions>(options?: T): Promise<ReadonlyArray<T extends { type: \"window\" } ? WindowClient : Client>>"
+                            ]
                         }
                     }
                 }


### PR DESCRIPTION
When specifically querying for clients of type `window`, return the specific `WindowClient` type instead of the generic `Client` type.