### PR TITLE
Fix RTCPeerConnection override

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -12288,7 +12288,7 @@ interface RTCPeerConnection extends EventTarget {
     removeTrack(sender: RTCRtpSender): void;
     setConfiguration(configuration: RTCConfiguration): void;
     setIdentityProvider(provider: string, options?: RTCIdentityProviderOptions): void;
-    setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>;
+    setLocalDescription(description?: RTCSessionDescriptionInit): Promise<void>;
     setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>;
     addEventListener<K extends keyof RTCPeerConnectionEventMap>(type: K, listener: (this: RTCPeerConnection, ev: RTCPeerConnectionEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1873,7 +1873,7 @@
                         "setLocalDescription": {
                             "name": "setLocalDescription",
                             "override-signatures": [
-                                "setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>"
+                                "setLocalDescription(description?: RTCSessionDescriptionInit): Promise<void>"
                             ]
                         },
                         "setRemoteDescription": {


### PR DESCRIPTION
The signature for RTCPeerConnection.setLocalDescription has been overriden, as of #386, to have a mandatory argument. This is no longer the case; see specs here:

https://w3c.github.io/webrtc-pc/#dom-peerconnection-setlocaldescription
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/setLocalDescription#Parameters

This PR makes it optional, as it should be.

Resolves #875
Resolves https://github.com/microsoft/TypeScript/issues/41939
Resolves https://github.com/microsoft/TypeScript/pull/39142

Props to @jcc10 and @Simonwep for finding this bug before me, but trying to fix it by modifying the generated declaration files, instead of here (as per [these instructions](https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md#modifying-generated-library-files)). I think this should solve the problem for good and finally stop TypeScript from complaining about the argument count?

That being said, I still think that [webidl2](https://github.com/w3c/webidl2.js) needs to be looked at, as @Simonwep said in #875, because in [this file](https://github.com/microsoft/TypeScript-DOM-lib-generator/blob/master/inputfiles/browser.webidl.preprocessed.json) after line 44565 there should be `"optional": 1`, (like #386, this is all from 2018) but I deliberatiely didn't touch that since I'm thinking it needs to be fixed upstream.