### PR TITLE
Remove unexposed TextMetrics APIs

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -15619,34 +15619,6 @@ interface TextMetrics {
     /**
      * Returns the measurement described below.
      */
-    readonly alphabeticBaseline: number;
-    /**
-     * Returns the measurement described below.
-     */
-    readonly emHeightAscent: number;
-    /**
-     * Returns the measurement described below.
-     */
-    readonly emHeightDescent: number;
-    /**
-     * Returns the measurement described below.
-     */
-    readonly fontBoundingBoxAscent: number;
-    /**
-     * Returns the measurement described below.
-     */
-    readonly fontBoundingBoxDescent: number;
-    /**
-     * Returns the measurement described below.
-     */
-    readonly hangingBaseline: number;
-    /**
-     * Returns the measurement described below.
-     */
-    readonly ideographicBaseline: number;
-    /**
-     * Returns the measurement described below.
-     */
     readonly width: number;
 }
 

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -3208,34 +3208,6 @@ interface TextMetrics {
     /**
      * Returns the measurement described below.
      */
-    readonly alphabeticBaseline: number;
-    /**
-     * Returns the measurement described below.
-     */
-    readonly emHeightAscent: number;
-    /**
-     * Returns the measurement described below.
-     */
-    readonly emHeightDescent: number;
-    /**
-     * Returns the measurement described below.
-     */
-    readonly fontBoundingBoxAscent: number;
-    /**
-     * Returns the measurement described below.
-     */
-    readonly fontBoundingBoxDescent: number;
-    /**
-     * Returns the measurement described below.
-     */
-    readonly hangingBaseline: number;
-    /**
-     * Returns the measurement described below.
-     */
-    readonly ideographicBaseline: number;
-    /**
-     * Returns the measurement described below.
-     */
     readonly width: number;
 }
 

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -344,6 +344,19 @@
                     }
                 }
             },
+            "TextMetrics": {
+                "properties": {
+                    "property": {
+                        "alphabeticBaseline": null,
+                        "emHeightAscent": null,
+                        "emHeightDescent": null,
+                        "fontBoundingBoxAscent": null,
+                        "fontBoundingBoxDescent": null,
+                        "hangingBaseline": null,
+                        "ideographicBaseline": null
+                    }
+                }
+            },
             "VideoTrackList": null,
             "WebKitCSSMatrix": null,
             "WebKitDirectoryEntry": null,


### PR DESCRIPTION
Those are highly experimental and disabled by default in Firefox/Chrome. https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics#Browser_compatibility