### PR TITLE
feat(WebAssembly): Add `shared: boolean` for `MemoryDescriptor` dict

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -19199,6 +19199,7 @@ declare namespace WebAssembly {
     interface MemoryDescriptor {
         initial: number;
         maximum?: number;
+        shared?: boolean;
     }
     
     interface ModuleExportDescriptor {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -5773,6 +5773,7 @@ declare namespace WebAssembly {
     interface MemoryDescriptor {
         initial: number;
         maximum?: number;
+        shared?: boolean;
     }
     
     interface ModuleExportDescriptor {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -2306,6 +2306,17 @@
                     }
                 }
             },
+            "MemoryDescriptor": {
+                "legacy-namespace": "WebAssembly",
+                "members": {
+                    "member": {
+                        "shared": {
+                            "name": "shared",
+                            "type": "boolean"
+                        }
+                    }
+                }
+            },
             "ShadowRootInit": {
                 "members": {
                     "member": {


### PR DESCRIPTION
(This is my first time contributing lib type updates, please let me know if I did anything wrong.)

Closes microsoft/TypeScript#42182.

[MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory/Memory#Parameters)

Note that this parameter is missing from the [spec](https://www.w3.org/TR/2019/REC-wasm-js-api-1-20191205/#memories).

[browser-compat-data](https://github.com/mdn/browser-compat-data/blob/5c9fce3086e91e9994ce8e8b37791c34512718e9/javascript/builtins/webassembly/Memory.json#L112)