### PR TITLE
Remove HTMLBaseFontElement

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3802,10 +3802,6 @@ declare var DOMImplementation: {
     new(): DOMImplementation;
 };
 
-interface DOML2DeprecatedColorProperty {
-    color: string;
-}
-
 interface DOMMatrix extends DOMMatrixReadOnly {
     a: number;
     b: number;
@@ -6282,29 +6278,6 @@ interface HTMLBaseElement extends HTMLElement {
 declare var HTMLBaseElement: {
     prototype: HTMLBaseElement;
     new(): HTMLBaseElement;
-};
-
-/** Provides special properties (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating <basefont> elements. */
-interface HTMLBaseFontElement extends HTMLElement, DOML2DeprecatedColorProperty {
-    /**
-     * Sets or retrieves the current typeface family.
-     */
-    /** @deprecated */
-    face: string;
-    /**
-     * Sets or retrieves the font size of the object.
-     */
-    /** @deprecated */
-    size: number;
-    addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLBaseFontElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-    removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLBaseFontElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-}
-
-declare var HTMLBaseFontElement: {
-    prototype: HTMLBaseFontElement;
-    new(): HTMLBaseFontElement;
 };
 
 interface HTMLBodyElementEventMap extends HTMLElementEventMap, WindowEventHandlersEventMap {
@@ -19320,7 +19293,6 @@ interface HTMLElementTagNameMap {
     "audio": HTMLAudioElement;
     "b": HTMLElement;
     "base": HTMLBaseElement;
-    "basefont": HTMLBaseFontElement;
     "bdi": HTMLElement;
     "bdo": HTMLElement;
     "blockquote": HTMLQuoteElement;

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -1338,18 +1338,6 @@
                     }
                 }
             },
-            "HTMLBaseFontElement": {
-                "properties": {
-                    "property": {
-                        "face": {
-                            "comment": "/**\n * Sets or retrieves the current typeface family.\n */"
-                        },
-                        "size": {
-                            "comment": "/**\n * Sets or retrieves the font size of the object.\n */"
-                        }
-                    }
-                }
-            },
             "HTMLTextAreaElement": {
                 "properties": {
                     "property": {

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -199,6 +199,7 @@
             "FederatedCredential": null,
             "FormDataEvent": null,
             "HTMLAreasCollection": null,
+            "HTMLBaseFontElement": null,
             "HTMLMediaElement": {
                 "properties": {
                     "property": {


### PR DESCRIPTION
It was already deprecated in [DOM2](https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-32774408) and then removed in HTML5.

Part of #914/#915