### PR TITLE
feat: Use `declare class` for namespaced types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -19031,81 +19031,46 @@ declare namespace CSS {
 }
 
 declare namespace WebAssembly {
-    interface CompileError {
+    class CompileError {
     }
     
-    var CompileError: {
-        prototype: CompileError;
-        new(): CompileError;
-    };
-    
-    interface Global {
+    class Global {
+        constructor(descriptor: GlobalDescriptor, v?: any);
         value: any;
         valueOf(): any;
     }
     
-    var Global: {
-        prototype: Global;
-        new(descriptor: GlobalDescriptor, v?: any): Global;
-    };
-    
-    interface Instance {
+    class Instance {
+        constructor(module: Module, importObject?: Imports);
         readonly exports: Exports;
     }
     
-    var Instance: {
-        prototype: Instance;
-        new(module: Module, importObject?: Imports): Instance;
-    };
-    
-    interface LinkError {
+    class LinkError {
     }
     
-    var LinkError: {
-        prototype: LinkError;
-        new(): LinkError;
-    };
-    
-    interface Memory {
+    class Memory {
+        constructor(descriptor: MemoryDescriptor);
         readonly buffer: ArrayBuffer;
         grow(delta: number): number;
     }
     
-    var Memory: {
-        prototype: Memory;
-        new(descriptor: MemoryDescriptor): Memory;
-    };
-    
-    interface Module {
+    class Module {
+        constructor(bytes: BufferSource);
+        static customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
+        static exports(moduleObject: Module): ModuleExportDescriptor[];
+        static imports(moduleObject: Module): ModuleImportDescriptor[];
     }
     
-    var Module: {
-        prototype: Module;
-        new(bytes: BufferSource): Module;
-        customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
-        exports(moduleObject: Module): ModuleExportDescriptor[];
-        imports(moduleObject: Module): ModuleImportDescriptor[];
-    };
-    
-    interface RuntimeError {
+    class RuntimeError {
     }
     
-    var RuntimeError: {
-        prototype: RuntimeError;
-        new(): RuntimeError;
-    };
-    
-    interface Table {
+    class Table {
+        constructor(descriptor: TableDescriptor);
         readonly length: number;
         get(index: number): Function | null;
         grow(delta: number): number;
         set(index: number, value: Function | null): void;
     }
-    
-    var Table: {
-        prototype: Table;
-        new(descriptor: TableDescriptor): Table;
-    };
     
     interface GlobalDescriptor {
         mutable?: boolean;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -5709,57 +5709,37 @@ interface Console {
 declare var console: Console;
 
 declare namespace WebAssembly {
-    interface Global {
+    class Global {
+        constructor(descriptor: GlobalDescriptor, v?: any);
         value: any;
         valueOf(): any;
     }
     
-    var Global: {
-        prototype: Global;
-        new(descriptor: GlobalDescriptor, v?: any): Global;
-    };
-    
-    interface Instance {
+    class Instance {
+        constructor(module: Module, importObject?: Imports);
         readonly exports: Exports;
     }
     
-    var Instance: {
-        prototype: Instance;
-        new(module: Module, importObject?: Imports): Instance;
-    };
-    
-    interface Memory {
+    class Memory {
+        constructor(descriptor: MemoryDescriptor);
         readonly buffer: ArrayBuffer;
         grow(delta: number): number;
     }
     
-    var Memory: {
-        prototype: Memory;
-        new(descriptor: MemoryDescriptor): Memory;
-    };
-    
-    interface Module {
+    class Module {
+        constructor(bytes: BufferSource);
+        static customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
+        static exports(moduleObject: Module): ModuleExportDescriptor[];
+        static imports(moduleObject: Module): ModuleImportDescriptor[];
     }
     
-    var Module: {
-        prototype: Module;
-        new(bytes: BufferSource): Module;
-        customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
-        exports(moduleObject: Module): ModuleExportDescriptor[];
-        imports(moduleObject: Module): ModuleImportDescriptor[];
-    };
-    
-    interface Table {
+    class Table {
+        constructor(descriptor: TableDescriptor);
         readonly length: number;
         get(index: number): Function | null;
         grow(delta: number): number;
         set(index: number, value: Function | null): void;
     }
-    
-    var Table: {
-        prototype: Table;
-        new(descriptor: TableDescriptor): Table;
-    };
     
     interface GlobalDescriptor {
         mutable?: boolean;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2538,7 +2538,7 @@
             "Instance": {
                 "constructor": {
                     "override-signatures": [
-                        "new(module: Module, importObject?: Imports): Instance"
+                        "constructor(module: Module, importObject?: Imports)"
                     ],
                     "force-references": [
                         {


### PR DESCRIPTION
Unlike <https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/858>, which failed because `class`es declared in the global scope exist only on the global Declarative Environment Record, `class`es exported from **TypeScript**’s `namespace` construct exist as own properties of the `namespace` object, which matches the **WebIDL** behaviour.