### PR TITLE
Remove unimplemented WebVR APIs

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -16138,7 +16138,6 @@ interface VRPose {
     readonly linearVelocity: Float32Array | null;
     readonly orientation: Float32Array | null;
     readonly position: Float32Array | null;
-    readonly timestamp: number;
 }
 
 declare var VRPose: {
@@ -18460,9 +18459,6 @@ interface WindowEventMap extends GlobalEventHandlersEventMap, WindowEventHandler
     "vrdisplayconnect": Event;
     "vrdisplaydeactivate": Event;
     "vrdisplaydisconnect": Event;
-    "vrdisplayfocus": Event;
-    "vrdisplaypointerrestricted": Event;
-    "vrdisplaypointerunrestricted": Event;
     "vrdisplaypresentchange": Event;
     "waiting": Event;
 }
@@ -18523,9 +18519,6 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
     onvrdisplayconnect: ((this: Window, ev: Event) => any) | null;
     onvrdisplaydeactivate: ((this: Window, ev: Event) => any) | null;
     onvrdisplaydisconnect: ((this: Window, ev: Event) => any) | null;
-    onvrdisplayfocus: ((this: Window, ev: Event) => any) | null;
-    onvrdisplaypointerrestricted: ((this: Window, ev: Event) => any) | null;
-    onvrdisplaypointerunrestricted: ((this: Window, ev: Event) => any) | null;
     onvrdisplaypresentchange: ((this: Window, ev: Event) => any) | null;
     opener: any;
     /** @deprecated */
@@ -19563,9 +19556,6 @@ declare var onvrdisplayblur: ((this: Window, ev: Event) => any) | null;
 declare var onvrdisplayconnect: ((this: Window, ev: Event) => any) | null;
 declare var onvrdisplaydeactivate: ((this: Window, ev: Event) => any) | null;
 declare var onvrdisplaydisconnect: ((this: Window, ev: Event) => any) | null;
-declare var onvrdisplayfocus: ((this: Window, ev: Event) => any) | null;
-declare var onvrdisplaypointerrestricted: ((this: Window, ev: Event) => any) | null;
-declare var onvrdisplaypointerunrestricted: ((this: Window, ev: Event) => any) | null;
 declare var onvrdisplaypresentchange: ((this: Window, ev: Event) => any) | null;
 declare var opener: any;
 /** @deprecated */

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -345,6 +345,13 @@
                 }
             },
             "VideoTrackList": null,
+            "VRPose": {
+                "properties": {
+                    "property": {
+                        "timestamp": null
+                    }
+                }
+            },
             "WebKitCSSMatrix": null,
             "WebKitDirectoryEntry": null,
             "WebKitDirectoryReader": null,
@@ -363,6 +370,9 @@
                         "ontouchend": null,
                         "ontouchmove": null,
                         "ontouchstart": null,
+                        "onvrdisplayfocus": null,
+                        "onvrdisplaypointerrestricted": null,
+                        "onvrdisplaypointerunrestricted": null,
                         "performance": null
                     }
                 },


### PR DESCRIPTION
We should probably remove the whole WebVR API as currently Firefox is the only implementer and it's being replaced by WebXR. But for now this only removes attributes that nobody implements.