### PR TITLE
fix(WebAssembly): Correct `NativeError` subclass types

### DIFF
--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -435,7 +435,8 @@ declare namespace WebAssembly {
 
     var CompileError: {
         prototype: CompileError;
-        new(): CompileError;
+        new(message?: string): CompileError;
+        (message?: string): CompileError;
     };
 
     interface Global {
@@ -462,7 +463,8 @@ declare namespace WebAssembly {
 
     var LinkError: {
         prototype: LinkError;
-        new(): LinkError;
+        new(message?: string): LinkError;
+        (message?: string): LinkError;
     };
 
     interface Memory {
@@ -491,7 +493,8 @@ declare namespace WebAssembly {
 
     var RuntimeError: {
         prototype: RuntimeError;
-        new(): RuntimeError;
+        new(message?: string): RuntimeError;
+        (message?: string): RuntimeError;
     };
 
     interface Table {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -16552,7 +16552,8 @@ declare namespace WebAssembly {
 
     var CompileError: {
         prototype: CompileError;
-        new(): CompileError;
+        new(message?: string): CompileError;
+        (message?: string): CompileError;
     };
 
     interface Global {
@@ -16579,7 +16580,8 @@ declare namespace WebAssembly {
 
     var LinkError: {
         prototype: LinkError;
-        new(): LinkError;
+        new(message?: string): LinkError;
+        (message?: string): LinkError;
     };
 
     interface Memory {
@@ -16608,7 +16610,8 @@ declare namespace WebAssembly {
 
     var RuntimeError: {
         prototype: RuntimeError;
-        new(): RuntimeError;
+        new(message?: string): RuntimeError;
+        (message?: string): RuntimeError;
     };
 
     interface Table {

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -5108,7 +5108,8 @@ declare namespace WebAssembly {
 
     var CompileError: {
         prototype: CompileError;
-        new(): CompileError;
+        new(message?: string): CompileError;
+        (message?: string): CompileError;
     };
 
     interface Global {
@@ -5135,7 +5136,8 @@ declare namespace WebAssembly {
 
     var LinkError: {
         prototype: LinkError;
-        new(): LinkError;
+        new(message?: string): LinkError;
+        (message?: string): LinkError;
     };
 
     interface Memory {
@@ -5164,7 +5166,8 @@ declare namespace WebAssembly {
 
     var RuntimeError: {
         prototype: RuntimeError;
-        new(): RuntimeError;
+        new(message?: string): RuntimeError;
+        (message?: string): RuntimeError;
     };
 
     interface Table {

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -5137,7 +5137,8 @@ declare namespace WebAssembly {
 
     var CompileError: {
         prototype: CompileError;
-        new(): CompileError;
+        new(message?: string): CompileError;
+        (message?: string): CompileError;
     };
 
     interface Global {
@@ -5164,7 +5165,8 @@ declare namespace WebAssembly {
 
     var LinkError: {
         prototype: LinkError;
-        new(): LinkError;
+        new(message?: string): LinkError;
+        (message?: string): LinkError;
     };
 
     interface Memory {
@@ -5193,7 +5195,8 @@ declare namespace WebAssembly {
 
     var RuntimeError: {
         prototype: RuntimeError;
-        new(): RuntimeError;
+        new(message?: string): RuntimeError;
+        (message?: string): RuntimeError;
     };
 
     interface Table {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -5351,7 +5351,8 @@ declare namespace WebAssembly {
 
     var CompileError: {
         prototype: CompileError;
-        new(): CompileError;
+        new(message?: string): CompileError;
+        (message?: string): CompileError;
     };
 
     interface Global {
@@ -5378,7 +5379,8 @@ declare namespace WebAssembly {
 
     var LinkError: {
         prototype: LinkError;
-        new(): LinkError;
+        new(message?: string): LinkError;
+        (message?: string): LinkError;
     };
 
     interface Memory {
@@ -5407,7 +5409,8 @@ declare namespace WebAssembly {
 
     var RuntimeError: {
         prototype: RuntimeError;
-        new(): RuntimeError;
+        new(message?: string): RuntimeError;
+        (message?: string): RuntimeError;
     };
 
     interface Table {

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -302,7 +302,13 @@
             "CompileError": {
                 "name": "CompileError",
                 "extends": "Error",
-                "legacyNamespace": "WebAssembly"
+                "legacyNamespace": "WebAssembly",
+                "constructor": {
+                    "overrideSignatures": [
+                        "new(message?: string): CompileError",
+                        "(message?: string): CompileError"
+                    ]
+                }
             },
             "DeviceMotionEventAcceleration": {
                 "noInterfaceObject": true
@@ -859,7 +865,13 @@
             "RuntimeError": {
                 "name": "RuntimeError",
                 "extends": "Error",
-                "legacyNamespace": "WebAssembly"
+                "legacyNamespace": "WebAssembly",
+                "constructor": {
+                    "overrideSignatures": [
+                        "new(message?: string): RuntimeError",
+                        "(message?: string): RuntimeError"
+                    ]
+                }
             },
             "SVGStyleElement": {
                 "properties": {
@@ -874,7 +886,13 @@
             "LinkError": {
                 "name": "LinkError",
                 "extends": "Error",
-                "legacyNamespace": "WebAssembly"
+                "legacyNamespace": "WebAssembly",
+                "constructor": {
+                    "overrideSignatures": [
+                        "new(message?: string): LinkError",
+                        "(message?: string): LinkError"
+                    ]
+                }
             },
             "MediaRecorder": {
                 "events": {


### PR DESCRIPTION
These types are actually defined using **ECMA‑262**’s <code><var>NativeError</var></code> object structure:
- <https://webassembly.github.io/spec/js-api/#error-objects>
- <https://tc39.es/ecma262/#sec-nativeerror-object-structure>

---

They’re also exposed everywhere <code>namespace [WebAssembly][namespacedef-webassembly]</code> is.

[namespacedef-webassembly]: https://webassembly.github.io/spec/js-api/#namespacedef-webassembly