### PR TITLE
Add Payment Request types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -15,6 +15,19 @@ interface AddEventListenerOptions extends EventListenerOptions {
     passive?: boolean;
 }
 
+interface AddressErrors {
+    addressLine?: string;
+    city?: string;
+    country?: string;
+    dependentLocality?: string;
+    organization?: string;
+    phone?: string;
+    postalCode?: string;
+    recipient?: string;
+    region?: string;
+    sortingCode?: string;
+}
+
 interface AesCbcParams extends Algorithm {
     iv: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer;
 }
@@ -940,9 +953,14 @@ interface PannerOptions extends AudioNodeOptions {
     rolloffFactor?: number;
 }
 
+interface PayerErrors {
+    email?: string;
+    name?: string;
+    phone?: string;
+}
+
 interface PaymentCurrencyAmount {
     currency: string;
-    currencySystem?: string;
     value: string;
 }
 
@@ -966,6 +984,9 @@ interface PaymentDetailsModifier {
 
 interface PaymentDetailsUpdate extends PaymentDetailsBase {
     error?: string;
+    payerErrors?: PayerErrors;
+    paymentMethodErrors?: any;
+    shippingAddressErrors?: AddressErrors;
     total?: PaymentItem;
 }
 
@@ -975,17 +996,23 @@ interface PaymentItem {
     pending?: boolean;
 }
 
+interface PaymentMethodChangeEventInit extends PaymentRequestUpdateEventInit {
+    methodDetails?: any;
+    methodName?: string;
+}
+
 interface PaymentMethodData {
     data?: any;
     supportedMethods: string | string[];
 }
 
 interface PaymentOptions {
+    requestBillingAddress?: boolean;
     requestPayerEmail?: boolean;
     requestPayerName?: boolean;
     requestPayerPhone?: boolean;
     requestShipping?: boolean;
-    shippingType?: string;
+    shippingType?: PaymentShippingType;
 }
 
 interface PaymentRequestUpdateEventInit extends EventInit {
@@ -996,6 +1023,13 @@ interface PaymentShippingOption {
     id: string;
     label: string;
     selected?: boolean;
+}
+
+interface PaymentValidationErrors {
+    error?: string;
+    payer?: PayerErrors;
+    paymentMethod?: any;
+    shippingAddress?: AddressErrors;
 }
 
 interface Pbkdf2Params extends Algorithm {
@@ -4668,6 +4702,7 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
     createEvent(eventInterface: "OfflineAudioCompletionEvent"): OfflineAudioCompletionEvent;
     createEvent(eventInterface: "OverflowEvent"): OverflowEvent;
     createEvent(eventInterface: "PageTransitionEvent"): PageTransitionEvent;
+    createEvent(eventInterface: "PaymentMethodChangeEvent"): PaymentMethodChangeEvent;
     createEvent(eventInterface: "PaymentRequestUpdateEvent"): PaymentRequestUpdateEvent;
     createEvent(eventInterface: "PermissionRequestedEvent"): PermissionRequestedEvent;
     createEvent(eventInterface: "PointerEvent"): PointerEvent;
@@ -4918,6 +4953,7 @@ interface DocumentEvent {
     createEvent(eventInterface: "OfflineAudioCompletionEvent"): OfflineAudioCompletionEvent;
     createEvent(eventInterface: "OverflowEvent"): OverflowEvent;
     createEvent(eventInterface: "PageTransitionEvent"): PageTransitionEvent;
+    createEvent(eventInterface: "PaymentMethodChangeEvent"): PaymentMethodChangeEvent;
     createEvent(eventInterface: "PaymentRequestUpdateEvent"): PaymentRequestUpdateEvent;
     createEvent(eventInterface: "PermissionRequestedEvent"): PermissionRequestedEvent;
     createEvent(eventInterface: "PointerEvent"): PointerEvent;
@@ -11378,11 +11414,10 @@ declare var Path2D: {
 
 /** This Payment Request API interface is used to store shipping or payment address information. */
 interface PaymentAddress {
-    readonly addressLine: string[];
+    readonly addressLine: ReadonlyArray<string>;
     readonly city: string;
     readonly country: string;
     readonly dependentLocality: string;
-    readonly languageCode: string;
     readonly organization: string;
     readonly phone: string;
     readonly postalCode: string;
@@ -11397,7 +11432,18 @@ declare var PaymentAddress: {
     new(): PaymentAddress;
 };
 
+interface PaymentMethodChangeEvent extends PaymentRequestUpdateEvent {
+    readonly methodDetails: any;
+    readonly methodName: string;
+}
+
+declare var PaymentMethodChangeEvent: {
+    prototype: PaymentMethodChangeEvent;
+    new(type: string, eventInitDict?: PaymentMethodChangeEventInit): PaymentMethodChangeEvent;
+};
+
 interface PaymentRequestEventMap {
+    "paymentmethodchange": Event;
     "shippingaddresschange": Event;
     "shippingoptionchange": Event;
 }
@@ -11405,6 +11451,7 @@ interface PaymentRequestEventMap {
 /** This Payment Request API interface is the primary access point into the API, and lets web content and apps accept payments from the end user. */
 interface PaymentRequest extends EventTarget {
     readonly id: string;
+    onpaymentmethodchange: ((this: PaymentRequest, ev: Event) => any) | null;
     onshippingaddresschange: ((this: PaymentRequest, ev: Event) => any) | null;
     onshippingoptionchange: ((this: PaymentRequest, ev: Event) => any) | null;
     readonly shippingAddress: PaymentAddress | null;
@@ -11412,7 +11459,7 @@ interface PaymentRequest extends EventTarget {
     readonly shippingType: PaymentShippingType | null;
     abort(): Promise<void>;
     canMakePayment(): Promise<boolean>;
-    show(): Promise<PaymentResponse>;
+    show(detailsPromise: PaymentDetailsUpdate | Promise<PaymentDetailsUpdate>): Promise<PaymentResponse>;
     addEventListener<K extends keyof PaymentRequestEventMap>(type: K, listener: (this: PaymentRequest, ev: PaymentRequestEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof PaymentRequestEventMap>(type: K, listener: (this: PaymentRequest, ev: PaymentRequestEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -11434,10 +11481,15 @@ declare var PaymentRequestUpdateEvent: {
     new(type: string, eventInitDict?: PaymentRequestUpdateEventInit): PaymentRequestUpdateEvent;
 };
 
+interface PaymentResponseEventMap {
+    "payerdetailchange": Event;
+}
+
 /** This Payment Request API interface is returned after a user selects a payment method and approves a payment request. */
-interface PaymentResponse {
+interface PaymentResponse extends EventTarget {
     readonly details: any;
     readonly methodName: string;
+    onpayerdetailchange: ((this: PaymentResponse, ev: Event) => any) | null;
     readonly payerEmail: string | null;
     readonly payerName: string | null;
     readonly payerPhone: string | null;
@@ -11445,7 +11497,12 @@ interface PaymentResponse {
     readonly shippingAddress: PaymentAddress | null;
     readonly shippingOption: string | null;
     complete(result?: PaymentComplete): Promise<void>;
+    retry(errorFields?: PaymentValidationErrors): Promise<void>;
     toJSON(): any;
+    addEventListener<K extends keyof PaymentResponseEventMap>(type: K, listener: (this: PaymentResponse, ev: PaymentResponseEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof PaymentResponseEventMap>(type: K, listener: (this: PaymentResponse, ev: PaymentResponseEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
 declare var PaymentResponse: {

--- a/inputfiles/idl/Payment Request.widl
+++ b/inputfiles/idl/Payment Request.widl
@@ -1,0 +1,188 @@
+[SecureContext, Exposed=Window]
+interface PaymentRequest : EventTarget {
+  constructor(
+    sequence<PaymentMethodData> methodData,
+    PaymentDetailsInit details,
+    optional PaymentOptions options = {}
+  );
+  [NewObject]
+  Promise<PaymentResponse> show(optional Promise<PaymentDetailsUpdate> detailsPromise);
+  [NewObject]
+  Promise<undefined> abort();
+  [NewObject]
+  Promise<boolean> canMakePayment();
+
+  readonly attribute DOMString id;
+  readonly attribute PaymentAddress? shippingAddress;
+  readonly attribute DOMString? shippingOption;
+  readonly attribute PaymentShippingType? shippingType;
+
+  attribute EventHandler onshippingaddresschange;
+  attribute EventHandler onshippingoptionchange;
+  attribute EventHandler onpaymentmethodchange;
+};
+
+dictionary PaymentMethodData {
+  required DOMString supportedMethods;
+  object data;
+};
+
+dictionary PaymentCurrencyAmount {
+  required DOMString currency;
+  required DOMString value;
+};
+
+dictionary PaymentDetailsBase {
+  sequence<PaymentItem> displayItems;
+  sequence<PaymentShippingOption> shippingOptions;
+  sequence<PaymentDetailsModifier> modifiers;
+};
+
+dictionary PaymentDetailsInit : PaymentDetailsBase {
+  DOMString id;
+  required PaymentItem total;
+};
+
+dictionary PaymentDetailsUpdate : PaymentDetailsBase {
+  DOMString error;
+  PaymentItem total;
+  AddressErrors shippingAddressErrors;
+  PayerErrors payerErrors;
+  object paymentMethodErrors;
+};
+
+dictionary PaymentDetailsModifier {
+  required DOMString supportedMethods;
+  PaymentItem total;
+  sequence<PaymentItem> additionalDisplayItems;
+  object data;
+};
+
+enum PaymentShippingType {
+  "shipping",
+  "delivery",
+  "pickup"
+};
+
+dictionary PaymentOptions {
+  boolean requestPayerName = false;
+  boolean requestBillingAddress = false;
+  boolean requestPayerEmail = false;
+  boolean requestPayerPhone = false;
+  boolean requestShipping = false;
+  PaymentShippingType shippingType = "shipping";
+};
+
+dictionary PaymentItem {
+  required DOMString label;
+  required PaymentCurrencyAmount amount;
+  boolean pending = false;
+};
+
+[SecureContext, Exposed=(Window)]
+interface PaymentAddress {
+  [Default] object toJSON();
+  readonly attribute DOMString city;
+  readonly attribute DOMString country;
+  readonly attribute DOMString dependentLocality;
+  readonly attribute DOMString organization;
+  readonly attribute DOMString phone;
+  readonly attribute DOMString postalCode;
+  readonly attribute DOMString recipient;
+  readonly attribute DOMString region;
+  readonly attribute DOMString sortingCode;
+  readonly attribute FrozenArray<DOMString> addressLine;
+};
+
+dictionary AddressInit {
+  DOMString country = "";
+  sequence<DOMString> addressLine = [];
+  DOMString region = "";
+  DOMString city = "";
+  DOMString dependentLocality = "";
+  DOMString postalCode = "";
+  DOMString sortingCode = "";
+  DOMString organization = "";
+  DOMString recipient = "";
+  DOMString phone = "";
+};
+
+dictionary AddressErrors {
+  DOMString addressLine;
+  DOMString city;
+  DOMString country;
+  DOMString dependentLocality;
+  DOMString organization;
+  DOMString phone;
+  DOMString postalCode;
+  DOMString recipient;
+  DOMString region;
+  DOMString sortingCode;
+};
+
+dictionary PaymentShippingOption {
+  required DOMString id;
+  required DOMString label;
+  required PaymentCurrencyAmount amount;
+  boolean selected = false;
+};
+
+enum PaymentComplete {
+  "fail",
+  "success",
+  "unknown"
+};
+
+[SecureContext, Exposed=Window]
+interface PaymentResponse : EventTarget  {
+  [Default] object toJSON();
+
+  readonly attribute DOMString requestId;
+  readonly attribute DOMString methodName;
+  readonly attribute object details;
+  readonly attribute PaymentAddress? shippingAddress;
+  readonly attribute DOMString? shippingOption;
+  readonly attribute DOMString? payerName;
+  readonly attribute DOMString? payerEmail;
+  readonly attribute DOMString? payerPhone;
+
+  [NewObject]
+  Promise<undefined> complete(optional PaymentComplete result = "unknown");
+  [NewObject]
+  Promise<undefined> retry(optional PaymentValidationErrors errorFields = {});
+
+  attribute EventHandler onpayerdetailchange;
+};
+
+dictionary PaymentValidationErrors {
+  PayerErrors payer;
+  AddressErrors shippingAddress;
+  DOMString error;
+  object paymentMethod;
+};
+
+dictionary PayerErrors {
+  DOMString email;
+  DOMString name;
+  DOMString phone;
+};
+
+[SecureContext, Exposed=Window]
+interface PaymentMethodChangeEvent : PaymentRequestUpdateEvent {
+  constructor(DOMString type, optional PaymentMethodChangeEventInit eventInitDict = {});
+  readonly attribute DOMString methodName;
+  readonly attribute object? methodDetails;
+};
+
+dictionary PaymentMethodChangeEventInit : PaymentRequestUpdateEventInit {
+  DOMString methodName = "";
+  object? methodDetails = null;
+};
+
+[SecureContext, Exposed=Window]
+interface PaymentRequestUpdateEvent : Event {
+  constructor(DOMString type, optional PaymentRequestUpdateEventInit eventInitDict = {});
+  undefined updateWith(Promise<PaymentDetailsUpdate> detailsPromise);
+};
+
+dictionary PaymentRequestUpdateEventInit : EventInit {};

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -435,6 +435,10 @@
         "title": "Push"
     },
     {
+        "url": "https://w3c.github.io/payment-request/",
+        "title": "Payment Request"
+    },
+    {
         "url": "https://www.w3.org/TR/referrer-policy/",
         "title": "Referrer Policy"
     },


### PR DESCRIPTION
https://github.com/w3c/payment-request/pull/694 removed `.currencySystem` and https://github.com/w3c/payment-request/pull/765 removed `.languageCode`.

Intentionally used editor's draft as the sole purpose of #915 is to stop reviewing implementation status here and receive already-reviewed data from https://github.com/mdn/browser-compat-data (which I think you already are using when reviewing PRs). That means we will be able to use everything latest without worrying about highly experimental types.