### PR TITLE
Correct type of Window.frameElement

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -18481,7 +18481,7 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
     readonly event: Event | undefined;
     /** @deprecated */
     readonly external: External;
-    readonly frameElement: Element;
+    readonly frameElement: Element | null;
     readonly frames: Window;
     readonly history: History;
     readonly innerHeight: number;
@@ -19520,7 +19520,7 @@ declare var document: Document;
 declare var event: Event | undefined;
 /** @deprecated */
 declare var external: External;
-declare var frameElement: Element;
+declare var frameElement: Element | null;
 declare var frames: Window;
 declare var history: History;
 declare var innerHeight: number;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -441,8 +441,7 @@
                             "deprecated": 1
                         },
                         "frameElement": {
-                            "name": "frameElement",
-                            "override-type": "Element | null"
+                            "nullable": 1
                         },
                         "location": {
                             "read-only": 0

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -440,6 +440,10 @@
                             "override-type": "Event | undefined",
                             "deprecated": 1
                         },
+                        "frameElement": {
+                            "name": "frameElement",
+                            "override-type": "Element | null"
+                        },
                         "location": {
                             "read-only": 0
                         },


### PR DESCRIPTION
`frameElement` is `null` if the window is the top-level window, or if the window is embedded in a document that has a different origin.

See https://developer.mozilla.org/en-US/docs/Web/API/Window/frameElement