### PR TITLE
Update WebRTC types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1154,12 +1154,11 @@ interface RTCConfiguration {
     iceCandidatePoolSize?: number;
     iceServers?: RTCIceServer[];
     iceTransportPolicy?: RTCIceTransportPolicy;
-    peerIdentity?: string;
     rtcpMuxPolicy?: RTCRtcpMuxPolicy;
 }
 
 interface RTCDTMFToneChangeEventInit extends EventInit {
-    tone: string;
+    tone?: string;
 }
 
 interface RTCDataChannelEventInit extends EventInit {
@@ -1172,7 +1171,6 @@ interface RTCDataChannelInit {
     maxRetransmits?: number;
     negotiated?: boolean;
     ordered?: boolean;
-    priority?: RTCPriorityType;
     protocol?: string;
 }
 
@@ -1192,7 +1190,6 @@ interface RTCErrorEventInit extends EventInit {
 
 interface RTCErrorInit {
     errorDetail: RTCErrorDetailType;
-    httpRequestStatusCode?: number;
     receivedAlert?: number;
     sctpCauseCode?: number;
     sdpLineNumber?: number;
@@ -1263,7 +1260,7 @@ interface RTCIceParameters {
 }
 
 interface RTCIceServer {
-    credential?: string | RTCOAuthCredential;
+    credential?: string;
     credentialType?: RTCIceCredentialType;
     urls: string | string[];
     username?: string;
@@ -1283,6 +1280,11 @@ interface RTCInboundRTPStreamStats extends RTCRTPStreamStats {
     packetsReceived?: number;
 }
 
+interface RTCLocalSessionDescriptionInit {
+    sdp?: string;
+    type?: RTCSdpType;
+}
+
 interface RTCMediaStreamTrackStats extends RTCStats {
     audioLevel?: number;
     echoReturnLoss?: number;
@@ -1300,13 +1302,7 @@ interface RTCMediaStreamTrackStats extends RTCStats {
     trackIdentifier?: string;
 }
 
-interface RTCOAuthCredential {
-    accessToken: string;
-    macKey: string;
-}
-
 interface RTCOfferAnswerOptions {
-    voiceActivityDetection?: boolean;
 }
 
 interface RTCOfferOptions extends RTCOfferAnswerOptions {
@@ -1323,8 +1319,9 @@ interface RTCOutboundRTPStreamStats extends RTCRTPStreamStats {
 }
 
 interface RTCPeerConnectionIceErrorEventInit extends EventInit {
+    address?: string | null;
     errorCode: number;
-    hostCandidate?: string;
+    port?: number | null;
     statusText?: string;
     url?: string;
 }
@@ -1389,16 +1386,9 @@ interface RTCRtpContributingSource {
     timestamp: number;
 }
 
-interface RTCRtpDecodingParameters extends RTCRtpCodingParameters {
-}
-
 interface RTCRtpEncodingParameters extends RTCRtpCodingParameters {
     active?: boolean;
-    codecPayloadType?: number;
-    dtx?: RTCDtxStatus;
     maxBitrate?: number;
-    maxFramerate?: number;
-    ptime?: number;
     scaleResolutionDownBy?: number;
 }
 
@@ -1431,7 +1421,6 @@ interface RTCRtpParameters {
 }
 
 interface RTCRtpReceiveParameters extends RTCRtpParameters {
-    encodings: RTCRtpDecodingParameters[];
 }
 
 interface RTCRtpRtxParameters {
@@ -1439,9 +1428,7 @@ interface RTCRtpRtxParameters {
 }
 
 interface RTCRtpSendParameters extends RTCRtpParameters {
-    degradationPreference?: RTCDegradationPreference;
     encodings: RTCRtpEncodingParameters[];
-    priority?: RTCPriorityType;
     transactionId: string;
 }
 
@@ -1463,7 +1450,7 @@ interface RTCRtpUnhandled {
 
 interface RTCSessionDescriptionInit {
     sdp?: string;
-    type?: RTCSdpType;
+    type: RTCSdpType;
 }
 
 interface RTCSrtpKeyParam {
@@ -1490,10 +1477,6 @@ interface RTCStats {
     id: string;
     timestamp: number;
     type: RTCStatsType;
-}
-
-interface RTCStatsEventInit extends EventInit {
-    report: RTCStatsReport;
 }
 
 interface RTCStatsReport {
@@ -4684,7 +4667,6 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
     createEvent(eventInterface: "RTCPeerConnectionIceErrorEvent"): RTCPeerConnectionIceErrorEvent;
     createEvent(eventInterface: "RTCPeerConnectionIceEvent"): RTCPeerConnectionIceEvent;
     createEvent(eventInterface: "RTCSsrcConflictEvent"): RTCSsrcConflictEvent;
-    createEvent(eventInterface: "RTCStatsEvent"): RTCStatsEvent;
     createEvent(eventInterface: "RTCTrackEvent"): RTCTrackEvent;
     createEvent(eventInterface: "SVGZoomEvent"): SVGZoomEvent;
     createEvent(eventInterface: "SVGZoomEvents"): SVGZoomEvent;
@@ -4934,7 +4916,6 @@ interface DocumentEvent {
     createEvent(eventInterface: "RTCPeerConnectionIceErrorEvent"): RTCPeerConnectionIceErrorEvent;
     createEvent(eventInterface: "RTCPeerConnectionIceEvent"): RTCPeerConnectionIceEvent;
     createEvent(eventInterface: "RTCSsrcConflictEvent"): RTCSsrcConflictEvent;
-    createEvent(eventInterface: "RTCStatsEvent"): RTCStatsEvent;
     createEvent(eventInterface: "RTCTrackEvent"): RTCTrackEvent;
     createEvent(eventInterface: "SVGZoomEvent"): SVGZoomEvent;
     createEvent(eventInterface: "SVGZoomEvents"): SVGZoomEvent;
@@ -11893,7 +11874,6 @@ interface RTCCertificate {
 declare var RTCCertificate: {
     prototype: RTCCertificate;
     new(): RTCCertificate;
-    getSupportedAlgorithms(): AlgorithmIdentifier[];
 };
 
 interface RTCDTMFSenderEventMap {
@@ -11923,7 +11903,7 @@ interface RTCDTMFToneChangeEvent extends Event {
 
 declare var RTCDTMFToneChangeEvent: {
     prototype: RTCDTMFToneChangeEvent;
-    new(type: string, eventInitDict: RTCDTMFToneChangeEventInit): RTCDTMFToneChangeEvent;
+    new(type: string, eventInitDict?: RTCDTMFToneChangeEventInit): RTCDTMFToneChangeEvent;
 };
 
 interface RTCDataChannelEventMap {
@@ -11935,7 +11915,7 @@ interface RTCDataChannelEventMap {
 }
 
 interface RTCDataChannel extends EventTarget {
-    binaryType: string;
+    binaryType: BinaryType;
     readonly bufferedAmount: number;
     bufferedAmountLowThreshold: number;
     readonly id: number | null;
@@ -11949,7 +11929,6 @@ interface RTCDataChannel extends EventTarget {
     onmessage: ((this: RTCDataChannel, ev: MessageEvent) => any) | null;
     onopen: ((this: RTCDataChannel, ev: Event) => any) | null;
     readonly ordered: boolean;
-    readonly priority: RTCPriorityType;
     readonly protocol: string;
     readonly readyState: RTCDataChannelState;
     close(): void;
@@ -12033,7 +12012,6 @@ declare var RTCDtmfSender: {
 
 interface RTCError extends DOMException {
     readonly errorDetail: RTCErrorDetailType;
-    readonly httpRequestStatusCode: number | null;
     readonly receivedAlert: number | null;
     readonly sctpCauseCode: number | null;
     readonly sdpLineNumber: number | null;
@@ -12126,7 +12104,6 @@ interface RTCIceTransportEventMap {
 
 /** Provides access to information about the ICE transport layer over which the data is being sent and received. */
 interface RTCIceTransport extends EventTarget {
-    readonly component: RTCIceComponent;
     readonly gatheringState: RTCIceGathererState;
     ongatheringstatechange: ((this: RTCIceTransport, ev: Event) => any) | null;
     onselectedcandidatepairchange: ((this: RTCIceTransport, ev: Event) => any) | null;
@@ -12177,7 +12154,6 @@ interface RTCPeerConnectionEventMap {
     "icegatheringstatechange": Event;
     "negotiationneeded": Event;
     "signalingstatechange": Event;
-    "statsended": RTCStatsEvent;
     "track": RTCTrackEvent;
 }
 
@@ -12200,7 +12176,6 @@ interface RTCPeerConnection extends EventTarget {
     onicegatheringstatechange: ((this: RTCPeerConnection, ev: Event) => any) | null;
     onnegotiationneeded: ((this: RTCPeerConnection, ev: Event) => any) | null;
     onsignalingstatechange: ((this: RTCPeerConnection, ev: Event) => any) | null;
-    onstatsended: ((this: RTCPeerConnection, ev: RTCStatsEvent) => any) | null;
     ontrack: ((this: RTCPeerConnection, ev: RTCTrackEvent) => any) | null;
     readonly peerIdentity: Promise<RTCIdentityAssertion>;
     readonly pendingLocalDescription: RTCSessionDescription | null;
@@ -12222,7 +12197,8 @@ interface RTCPeerConnection extends EventTarget {
     getStats(selector?: MediaStreamTrack | null): Promise<RTCStatsReport>;
     getTransceivers(): RTCRtpTransceiver[];
     removeTrack(sender: RTCRtpSender): void;
-    setConfiguration(configuration: RTCConfiguration): void;
+    restartIce(): void;
+    setConfiguration(configuration?: RTCConfiguration): void;
     setIdentityProvider(provider: string, options?: RTCIdentityProviderOptions): void;
     setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>;
     setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>;
@@ -12236,13 +12212,13 @@ declare var RTCPeerConnection: {
     prototype: RTCPeerConnection;
     new(configuration?: RTCConfiguration): RTCPeerConnection;
     generateCertificate(keygenAlgorithm: AlgorithmIdentifier): Promise<RTCCertificate>;
-    getDefaultIceServers(): RTCIceServer[];
 };
 
 interface RTCPeerConnectionIceErrorEvent extends Event {
+    readonly address: string | null;
     readonly errorCode: number;
     readonly errorText: string;
-    readonly hostCandidate: string;
+    readonly port: number | null;
     readonly url: string;
 }
 
@@ -12254,7 +12230,6 @@ declare var RTCPeerConnectionIceErrorEvent: {
 /** Events that occurs in relation to ICE candidates with the target, usually an RTCPeerConnection. Only one event is of this type: icecandidate. */
 interface RTCPeerConnectionIceEvent extends Event {
     readonly candidate: RTCIceCandidate | null;
-    readonly url: string | null;
 }
 
 declare var RTCPeerConnectionIceEvent: {
@@ -12264,7 +12239,6 @@ declare var RTCPeerConnectionIceEvent: {
 
 /** This WebRTC API interface manages the reception and decoding of data for a MediaStreamTrack on an RTCPeerConnection. */
 interface RTCRtpReceiver {
-    readonly rtcpTransport: RTCDtlsTransport | null;
     readonly track: MediaStreamTrack;
     readonly transport: RTCDtlsTransport | null;
     getContributingSources(): RTCRtpContributingSource[];
@@ -12282,7 +12256,6 @@ declare var RTCRtpReceiver: {
 /** Provides the ability to control and obtain details about how a particular MediaStreamTrack is encoded and sent to a remote peer. */
 interface RTCRtpSender {
     readonly dtmf: RTCDTMFSender | null;
-    readonly rtcpTransport: RTCDtlsTransport | null;
     readonly track: MediaStreamTrack | null;
     readonly transport: RTCDtlsTransport | null;
     getParameters(): RTCRtpSendParameters;
@@ -12343,7 +12316,7 @@ interface RTCSessionDescription {
 
 declare var RTCSessionDescription: {
     prototype: RTCSessionDescription;
-    new(descriptionInitDict?: RTCSessionDescriptionInit): RTCSessionDescription;
+    new(descriptionInitDict: RTCSessionDescriptionInit): RTCSessionDescription;
 };
 
 interface RTCSrtpSdesTransportEventMap {
@@ -12372,15 +12345,6 @@ interface RTCSsrcConflictEvent extends Event {
 declare var RTCSsrcConflictEvent: {
     prototype: RTCSsrcConflictEvent;
     new(): RTCSsrcConflictEvent;
-};
-
-interface RTCStatsEvent extends Event {
-    readonly report: RTCStatsReport;
-}
-
-declare var RTCStatsEvent: {
-    prototype: RTCStatsEvent;
-    new(type: string, eventInitDict: RTCStatsEventInit): RTCStatsEvent;
 };
 
 interface RTCStatsProvider extends EventTarget {
@@ -20078,15 +20042,13 @@ type PushEncryptionKeyName = "auth" | "p256dh";
 type PushPermissionState = "denied" | "granted" | "prompt";
 type RTCBundlePolicy = "balanced" | "max-bundle" | "max-compat";
 type RTCDataChannelState = "closed" | "closing" | "connecting" | "open";
-type RTCDegradationPreference = "balanced" | "maintain-framerate" | "maintain-resolution";
 type RTCDtlsRole = "auto" | "client" | "server";
 type RTCDtlsTransportState = "closed" | "connected" | "connecting" | "failed" | "new";
-type RTCDtxStatus = "disabled" | "enabled";
-type RTCErrorDetailType = "data-channel-failure" | "dtls-failure" | "fingerprint-failure" | "hardware-encoder-error" | "hardware-encoder-not-available" | "idp-bad-script-failure" | "idp-execution-failure" | "idp-load-failure" | "idp-need-login" | "idp-timeout" | "idp-tls-failure" | "idp-token-expired" | "idp-token-invalid" | "sctp-failure" | "sdp-syntax-error";
+type RTCErrorDetailType = "data-channel-failure" | "dtls-failure" | "fingerprint-failure" | "hardware-encoder-error" | "hardware-encoder-not-available" | "sctp-failure" | "sdp-syntax-error";
 type RTCIceCandidateType = "host" | "prflx" | "relay" | "srflx";
 type RTCIceComponent = "rtcp" | "rtp";
 type RTCIceConnectionState = "checking" | "closed" | "completed" | "connected" | "disconnected" | "failed" | "new";
-type RTCIceCredentialType = "oauth" | "password";
+type RTCIceCredentialType = "password";
 type RTCIceGatherPolicy = "all" | "nohost" | "relay";
 type RTCIceGathererState = "complete" | "gathering" | "new";
 type RTCIceGatheringState = "complete" | "gathering" | "new";
@@ -20096,8 +20058,7 @@ type RTCIceTcpCandidateType = "active" | "passive" | "so";
 type RTCIceTransportPolicy = "all" | "relay";
 type RTCIceTransportState = "checking" | "closed" | "completed" | "connected" | "disconnected" | "failed" | "new";
 type RTCPeerConnectionState = "closed" | "connected" | "connecting" | "disconnected" | "failed" | "new";
-type RTCPriorityType = "high" | "low" | "medium" | "very-low";
-type RTCRtcpMuxPolicy = "negotiate" | "require";
+type RTCRtcpMuxPolicy = "require";
 type RTCRtpTransceiverDirection = "inactive" | "recvonly" | "sendonly" | "sendrecv" | "stopped";
 type RTCSctpTransportState = "closed" | "connected" | "connecting";
 type RTCSdpType = "answer" | "offer" | "pranswer" | "rollback";

--- a/inputfiles/idl/WebRTC.widl
+++ b/inputfiles/idl/WebRTC.widl
@@ -3,25 +3,18 @@ dictionary RTCConfiguration {
   RTCIceTransportPolicy iceTransportPolicy;
   RTCBundlePolicy bundlePolicy;
   RTCRtcpMuxPolicy rtcpMuxPolicy;
-  DOMString peerIdentity;
   sequence<RTCCertificate> certificates;
   [EnforceRange] octet iceCandidatePoolSize = 0;
 };
 
 enum RTCIceCredentialType {
-  "password",
-  "oauth"
-};
-
-dictionary RTCOAuthCredential {
-  required DOMString macKey;
-  required DOMString accessToken;
+  "password"
 };
 
 dictionary RTCIceServer {
   required (DOMString or sequence<DOMString>) urls;
   DOMString username;
-  (DOMString or RTCOAuthCredential) credential;
+  DOMString credential;
   RTCIceCredentialType credentialType = "password";
 };
 
@@ -37,14 +30,10 @@ enum RTCBundlePolicy {
 };
 
 enum RTCRtcpMuxPolicy {
-  // At risk due to lack of implementers' interest.
-  "negotiate",
   "require"
 };
 
-dictionary RTCOfferAnswerOptions {
-  boolean voiceActivityDetection = true;
-};
+dictionary RTCOfferAnswerOptions {};
 
 dictionary RTCOfferOptions : RTCOfferAnswerOptions {
   boolean iceRestart = false;
@@ -91,25 +80,24 @@ interface RTCPeerConnection : EventTarget  {
   constructor(optional RTCConfiguration configuration = {});
   Promise<RTCSessionDescriptionInit> createOffer(optional RTCOfferOptions options = {});
   Promise<RTCSessionDescriptionInit> createAnswer(optional RTCAnswerOptions options = {});
-  Promise<void> setLocalDescription(optional RTCSessionDescriptionInit description = {});
+  Promise<undefined> setLocalDescription(optional RTCLocalSessionDescriptionInit description = {});
   readonly attribute RTCSessionDescription? localDescription;
   readonly attribute RTCSessionDescription? currentLocalDescription;
   readonly attribute RTCSessionDescription? pendingLocalDescription;
-  Promise<void> setRemoteDescription(optional RTCSessionDescriptionInit description = {});
+  Promise<undefined> setRemoteDescription(RTCSessionDescriptionInit description);
   readonly attribute RTCSessionDescription? remoteDescription;
   readonly attribute RTCSessionDescription? currentRemoteDescription;
   readonly attribute RTCSessionDescription? pendingRemoteDescription;
-  Promise<void> addIceCandidate(optional RTCIceCandidateInit candidate = {});
+  Promise<undefined> addIceCandidate(optional RTCIceCandidateInit candidate = {});
   readonly attribute RTCSignalingState signalingState;
   readonly attribute RTCIceGatheringState iceGatheringState;
   readonly attribute RTCIceConnectionState iceConnectionState;
   readonly attribute RTCPeerConnectionState connectionState;
   readonly attribute boolean? canTrickleIceCandidates;
-  void restartIce();
-  static sequence<RTCIceServer> getDefaultIceServers();
+  undefined restartIce();
   RTCConfiguration getConfiguration();
-  void setConfiguration(RTCConfiguration configuration);
-  void close();
+  undefined setConfiguration(optional RTCConfiguration configuration = {});
+  undefined close();
   attribute EventHandler onnegotiationneeded;
   attribute EventHandler onicecandidate;
   attribute EventHandler onicecandidateerror;
@@ -123,25 +111,25 @@ interface RTCPeerConnection : EventTarget  {
   // If these methods are supported
   // they must be implemented as defined
   // in section "Legacy Interface Extensions"
-  Promise<void> createOffer(RTCSessionDescriptionCallback successCallback,
+  Promise<undefined> createOffer(RTCSessionDescriptionCallback successCallback,
                             RTCPeerConnectionErrorCallback failureCallback,
                             optional RTCOfferOptions options = {});
-  Promise<void> setLocalDescription(optional RTCSessionDescriptionInit description = {},
+  Promise<undefined> setLocalDescription(optional RTCLocalSessionDescriptionInit description = {},
                                     VoidFunction successCallback,
                                     RTCPeerConnectionErrorCallback failureCallback);
-  Promise<void> createAnswer(RTCSessionDescriptionCallback successCallback,
+  Promise<undefined> createAnswer(RTCSessionDescriptionCallback successCallback,
                              RTCPeerConnectionErrorCallback failureCallback);
-  Promise<void> setRemoteDescription(optional RTCSessionDescriptionInit description = {},
+  Promise<undefined> setRemoteDescription(RTCSessionDescriptionInit description,
                                      VoidFunction successCallback,
                                      RTCPeerConnectionErrorCallback failureCallback);
-  Promise<void> addIceCandidate(RTCIceCandidateInit candidate,
+  Promise<undefined> addIceCandidate(RTCIceCandidateInit candidate,
                                 VoidFunction successCallback,
                                 RTCPeerConnectionErrorCallback failureCallback);
 };
 
-callback RTCPeerConnectionErrorCallback = void (DOMException error);
+callback RTCPeerConnectionErrorCallback = undefined (DOMException error);
 
-callback RTCSessionDescriptionCallback = void (RTCSessionDescriptionInit description);
+callback RTCSessionDescriptionCallback = undefined (RTCSessionDescriptionInit description);
 
 partial dictionary RTCOfferOptions {
   boolean offerToReceiveAudio;
@@ -157,13 +145,18 @@ enum RTCSdpType {
 
 [Exposed=Window]
 interface RTCSessionDescription {
-  constructor(optional RTCSessionDescriptionInit descriptionInitDict = {});
+  constructor(RTCSessionDescriptionInit descriptionInitDict);
   readonly attribute RTCSdpType type;
   readonly attribute DOMString sdp;
   [Default] object toJSON();
 };
 
 dictionary RTCSessionDescriptionInit {
+  required RTCSdpType type;
+  DOMString sdp = "";
+};
+
+dictionary RTCLocalSessionDescriptionInit {
   RTCSdpType type;
   DOMString sdp = "";
 };
@@ -228,24 +221,19 @@ dictionary RTCPeerConnectionIceEventInit : EventInit {
 [Exposed=Window]
 interface RTCPeerConnectionIceErrorEvent : Event {
   constructor(DOMString type, RTCPeerConnectionIceErrorEventInit eventInitDict);
-  readonly attribute DOMString hostCandidate;
+  readonly attribute DOMString? address;
+  readonly attribute unsigned short? port;
   readonly attribute DOMString url;
   readonly attribute unsigned short errorCode;
   readonly attribute USVString errorText;
 };
 
 dictionary RTCPeerConnectionIceErrorEventInit : EventInit {
-  DOMString hostCandidate;
+  DOMString? address;
+  unsigned short? port;
   DOMString url;
   required unsigned short errorCode;
   USVString statusText;
-};
-
-enum RTCPriorityType {
-  "very-low",
-  "low",
-  "medium",
-  "high"
 };
 
 partial interface RTCPeerConnection {
@@ -260,7 +248,6 @@ dictionary RTCCertificateExpiration {
 [Exposed=Window, Serializable]
 interface RTCCertificate {
   readonly attribute DOMTimeStamp expires;
-  static sequence<AlgorithmIdentifier> getSupportedAlgorithms();
   sequence<RTCDtlsFingerprint> getFingerprints();
 };
 
@@ -269,7 +256,7 @@ partial interface RTCPeerConnection {
   sequence<RTCRtpReceiver> getReceivers();
   sequence<RTCRtpTransceiver> getTransceivers();
   RTCRtpSender addTrack(MediaStreamTrack track, MediaStream... streams);
-  void removeTrack(RTCRtpSender sender);
+  undefined removeTrack(RTCRtpSender sender);
   RTCRtpTransceiver addTransceiver((MediaStreamTrack or DOMString) trackOrKind,
                                    optional RTCRtpTransceiverInit init = {});
   attribute EventHandler ontrack;
@@ -293,12 +280,11 @@ enum RTCRtpTransceiverDirection {
 interface RTCRtpSender {
   readonly attribute MediaStreamTrack? track;
   readonly attribute RTCDtlsTransport? transport;
-  readonly attribute RTCDtlsTransport? rtcpTransport;
   static RTCRtpCapabilities? getCapabilities(DOMString kind);
-  Promise<void> setParameters(RTCRtpSendParameters parameters);
+  Promise<undefined> setParameters(RTCRtpSendParameters parameters);
   RTCRtpSendParameters getParameters();
-  Promise<void> replaceTrack(MediaStreamTrack? withTrack);
-  void setStreams(MediaStream... streams);
+  Promise<undefined> replaceTrack(MediaStreamTrack? withTrack);
+  undefined setStreams(MediaStream... streams);
   Promise<RTCStatsReport> getStats();
 };
 
@@ -311,12 +297,9 @@ dictionary RTCRtpParameters {
 dictionary RTCRtpSendParameters : RTCRtpParameters {
   required DOMString transactionId;
   required sequence<RTCRtpEncodingParameters> encodings;
-  RTCDegradationPreference degradationPreference = "balanced";
-  RTCPriorityType priority = "low";
 };
 
 dictionary RTCRtpReceiveParameters : RTCRtpParameters {
-  required sequence<RTCRtpDecodingParameters> encodings;
 };
 
 dictionary RTCRtpCodingParameters {
@@ -326,24 +309,9 @@ dictionary RTCRtpCodingParameters {
 dictionary RTCRtpDecodingParameters : RTCRtpCodingParameters {};
 
 dictionary RTCRtpEncodingParameters : RTCRtpCodingParameters {
-  octet codecPayloadType;
-  RTCDtxStatus dtx;
   boolean active = true;
-  unsigned long ptime;
   unsigned long maxBitrate;
-  double maxFramerate;
   double scaleResolutionDownBy;
-};
-
-enum RTCDtxStatus {
-  "disabled",
-  "enabled"
-};
-
-enum RTCDegradationPreference {
-  "maintain-framerate",
-  "maintain-resolution",
-  "balanced"
 };
 
 dictionary RTCRtcpParameters {
@@ -385,7 +353,6 @@ dictionary RTCRtpHeaderExtensionCapability {
 interface RTCRtpReceiver {
   readonly attribute MediaStreamTrack track;
   readonly attribute RTCDtlsTransport? transport;
-  readonly attribute RTCDtlsTransport? rtcpTransport;
   static RTCRtpCapabilities? getCapabilities(DOMString kind);
   RTCRtpReceiveParameters getParameters();
   sequence<RTCRtpContributingSource> getContributingSources();
@@ -411,8 +378,8 @@ interface RTCRtpTransceiver {
   [SameObject] readonly attribute RTCRtpReceiver receiver;
   attribute RTCRtpTransceiverDirection direction;
   readonly attribute RTCRtpTransceiverDirection? currentDirection;
-  void stop();
-  void setCodecPreferences(sequence<RTCRtpCodecCapability> codecs);
+  undefined stop();
+  undefined setCodecPreferences(sequence<RTCRtpCodecCapability> codecs);
 };
 
 [Exposed=Window]
@@ -537,7 +504,6 @@ interface RTCDataChannel : EventTarget {
   readonly attribute USVString protocol;
   readonly attribute boolean negotiated;
   readonly attribute unsigned short? id;
-  readonly attribute RTCPriorityType priority;
   readonly attribute RTCDataChannelState readyState;
   readonly attribute unsigned long bufferedAmount;
   [EnforceRange] attribute unsigned long bufferedAmountLowThreshold;
@@ -546,13 +512,13 @@ interface RTCDataChannel : EventTarget {
   attribute EventHandler onerror;
   attribute EventHandler onclosing;
   attribute EventHandler onclose;
-  void close();
+  undefined close();
   attribute EventHandler onmessage;
-  attribute DOMString binaryType;
-  void send(USVString data);
-  void send(Blob data);
-  void send(ArrayBuffer data);
-  void send(ArrayBufferView data);
+  attribute BinaryType binaryType;
+  undefined send(USVString data);
+  undefined send(Blob data);
+  undefined send(ArrayBuffer data);
+  undefined send(ArrayBufferView data);
 };
 
 dictionary RTCDataChannelInit {
@@ -562,7 +528,6 @@ dictionary RTCDataChannelInit {
   USVString protocol = "";
   boolean negotiated = false;
   [EnforceRange] unsigned short id;
-  RTCPriorityType priority = "low";
 };
 
 enum RTCDataChannelState {
@@ -588,7 +553,7 @@ partial interface RTCRtpSender {
 
 [Exposed=Window]
 interface RTCDTMFSender : EventTarget {
-  void insertDTMF(DOMString tones, optional unsigned long duration = 100, optional unsigned long interToneGap = 70);
+  undefined insertDTMF(DOMString tones, optional unsigned long duration = 100, optional unsigned long interToneGap = 70);
   attribute EventHandler ontonechange;
   readonly attribute boolean canInsertDTMF;
   readonly attribute DOMString toneBuffer;
@@ -596,17 +561,16 @@ interface RTCDTMFSender : EventTarget {
 
 [Exposed=Window]
 interface RTCDTMFToneChangeEvent : Event {
-  constructor(DOMString type, RTCDTMFToneChangeEventInit eventInitDict);
+  constructor(DOMString type, optional RTCDTMFToneChangeEventInit eventInitDict = {});
   readonly attribute DOMString tone;
 };
 
 dictionary RTCDTMFToneChangeEventInit : EventInit {
-  required DOMString tone;
+  DOMString tone = "";
 };
 
 partial interface RTCPeerConnection {
   Promise<RTCStatsReport> getStats(optional MediaStreamTrack? selector = null);
-  attribute EventHandler onstatsended;
 };
 
 [Exposed=Window]
@@ -621,21 +585,10 @@ dictionary RTCStats {
 };
 
 [Exposed=Window]
-interface RTCStatsEvent : Event {
-  constructor(DOMString type, RTCStatsEventInit eventInitDict);
-  readonly attribute RTCStatsReport report;
-};
-
-dictionary RTCStatsEventInit : EventInit {
-  required RTCStatsReport report;
-};
-
-[Exposed=Window]
 interface RTCError : DOMException {
   constructor(RTCErrorInit init, optional DOMString message = "");
   readonly attribute RTCErrorDetailType errorDetail;
   readonly attribute long? sdpLineNumber;
-  readonly attribute long? httpRequestStatusCode;
   readonly attribute long? sctpCauseCode;
   readonly attribute unsigned long? receivedAlert;
   readonly attribute unsigned long? sentAlert;
@@ -644,7 +597,6 @@ interface RTCError : DOMException {
 dictionary RTCErrorInit {
   required RTCErrorDetailType errorDetail;
   long sdpLineNumber;
-  long httpRequestStatusCode;
   long sctpCauseCode;
   unsigned long receivedAlert;
   unsigned long sentAlert;
@@ -654,14 +606,6 @@ enum RTCErrorDetailType {
   "data-channel-failure",
   "dtls-failure",
   "fingerprint-failure",
-  "idp-bad-script-failure",
-  "idp-execution-failure",
-  "idp-load-failure",
-  "idp-need-login",
-  "idp-timeout",
-  "idp-tls-failure",
-  "idp-token-expired",
-  "idp-token-invalid",
   "sctp-failure",
   "sdp-syntax-error",
   "hardware-encoder-not-available",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1835,10 +1835,6 @@
                         {
                             "name": "isolationchange",
                             "type": "Event"
-                        },
-                        {
-                            "name": "statsended",
-                            "type": "RTCStatsEvent"
                         }
                     ]
                 }

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -260,10 +260,17 @@
                     }
                 }
             },
-            "RTCPeerConnection": {
-                "methods": {
-                    "method": {
-                        "restartIce": null
+            "RTCIceTransport": {
+                "properties": {
+                    "property": {
+                        "component": null
+                    }
+                }
+            },
+            "RTCPeerConnectionIceEvent": {
+                "properties": {
+                    "property": {
+                        "url": null
                     }
                 }
             },


### PR DESCRIPTION
Removes some unimplemented types e.g. `RTCConfiguration#peerIdentity`, `RTCDataChannel#priority`, etc.