### PR TITLE
Remove unimplemented SVGUseElement properties

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14700,9 +14700,7 @@ declare var SVGUnitTypes: {
 
 /** Corresponds to the <use> element. */
 interface SVGUseElement extends SVGGraphicsElement, SVGURIReference {
-    readonly animatedInstanceRoot: SVGElementInstance | null;
     readonly height: SVGAnimatedLength;
-    readonly instanceRoot: SVGElementInstance | null;
     readonly width: SVGAnimatedLength;
     readonly x: SVGAnimatedLength;
     readonly y: SVGAnimatedLength;
@@ -14735,16 +14733,12 @@ declare var SVGViewElement: {
     readonly SVG_ZOOMANDPAN_UNKNOWN: number;
 };
 
-/** Used to reflect the zoomAndPan attribute, and is mixed in to other interfaces for elements that support this attribute. */
 interface SVGZoomAndPan {
-    readonly zoomAndPan: number;
-}
-
-declare var SVGZoomAndPan: {
+    zoomAndPan: number;
     readonly SVG_ZOOMANDPAN_DISABLE: number;
     readonly SVG_ZOOMANDPAN_MAGNIFY: number;
     readonly SVG_ZOOMANDPAN_UNKNOWN: number;
-};
+}
 
 interface SVGZoomEvent extends UIEvent {
     readonly newScale: number;

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -344,6 +344,15 @@
                     }
                 }
             },
+            "SVGUseElement": {
+                "properties": {
+                    "property": {
+                        "animatedInstanceRoot": null,
+                        "instanceRoot": null
+                    }
+                }
+            },
+            "SVGZoomAndPan": null,
             "VideoTrackList": null,
             "WebKitCSSMatrix": null,
             "WebKitDirectoryEntry": null,


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/API/SVGUseElement#Browser_compatibility.

Also, SVGZoomAndPan is now a mixin.