### PR TITLE
feat: Emit WebAssembly types separately from DOM types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -19055,52 +19055,52 @@ declare namespace CSS {
 declare namespace WebAssembly {
     interface CompileError {
     }
-    
+
     var CompileError: {
         prototype: CompileError;
         new(): CompileError;
     };
-    
+
     interface Global {
         value: any;
         valueOf(): any;
     }
-    
+
     var Global: {
         prototype: Global;
         new(descriptor: GlobalDescriptor, v?: any): Global;
     };
-    
+
     interface Instance {
         readonly exports: Exports;
     }
-    
+
     var Instance: {
         prototype: Instance;
         new(module: Module, importObject?: Imports): Instance;
     };
-    
+
     interface LinkError {
     }
-    
+
     var LinkError: {
         prototype: LinkError;
         new(): LinkError;
     };
-    
+
     interface Memory {
         readonly buffer: ArrayBuffer;
         grow(delta: number): number;
     }
-    
+
     var Memory: {
         prototype: Memory;
         new(descriptor: MemoryDescriptor): Memory;
     };
-    
+
     interface Module {
     }
-    
+
     var Module: {
         prototype: Module;
         new(bytes: BufferSource): Module;
@@ -19108,59 +19108,59 @@ declare namespace WebAssembly {
         exports(moduleObject: Module): ModuleExportDescriptor[];
         imports(moduleObject: Module): ModuleImportDescriptor[];
     };
-    
+
     interface RuntimeError {
     }
-    
+
     var RuntimeError: {
         prototype: RuntimeError;
         new(): RuntimeError;
     };
-    
+
     interface Table {
         readonly length: number;
         get(index: number): Function | null;
         grow(delta: number): number;
         set(index: number, value: Function | null): void;
     }
-    
+
     var Table: {
         prototype: Table;
         new(descriptor: TableDescriptor): Table;
     };
-    
+
     interface GlobalDescriptor {
         mutable?: boolean;
         value: ValueType;
     }
-    
+
     interface MemoryDescriptor {
         initial: number;
         maximum?: number;
     }
-    
+
     interface ModuleExportDescriptor {
         kind: ImportExportKind;
         name: string;
     }
-    
+
     interface ModuleImportDescriptor {
         kind: ImportExportKind;
         module: string;
         name: string;
     }
-    
+
     interface TableDescriptor {
         element: TableKind;
         initial: number;
         maximum?: number;
     }
-    
+
     interface WebAssemblyInstantiatedSource {
         instance: Instance;
         module: Module;
     }
-    
+
     type ImportExportKind = "function" | "global" | "memory" | "table";
     type TableKind = "anyfunc";
     type ValueType = "f32" | "f64" | "i32" | "i64";

--- a/baselines/webassembly.generated.d.ts
+++ b/baselines/webassembly.generated.d.ts
@@ -1,0 +1,128 @@
+/////////////////////////////
+/// WebAssembly APIs
+/////////////////////////////
+
+declare namespace WebAssembly {
+    interface CompileError {
+    }
+
+    var CompileError: {
+        prototype: CompileError;
+        new(): CompileError;
+    };
+
+    interface Global {
+        value: any;
+        valueOf(): any;
+    }
+
+    var Global: {
+        prototype: Global;
+        new(descriptor: GlobalDescriptor, v?: any): Global;
+    };
+
+    interface Instance {
+        readonly exports: Exports;
+    }
+
+    var Instance: {
+        prototype: Instance;
+        new(module: Module, importObject?: Imports): Instance;
+    };
+
+    interface LinkError {
+    }
+
+    var LinkError: {
+        prototype: LinkError;
+        new(): LinkError;
+    };
+
+    interface Memory {
+        readonly buffer: ArrayBuffer;
+        grow(delta: number): number;
+    }
+
+    var Memory: {
+        prototype: Memory;
+        new(descriptor: MemoryDescriptor): Memory;
+    };
+
+    interface Module {
+    }
+
+    var Module: {
+        prototype: Module;
+        new(bytes: BufferSource): Module;
+        customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
+        exports(moduleObject: Module): ModuleExportDescriptor[];
+        imports(moduleObject: Module): ModuleImportDescriptor[];
+    };
+
+    interface RuntimeError {
+    }
+
+    var RuntimeError: {
+        prototype: RuntimeError;
+        new(): RuntimeError;
+    };
+
+    interface Table {
+        readonly length: number;
+        get(index: number): Function | null;
+        grow(delta: number): number;
+        set(index: number, value: Function | null): void;
+    }
+
+    var Table: {
+        prototype: Table;
+        new(descriptor: TableDescriptor): Table;
+    };
+
+    interface GlobalDescriptor {
+        mutable?: boolean;
+        value: ValueType;
+    }
+
+    interface MemoryDescriptor {
+        initial: number;
+        maximum?: number;
+    }
+
+    interface ModuleExportDescriptor {
+        kind: ImportExportKind;
+        name: string;
+    }
+
+    interface ModuleImportDescriptor {
+        kind: ImportExportKind;
+        module: string;
+        name: string;
+    }
+
+    interface TableDescriptor {
+        element: TableKind;
+        initial: number;
+        maximum?: number;
+    }
+
+    interface WebAssemblyInstantiatedSource {
+        instance: Instance;
+        module: Module;
+    }
+
+    type ImportExportKind = "function" | "global" | "memory" | "table";
+    type TableKind = "anyfunc";
+    type ValueType = "f32" | "f64" | "i32" | "i64";
+    type ExportValue = Function | Global | Memory | Table;
+    type Exports = Record<string, ExportValue>;
+    type ImportValue = ExportValue | number;
+    type ModuleImports = Record<string, ImportValue>;
+    type Imports = Record<string, ModuleImports>;
+    function compile(bytes: BufferSource): Promise<Module>;
+    function instantiate(bytes: BufferSource, importObject?: Imports): Promise<WebAssemblyInstantiatedSource>;
+    function instantiate(moduleObject: Module, importObject?: Imports): Promise<Instance>;
+    function validate(bytes: BufferSource): boolean;
+}
+
+type BufferSource = ArrayBufferView | ArrayBuffer;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -5748,34 +5748,34 @@ declare namespace WebAssembly {
         value: any;
         valueOf(): any;
     }
-    
+
     var Global: {
         prototype: Global;
         new(descriptor: GlobalDescriptor, v?: any): Global;
     };
-    
+
     interface Instance {
         readonly exports: Exports;
     }
-    
+
     var Instance: {
         prototype: Instance;
         new(module: Module, importObject?: Imports): Instance;
     };
-    
+
     interface Memory {
         readonly buffer: ArrayBuffer;
         grow(delta: number): number;
     }
-    
+
     var Memory: {
         prototype: Memory;
         new(descriptor: MemoryDescriptor): Memory;
     };
-    
+
     interface Module {
     }
-    
+
     var Module: {
         prototype: Module;
         new(bytes: BufferSource): Module;
@@ -5783,51 +5783,51 @@ declare namespace WebAssembly {
         exports(moduleObject: Module): ModuleExportDescriptor[];
         imports(moduleObject: Module): ModuleImportDescriptor[];
     };
-    
+
     interface Table {
         readonly length: number;
         get(index: number): Function | null;
         grow(delta: number): number;
         set(index: number, value: Function | null): void;
     }
-    
+
     var Table: {
         prototype: Table;
         new(descriptor: TableDescriptor): Table;
     };
-    
+
     interface GlobalDescriptor {
         mutable?: boolean;
         value: ValueType;
     }
-    
+
     interface MemoryDescriptor {
         initial: number;
         maximum?: number;
     }
-    
+
     interface ModuleExportDescriptor {
         kind: ImportExportKind;
         name: string;
     }
-    
+
     interface ModuleImportDescriptor {
         kind: ImportExportKind;
         module: string;
         name: string;
     }
-    
+
     interface TableDescriptor {
         element: TableKind;
         initial: number;
         maximum?: number;
     }
-    
+
     interface WebAssemblyInstantiatedSource {
         instance: Instance;
         module: Module;
     }
-    
+
     type ImportExportKind = "function" | "global" | "memory" | "table";
     type TableKind = "anyfunc";
     type ValueType = "f32" | "f64" | "i32" | "i64";

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -3113,6 +3113,11 @@
             "name": "WebAssembly",
             "methods": {
                 "method": {
+                    "compileStreaming": {
+                        "excluded-from": [
+                            "webassembly"
+                        ]
+                    },
                     "instantiate": {
                         "override-signatures": [
                             "instantiate(bytes: BufferSource, importObject?: Imports): Promise<WebAssemblyInstantiatedSource>",
@@ -3132,6 +3137,9 @@
                             {
                                 "type": "Imports"
                             }
+                        ],
+                        "excluded-from": [
+                            "webassembly"
                         ]
                     }
                 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -19,6 +19,7 @@ export const baseTypeConversionMap = new Map<string, string>([
     ["EventHandler", "EventHandler"]
 ]);
 
+// FIXME: This should be named `deepFilter`
 export function filter<T>(obj: T, fn: (o: any, n: string | undefined) => boolean): T {
     if (typeof obj === "object") {
         if (Array.isArray(obj)) {
@@ -64,7 +65,7 @@ export function merge<T>(target: T, src: T, shallow?: boolean): T {
                 const targetProp = target[k];
                 const srcProp = src[k];
                 if (Array.isArray(targetProp) && Array.isArray(srcProp)) {
-                    mergeNamedArrays(targetProp, srcProp);
+                    mergeNamedArrays(targetProp as any, srcProp as any);
                 }
                 else {
                     if (Array.isArray(targetProp) !== Array.isArray(srcProp)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import { merge, resolveExposure, markAsDeprecated, mapToArray, arrayToMap } from "./helpers";
 import { Flavor, emitWebIdl } from "./emitter";
 import { convert } from "./widlprocess";
-import { getExposedTypes } from "./expose";
+import { getExposedTypes, getWebAssemblyTypes } from "./expose";
 
 function mergeNamesakes(filtered: Browser.WebIdl) {
     const targets = [
@@ -41,6 +41,14 @@ function emitFlavor(webidl: Browser.WebIdl, forceKnownTypes: Set<string>, option
 
     const iterators = emitWebIdl(exposed, options.flavor, true);
     fs.writeFileSync(`${options.outputFolder}/${options.name}.iterable.generated.d.ts`, iterators);
+}
+
+function emitWebAssembly(webidl: Browser.WebIdl, options: Pick<EmitOptions, 'name' | 'outputFolder'>) {
+    const exposed = getWebAssemblyTypes(webidl);
+    mergeNamesakes(exposed);
+
+    const result = emitWebIdl(exposed, Flavor.WebAssembly, false);
+    fs.writeFileSync(`${options.outputFolder}/${options.name}.generated.d.ts`, result);
 }
 
 function emitDom() {
@@ -187,6 +195,7 @@ function emitDom() {
 
     emitFlavor(webidl, new Set(knownTypes.Window), { name: "dom", flavor: Flavor.Window, global: "Window", outputFolder });
     emitFlavor(webidl, new Set(knownTypes.Worker), { name: "webworker", flavor: Flavor.Worker, global: "Worker", outputFolder });
+    emitWebAssembly(webidl, { name: "webassembly", outputFolder });
 
     function prune(obj: Browser.WebIdl, template: Partial<Browser.WebIdl>): Browser.WebIdl {
         return filterByNull(obj, template);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -91,6 +91,7 @@ export interface AnonymousMethod {
     exposed?: string;
     deprecated?: 1;
     signature: Signature[];
+    "excluded-from"?: string[];
 }
 
 export interface Method extends AnonymousMethod {


### PR DESCRIPTION
Fixes <https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/826>

---

Note that I’d prefer if there was a way to filter based on the source **WebIDL** file, rather than the current `Flavor` const enum approach.