### PR TITLE
Add composition events to GlobalEventHandlers

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5711,6 +5711,9 @@ interface GlobalEventHandlersEventMap {
     "change": Event;
     "click": MouseEvent;
     "close": Event;
+    "compositionend": CompositionEvent;
+    "compositionstart": CompositionEvent;
+    "compositionupdate": CompositionEvent;
     "contextmenu": MouseEvent;
     "cuechange": Event;
     "dblclick": MouseEvent;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -70,6 +70,18 @@
                 "attributeless-events": {
                     "event": [
                         {
+                            "name": "compositionstart",
+                            "type": "CompositionEvent"
+                        },
+                        {
+                            "name": "compositionupdate",
+                            "type": "CompositionEvent"
+                        },
+                        {
+                            "name": "compositionend",
+                            "type": "CompositionEvent"
+                        },
+                        {
                             "name": "focusin",
                             "type": "FocusEvent"
                         },


### PR DESCRIPTION
`GlobalEventHandlers` were missing `"compositionstart"`, `"compositionupdate"` and `"compositionend"`, which caused errors when trying to use a function type that relied on getting even object types from that type.

(I should note that I don't really know what I'm doing here, and just searched for the other event names and added similar declarations in what looked like the appropriate place.)