### PR TITLE
fix: Mark `prototype` property of constructors as `readonly`

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1997,7 +1997,7 @@ interface AbortController {
 }
 
 declare var AbortController: {
-    prototype: AbortController;
+    readonly prototype: AbortController;
     new(): AbortController;
 };
 
@@ -2019,7 +2019,7 @@ interface AbortSignal extends EventTarget {
 }
 
 declare var AbortSignal: {
-    prototype: AbortSignal;
+    readonly prototype: AbortSignal;
     new(): AbortSignal;
 };
 
@@ -2047,7 +2047,7 @@ interface AbstractRange {
 }
 
 declare var AbstractRange: {
-    prototype: AbstractRange;
+    readonly prototype: AbstractRange;
     new(): AbstractRange;
 };
 
@@ -2085,7 +2085,7 @@ interface AnalyserNode extends AudioNode {
 }
 
 declare var AnalyserNode: {
-    prototype: AnalyserNode;
+    readonly prototype: AnalyserNode;
     new(context: BaseAudioContext, options?: AnalyserOptions): AnalyserNode;
 };
 
@@ -2125,7 +2125,7 @@ interface Animation extends EventTarget {
 }
 
 declare var Animation: {
-    prototype: Animation;
+    readonly prototype: Animation;
     new(effect?: AnimationEffect | null, timeline?: AnimationTimeline | null): Animation;
 };
 
@@ -2136,7 +2136,7 @@ interface AnimationEffect {
 }
 
 declare var AnimationEffect: {
-    prototype: AnimationEffect;
+    readonly prototype: AnimationEffect;
     new(): AnimationEffect;
 };
 
@@ -2148,7 +2148,7 @@ interface AnimationEvent extends Event {
 }
 
 declare var AnimationEvent: {
-    prototype: AnimationEvent;
+    readonly prototype: AnimationEvent;
     new(type: string, animationEventInitDict?: AnimationEventInit): AnimationEvent;
 };
 
@@ -2163,7 +2163,7 @@ interface AnimationPlaybackEvent extends Event {
 }
 
 declare var AnimationPlaybackEvent: {
-    prototype: AnimationPlaybackEvent;
+    readonly prototype: AnimationPlaybackEvent;
     new(type: string, eventInitDict?: AnimationPlaybackEventInit): AnimationPlaybackEvent;
 };
 
@@ -2172,7 +2172,7 @@ interface AnimationTimeline {
 }
 
 declare var AnimationTimeline: {
-    prototype: AnimationTimeline;
+    readonly prototype: AnimationTimeline;
     new(): AnimationTimeline;
 };
 
@@ -2225,7 +2225,7 @@ interface ApplicationCache extends EventTarget {
 }
 
 declare var ApplicationCache: {
-    prototype: ApplicationCache;
+    readonly prototype: ApplicationCache;
     new(): ApplicationCache;
     readonly CHECKING: number;
     readonly DOWNLOADING: number;
@@ -2248,7 +2248,7 @@ interface Attr extends Node {
 }
 
 declare var Attr: {
-    prototype: Attr;
+    readonly prototype: Attr;
     new(): Attr;
 };
 
@@ -2264,7 +2264,7 @@ interface AudioBuffer {
 }
 
 declare var AudioBuffer: {
-    prototype: AudioBuffer;
+    readonly prototype: AudioBuffer;
     new(options: AudioBufferOptions): AudioBuffer;
 };
 
@@ -2284,7 +2284,7 @@ interface AudioBufferSourceNode extends AudioScheduledSourceNode {
 }
 
 declare var AudioBufferSourceNode: {
-    prototype: AudioBufferSourceNode;
+    readonly prototype: AudioBufferSourceNode;
     new(context: BaseAudioContext, options?: AudioBufferSourceOptions): AudioBufferSourceNode;
 };
 
@@ -2307,7 +2307,7 @@ interface AudioContext extends BaseAudioContext {
 }
 
 declare var AudioContext: {
-    prototype: AudioContext;
+    readonly prototype: AudioContext;
     new(contextOptions?: AudioContextOptions): AudioContext;
 };
 
@@ -2317,7 +2317,7 @@ interface AudioDestinationNode extends AudioNode {
 }
 
 declare var AudioDestinationNode: {
-    prototype: AudioDestinationNode;
+    readonly prototype: AudioDestinationNode;
     new(): AudioDestinationNode;
 };
 
@@ -2339,7 +2339,7 @@ interface AudioListener {
 }
 
 declare var AudioListener: {
-    prototype: AudioListener;
+    readonly prototype: AudioListener;
     new(): AudioListener;
 };
 
@@ -2363,7 +2363,7 @@ interface AudioNode extends EventTarget {
 }
 
 declare var AudioNode: {
-    prototype: AudioNode;
+    readonly prototype: AudioNode;
     new(): AudioNode;
 };
 
@@ -2384,7 +2384,7 @@ interface AudioParam {
 }
 
 declare var AudioParam: {
-    prototype: AudioParam;
+    readonly prototype: AudioParam;
     new(): AudioParam;
 };
 
@@ -2393,7 +2393,7 @@ interface AudioParamMap {
 }
 
 declare var AudioParamMap: {
-    prototype: AudioParamMap;
+    readonly prototype: AudioParamMap;
     new(): AudioParamMap;
 };
 
@@ -2407,7 +2407,7 @@ interface AudioProcessingEvent extends Event {
 }
 
 declare var AudioProcessingEvent: {
-    prototype: AudioProcessingEvent;
+    readonly prototype: AudioProcessingEvent;
     new(type: string, eventInitDict: AudioProcessingEventInit): AudioProcessingEvent;
 };
 
@@ -2426,7 +2426,7 @@ interface AudioScheduledSourceNode extends AudioNode {
 }
 
 declare var AudioScheduledSourceNode: {
-    prototype: AudioScheduledSourceNode;
+    readonly prototype: AudioScheduledSourceNode;
     new(): AudioScheduledSourceNode;
 };
 
@@ -2434,7 +2434,7 @@ interface AudioWorklet extends Worklet {
 }
 
 declare var AudioWorklet: {
-    prototype: AudioWorklet;
+    readonly prototype: AudioWorklet;
     new(): AudioWorklet;
 };
 
@@ -2453,7 +2453,7 @@ interface AudioWorkletNode extends AudioNode {
 }
 
 declare var AudioWorkletNode: {
-    prototype: AudioWorkletNode;
+    readonly prototype: AudioWorkletNode;
     new(context: BaseAudioContext, name: string, options?: AudioWorkletNodeOptions): AudioWorkletNode;
 };
 
@@ -2464,7 +2464,7 @@ interface AuthenticatorAssertionResponse extends AuthenticatorResponse {
 }
 
 declare var AuthenticatorAssertionResponse: {
-    prototype: AuthenticatorAssertionResponse;
+    readonly prototype: AuthenticatorAssertionResponse;
     new(): AuthenticatorAssertionResponse;
 };
 
@@ -2473,7 +2473,7 @@ interface AuthenticatorAttestationResponse extends AuthenticatorResponse {
 }
 
 declare var AuthenticatorAttestationResponse: {
-    prototype: AuthenticatorAttestationResponse;
+    readonly prototype: AuthenticatorAttestationResponse;
     new(): AuthenticatorAttestationResponse;
 };
 
@@ -2482,7 +2482,7 @@ interface AuthenticatorResponse {
 }
 
 declare var AuthenticatorResponse: {
-    prototype: AuthenticatorResponse;
+    readonly prototype: AuthenticatorResponse;
     new(): AuthenticatorResponse;
 };
 
@@ -2491,7 +2491,7 @@ interface BarProp {
 }
 
 declare var BarProp: {
-    prototype: BarProp;
+    readonly prototype: BarProp;
     new(): BarProp;
 };
 
@@ -2533,7 +2533,7 @@ interface BaseAudioContext extends EventTarget {
 }
 
 declare var BaseAudioContext: {
-    prototype: BaseAudioContext;
+    readonly prototype: BaseAudioContext;
     new(): BaseAudioContext;
 };
 
@@ -2543,7 +2543,7 @@ interface BeforeUnloadEvent extends Event {
 }
 
 declare var BeforeUnloadEvent: {
-    prototype: BeforeUnloadEvent;
+    readonly prototype: BeforeUnloadEvent;
     new(): BeforeUnloadEvent;
 };
 
@@ -2565,7 +2565,7 @@ interface BhxBrowser {
 }
 
 declare var BhxBrowser: {
-    prototype: BhxBrowser;
+    readonly prototype: BhxBrowser;
     new(): BhxBrowser;
 };
 
@@ -2580,7 +2580,7 @@ interface BiquadFilterNode extends AudioNode {
 }
 
 declare var BiquadFilterNode: {
-    prototype: BiquadFilterNode;
+    readonly prototype: BiquadFilterNode;
     new(context: BaseAudioContext, options?: BiquadFilterOptions): BiquadFilterNode;
 };
 
@@ -2595,7 +2595,7 @@ interface Blob {
 }
 
 declare var Blob: {
-    prototype: Blob;
+    readonly prototype: Blob;
     new(blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
 };
 
@@ -2636,7 +2636,7 @@ interface BroadcastChannel extends EventTarget {
 }
 
 declare var BroadcastChannel: {
-    prototype: BroadcastChannel;
+    readonly prototype: BroadcastChannel;
     new(name: string): BroadcastChannel;
 };
 
@@ -2647,7 +2647,7 @@ interface ByteLengthQueuingStrategy extends QueuingStrategy<ArrayBufferView> {
 }
 
 declare var ByteLengthQueuingStrategy: {
-    prototype: ByteLengthQueuingStrategy;
+    readonly prototype: ByteLengthQueuingStrategy;
     new(init: QueuingStrategyInit): ByteLengthQueuingStrategy;
 };
 
@@ -2656,7 +2656,7 @@ interface CDATASection extends Text {
 }
 
 declare var CDATASection: {
-    prototype: CDATASection;
+    readonly prototype: CDATASection;
     new(): CDATASection;
 };
 
@@ -2666,7 +2666,7 @@ interface CSSConditionRule extends CSSGroupingRule {
 }
 
 declare var CSSConditionRule: {
-    prototype: CSSConditionRule;
+    readonly prototype: CSSConditionRule;
     new(): CSSConditionRule;
 };
 
@@ -2675,7 +2675,7 @@ interface CSSFontFaceRule extends CSSRule {
 }
 
 declare var CSSFontFaceRule: {
-    prototype: CSSFontFaceRule;
+    readonly prototype: CSSFontFaceRule;
     new(): CSSFontFaceRule;
 };
 
@@ -2687,7 +2687,7 @@ interface CSSGroupingRule extends CSSRule {
 }
 
 declare var CSSGroupingRule: {
-    prototype: CSSGroupingRule;
+    readonly prototype: CSSGroupingRule;
     new(): CSSGroupingRule;
 };
 
@@ -2698,7 +2698,7 @@ interface CSSImportRule extends CSSRule {
 }
 
 declare var CSSImportRule: {
-    prototype: CSSImportRule;
+    readonly prototype: CSSImportRule;
     new(): CSSImportRule;
 };
 
@@ -2709,7 +2709,7 @@ interface CSSKeyframeRule extends CSSRule {
 }
 
 declare var CSSKeyframeRule: {
-    prototype: CSSKeyframeRule;
+    readonly prototype: CSSKeyframeRule;
     new(): CSSKeyframeRule;
 };
 
@@ -2723,7 +2723,7 @@ interface CSSKeyframesRule extends CSSRule {
 }
 
 declare var CSSKeyframesRule: {
-    prototype: CSSKeyframesRule;
+    readonly prototype: CSSKeyframesRule;
     new(): CSSKeyframesRule;
 };
 
@@ -2733,7 +2733,7 @@ interface CSSMediaRule extends CSSConditionRule {
 }
 
 declare var CSSMediaRule: {
-    prototype: CSSMediaRule;
+    readonly prototype: CSSMediaRule;
     new(): CSSMediaRule;
 };
 
@@ -2744,7 +2744,7 @@ interface CSSNamespaceRule extends CSSRule {
 }
 
 declare var CSSNamespaceRule: {
-    prototype: CSSNamespaceRule;
+    readonly prototype: CSSNamespaceRule;
     new(): CSSNamespaceRule;
 };
 
@@ -2755,7 +2755,7 @@ interface CSSPageRule extends CSSGroupingRule {
 }
 
 declare var CSSPageRule: {
-    prototype: CSSPageRule;
+    readonly prototype: CSSPageRule;
     new(): CSSPageRule;
 };
 
@@ -2778,7 +2778,7 @@ interface CSSRule {
 }
 
 declare var CSSRule: {
-    prototype: CSSRule;
+    readonly prototype: CSSRule;
     new(): CSSRule;
     readonly CHARSET_RULE: number;
     readonly FONT_FACE_RULE: number;
@@ -2800,7 +2800,7 @@ interface CSSRuleList {
 }
 
 declare var CSSRuleList: {
-    prototype: CSSRuleList;
+    readonly prototype: CSSRuleList;
     new(): CSSRuleList;
 };
 
@@ -3273,7 +3273,7 @@ interface CSSStyleDeclaration {
 }
 
 declare var CSSStyleDeclaration: {
-    prototype: CSSStyleDeclaration;
+    readonly prototype: CSSStyleDeclaration;
     new(): CSSStyleDeclaration;
 };
 
@@ -3284,7 +3284,7 @@ interface CSSStyleRule extends CSSRule {
 }
 
 declare var CSSStyleRule: {
-    prototype: CSSStyleRule;
+    readonly prototype: CSSStyleRule;
     new(): CSSStyleRule;
 };
 
@@ -3300,7 +3300,7 @@ interface CSSStyleSheet extends StyleSheet {
 }
 
 declare var CSSStyleSheet: {
-    prototype: CSSStyleSheet;
+    readonly prototype: CSSStyleSheet;
     new(): CSSStyleSheet;
 };
 
@@ -3309,7 +3309,7 @@ interface CSSSupportsRule extends CSSConditionRule {
 }
 
 declare var CSSSupportsRule: {
-    prototype: CSSSupportsRule;
+    readonly prototype: CSSSupportsRule;
     new(): CSSSupportsRule;
 };
 
@@ -3325,7 +3325,7 @@ interface Cache {
 }
 
 declare var Cache: {
-    prototype: Cache;
+    readonly prototype: Cache;
     new(): Cache;
 };
 
@@ -3339,7 +3339,7 @@ interface CacheStorage {
 }
 
 declare var CacheStorage: {
-    prototype: CacheStorage;
+    readonly prototype: CacheStorage;
     new(): CacheStorage;
 };
 
@@ -3391,7 +3391,7 @@ interface CanvasGradient {
 }
 
 declare var CanvasGradient: {
-    prototype: CanvasGradient;
+    readonly prototype: CanvasGradient;
     new(): CanvasGradient;
 };
 
@@ -3439,7 +3439,7 @@ interface CanvasPattern {
 }
 
 declare var CanvasPattern: {
-    prototype: CanvasPattern;
+    readonly prototype: CanvasPattern;
     new(): CanvasPattern;
 };
 
@@ -3455,7 +3455,7 @@ interface CanvasRenderingContext2D extends CanvasCompositing, CanvasDrawImage, C
 }
 
 declare var CanvasRenderingContext2D: {
-    prototype: CanvasRenderingContext2D;
+    readonly prototype: CanvasRenderingContext2D;
     new(): CanvasRenderingContext2D;
 };
 
@@ -3509,7 +3509,7 @@ interface CaretPosition {
 }
 
 declare var CaretPosition: {
-    prototype: CaretPosition;
+    readonly prototype: CaretPosition;
     new(): CaretPosition;
 };
 
@@ -3518,7 +3518,7 @@ interface ChannelMergerNode extends AudioNode {
 }
 
 declare var ChannelMergerNode: {
-    prototype: ChannelMergerNode;
+    readonly prototype: ChannelMergerNode;
     new(context: BaseAudioContext, options?: ChannelMergerOptions): ChannelMergerNode;
 };
 
@@ -3527,7 +3527,7 @@ interface ChannelSplitterNode extends AudioNode {
 }
 
 declare var ChannelSplitterNode: {
-    prototype: ChannelSplitterNode;
+    readonly prototype: ChannelSplitterNode;
     new(context: BaseAudioContext, options?: ChannelSplitterOptions): ChannelSplitterNode;
 };
 
@@ -3544,7 +3544,7 @@ interface CharacterData extends Node, ChildNode, NonDocumentTypeChildNode {
 }
 
 declare var CharacterData: {
-    prototype: CharacterData;
+    readonly prototype: CharacterData;
     new(): CharacterData;
 };
 
@@ -3583,7 +3583,7 @@ interface ClientRect {
 }
 
 declare var ClientRect: {
-    prototype: ClientRect;
+    readonly prototype: ClientRect;
     new(): ClientRect;
 };
 
@@ -3594,7 +3594,7 @@ interface ClientRectList {
 }
 
 declare var ClientRectList: {
-    prototype: ClientRectList;
+    readonly prototype: ClientRectList;
     new(): ClientRectList;
 };
 
@@ -3604,7 +3604,7 @@ interface Clipboard extends EventTarget {
 }
 
 declare var Clipboard: {
-    prototype: Clipboard;
+    readonly prototype: Clipboard;
     new(): Clipboard;
 };
 
@@ -3614,7 +3614,7 @@ interface ClipboardEvent extends Event {
 }
 
 declare var ClipboardEvent: {
-    prototype: ClipboardEvent;
+    readonly prototype: ClipboardEvent;
     new(type: string, eventInitDict?: ClipboardEventInit): ClipboardEvent;
 };
 
@@ -3635,7 +3635,7 @@ interface CloseEvent extends Event {
 }
 
 declare var CloseEvent: {
-    prototype: CloseEvent;
+    readonly prototype: CloseEvent;
     new(type: string, eventInitDict?: CloseEventInit): CloseEvent;
 };
 
@@ -3644,7 +3644,7 @@ interface Comment extends CharacterData {
 }
 
 declare var Comment: {
-    prototype: Comment;
+    readonly prototype: Comment;
     new(data?: string): Comment;
 };
 
@@ -3654,7 +3654,7 @@ interface CompositionEvent extends UIEvent {
 }
 
 declare var CompositionEvent: {
-    prototype: CompositionEvent;
+    readonly prototype: CompositionEvent;
     new(type: string, eventInitDict?: CompositionEventInit): CompositionEvent;
 };
 
@@ -3676,7 +3676,7 @@ interface ConstantSourceNode extends AudioScheduledSourceNode {
 }
 
 declare var ConstantSourceNode: {
-    prototype: ConstantSourceNode;
+    readonly prototype: ConstantSourceNode;
     new(context: BaseAudioContext, options?: ConstantSourceOptions): ConstantSourceNode;
 };
 
@@ -3687,7 +3687,7 @@ interface ConvolverNode extends AudioNode {
 }
 
 declare var ConvolverNode: {
-    prototype: ConvolverNode;
+    readonly prototype: ConvolverNode;
     new(context: BaseAudioContext, options?: ConvolverOptions): ConvolverNode;
 };
 
@@ -3698,7 +3698,7 @@ interface CountQueuingStrategy extends QueuingStrategy {
 }
 
 declare var CountQueuingStrategy: {
-    prototype: CountQueuingStrategy;
+    readonly prototype: CountQueuingStrategy;
     new(init: QueuingStrategyInit): CountQueuingStrategy;
 };
 
@@ -3708,7 +3708,7 @@ interface Credential {
 }
 
 declare var Credential: {
-    prototype: Credential;
+    readonly prototype: Credential;
     new(): Credential;
 };
 
@@ -3720,7 +3720,7 @@ interface CredentialsContainer {
 }
 
 declare var CredentialsContainer: {
-    prototype: CredentialsContainer;
+    readonly prototype: CredentialsContainer;
     new(): CredentialsContainer;
 };
 
@@ -3731,7 +3731,7 @@ interface Crypto {
 }
 
 declare var Crypto: {
-    prototype: Crypto;
+    readonly prototype: Crypto;
     new(): Crypto;
 };
 
@@ -3744,7 +3744,7 @@ interface CryptoKey {
 }
 
 declare var CryptoKey: {
-    prototype: CryptoKey;
+    readonly prototype: CryptoKey;
     new(): CryptoKey;
 };
 
@@ -3755,7 +3755,7 @@ interface CryptoKeyPair {
 }
 
 declare var CryptoKeyPair: {
-    prototype: CryptoKeyPair;
+    readonly prototype: CryptoKeyPair;
     new(): CryptoKeyPair;
 };
 
@@ -3767,7 +3767,7 @@ interface CustomElementRegistry {
 }
 
 declare var CustomElementRegistry: {
-    prototype: CustomElementRegistry;
+    readonly prototype: CustomElementRegistry;
     new(): CustomElementRegistry;
 };
 
@@ -3780,7 +3780,7 @@ interface CustomEvent<T = any> extends Event {
 }
 
 declare var CustomEvent: {
-    prototype: CustomEvent;
+    readonly prototype: CustomEvent;
     new<T>(typeArg: string, eventInitDict?: CustomEventInit<T>): CustomEvent<T>;
 };
 
@@ -3791,7 +3791,7 @@ interface DOMError {
 }
 
 declare var DOMError: {
-    prototype: DOMError;
+    readonly prototype: DOMError;
     new(): DOMError;
 };
 
@@ -3828,7 +3828,7 @@ interface DOMException {
 }
 
 declare var DOMException: {
-    prototype: DOMException;
+    readonly prototype: DOMException;
     new(message?: string, name?: string): DOMException;
     readonly ABORT_ERR: number;
     readonly DATA_CLONE_ERR: number;
@@ -3867,7 +3867,7 @@ interface DOMImplementation {
 }
 
 declare var DOMImplementation: {
-    prototype: DOMImplementation;
+    readonly prototype: DOMImplementation;
     new(): DOMImplementation;
 };
 
@@ -3913,7 +3913,7 @@ interface DOMMatrix extends DOMMatrixReadOnly {
 }
 
 declare var DOMMatrix: {
-    prototype: DOMMatrix;
+    readonly prototype: DOMMatrix;
     new(init?: string | number[]): DOMMatrix;
     fromFloat32Array(array32: Float32Array): DOMMatrix;
     fromFloat64Array(array64: Float64Array): DOMMatrix;
@@ -3973,7 +3973,7 @@ interface DOMMatrixReadOnly {
 }
 
 declare var DOMMatrixReadOnly: {
-    prototype: DOMMatrixReadOnly;
+    readonly prototype: DOMMatrixReadOnly;
     new(init?: string | number[]): DOMMatrixReadOnly;
     fromFloat32Array(array32: Float32Array): DOMMatrixReadOnly;
     fromFloat64Array(array64: Float64Array): DOMMatrixReadOnly;
@@ -3996,7 +3996,7 @@ interface DOMParser {
 }
 
 declare var DOMParser: {
-    prototype: DOMParser;
+    readonly prototype: DOMParser;
     new(): DOMParser;
 };
 
@@ -4008,7 +4008,7 @@ interface DOMPoint extends DOMPointReadOnly {
 }
 
 declare var DOMPoint: {
-    prototype: DOMPoint;
+    readonly prototype: DOMPoint;
     new(x?: number, y?: number, z?: number, w?: number): DOMPoint;
     fromPoint(other?: DOMPointInit): DOMPoint;
 };
@@ -4026,7 +4026,7 @@ interface DOMPointReadOnly {
 }
 
 declare var DOMPointReadOnly: {
-    prototype: DOMPointReadOnly;
+    readonly prototype: DOMPointReadOnly;
     new(x?: number, y?: number, z?: number, w?: number): DOMPointReadOnly;
     fromPoint(other?: DOMPointInit): DOMPointReadOnly;
 };
@@ -4041,7 +4041,7 @@ interface DOMQuad {
 }
 
 declare var DOMQuad: {
-    prototype: DOMQuad;
+    readonly prototype: DOMQuad;
     new(p1?: DOMPointInit, p2?: DOMPointInit, p3?: DOMPointInit, p4?: DOMPointInit): DOMQuad;
     fromQuad(other?: DOMQuadInit): DOMQuad;
     fromRect(other?: DOMRectInit): DOMQuad;
@@ -4055,7 +4055,7 @@ interface DOMRect extends DOMRectReadOnly {
 }
 
 declare var DOMRect: {
-    prototype: DOMRect;
+    readonly prototype: DOMRect;
     new(x?: number, y?: number, width?: number, height?: number): DOMRect;
     fromRect(other?: DOMRectInit): DOMRect;
 };
@@ -4070,7 +4070,7 @@ interface DOMRectList {
 }
 
 declare var DOMRectList: {
-    prototype: DOMRectList;
+    readonly prototype: DOMRectList;
     new(): DOMRectList;
 };
 
@@ -4087,7 +4087,7 @@ interface DOMRectReadOnly {
 }
 
 declare var DOMRectReadOnly: {
-    prototype: DOMRectReadOnly;
+    readonly prototype: DOMRectReadOnly;
     new(x?: number, y?: number, width?: number, height?: number): DOMRectReadOnly;
     fromRect(other?: DOMRectInit): DOMRectReadOnly;
 };
@@ -4097,7 +4097,7 @@ interface DOMSettableTokenList extends DOMTokenList {
 }
 
 declare var DOMSettableTokenList: {
-    prototype: DOMSettableTokenList;
+    readonly prototype: DOMSettableTokenList;
     new(): DOMSettableTokenList;
 };
 
@@ -4119,7 +4119,7 @@ interface DOMStringList {
 }
 
 declare var DOMStringList: {
-    prototype: DOMStringList;
+    readonly prototype: DOMStringList;
     new(): DOMStringList;
 };
 
@@ -4129,7 +4129,7 @@ interface DOMStringMap {
 }
 
 declare var DOMStringMap: {
-    prototype: DOMStringMap;
+    readonly prototype: DOMStringMap;
     new(): DOMStringMap;
 };
 
@@ -4201,7 +4201,7 @@ interface DOMTokenList {
 }
 
 declare var DOMTokenList: {
-    prototype: DOMTokenList;
+    readonly prototype: DOMTokenList;
     new(): DOMTokenList;
 };
 
@@ -4214,7 +4214,7 @@ interface DataCue extends TextTrackCue {
 }
 
 declare var DataCue: {
-    prototype: DataCue;
+    readonly prototype: DataCue;
     new(): DataCue;
 };
 
@@ -4267,7 +4267,7 @@ interface DataTransfer {
 }
 
 declare var DataTransfer: {
-    prototype: DataTransfer;
+    readonly prototype: DataTransfer;
     new(): DataTransfer;
 };
 
@@ -4293,7 +4293,7 @@ interface DataTransferItem {
 }
 
 declare var DataTransferItem: {
-    prototype: DataTransferItem;
+    readonly prototype: DataTransferItem;
     new(): DataTransferItem;
 };
 
@@ -4321,7 +4321,7 @@ interface DataTransferItemList {
 }
 
 declare var DataTransferItemList: {
-    prototype: DataTransferItemList;
+    readonly prototype: DataTransferItemList;
     new(): DataTransferItemList;
 };
 
@@ -4334,7 +4334,7 @@ interface DeferredPermissionRequest {
 }
 
 declare var DeferredPermissionRequest: {
-    prototype: DeferredPermissionRequest;
+    readonly prototype: DeferredPermissionRequest;
     new(): DeferredPermissionRequest;
 };
 
@@ -4344,7 +4344,7 @@ interface DelayNode extends AudioNode {
 }
 
 declare var DelayNode: {
-    prototype: DelayNode;
+    readonly prototype: DelayNode;
     new(context: BaseAudioContext, options?: DelayOptions): DelayNode;
 };
 
@@ -4356,7 +4356,7 @@ interface DeviceAcceleration {
 }
 
 declare var DeviceAcceleration: {
-    prototype: DeviceAcceleration;
+    readonly prototype: DeviceAcceleration;
     new(): DeviceAcceleration;
 };
 
@@ -4366,7 +4366,7 @@ interface DeviceLightEvent extends Event {
 }
 
 declare var DeviceLightEvent: {
-    prototype: DeviceLightEvent;
+    readonly prototype: DeviceLightEvent;
     new(typeArg: string, eventInitDict?: DeviceLightEventInit): DeviceLightEvent;
 };
 
@@ -4379,7 +4379,7 @@ interface DeviceMotionEvent extends Event {
 }
 
 declare var DeviceMotionEvent: {
-    prototype: DeviceMotionEvent;
+    readonly prototype: DeviceMotionEvent;
     new(type: string, eventInitDict?: DeviceMotionEventInit): DeviceMotionEvent;
     requestPermission(): Promise<PermissionState>;
 };
@@ -4405,7 +4405,7 @@ interface DeviceOrientationEvent extends Event {
 }
 
 declare var DeviceOrientationEvent: {
-    prototype: DeviceOrientationEvent;
+    readonly prototype: DeviceOrientationEvent;
     new(type: string, eventInitDict?: DeviceOrientationEventInit): DeviceOrientationEvent;
     requestPermission(): Promise<PermissionState>;
 };
@@ -4418,7 +4418,7 @@ interface DeviceRotationRate {
 }
 
 declare var DeviceRotationRate: {
-    prototype: DeviceRotationRate;
+    readonly prototype: DeviceRotationRate;
     new(): DeviceRotationRate;
 };
 
@@ -4925,7 +4925,7 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
 }
 
 declare var Document: {
-    prototype: Document;
+    readonly prototype: Document;
     new(): Document;
 };
 
@@ -5034,7 +5034,7 @@ interface DocumentFragment extends Node, NonElementParentNode, ParentNode {
 }
 
 declare var DocumentFragment: {
-    prototype: DocumentFragment;
+    readonly prototype: DocumentFragment;
     new(): DocumentFragment;
 };
 
@@ -5061,7 +5061,7 @@ interface DocumentTimeline extends AnimationTimeline {
 }
 
 declare var DocumentTimeline: {
-    prototype: DocumentTimeline;
+    readonly prototype: DocumentTimeline;
     new(options?: DocumentTimelineOptions): DocumentTimeline;
 };
 
@@ -5074,7 +5074,7 @@ interface DocumentType extends Node, ChildNode {
 }
 
 declare var DocumentType: {
-    prototype: DocumentType;
+    readonly prototype: DocumentType;
     new(): DocumentType;
 };
 
@@ -5087,7 +5087,7 @@ interface DragEvent extends MouseEvent {
 }
 
 declare var DragEvent: {
-    prototype: DragEvent;
+    readonly prototype: DragEvent;
     new(type: string, eventInitDict?: DragEventInit): DragEvent;
 };
 
@@ -5102,7 +5102,7 @@ interface DynamicsCompressorNode extends AudioNode {
 }
 
 declare var DynamicsCompressorNode: {
-    prototype: DynamicsCompressorNode;
+    readonly prototype: DynamicsCompressorNode;
     new(context: BaseAudioContext, options?: DynamicsCompressorOptions): DynamicsCompressorNode;
 };
 
@@ -5293,7 +5293,7 @@ interface Element extends Node, Animatable, ChildNode, InnerHTML, NonDocumentTyp
 }
 
 declare var Element: {
-    prototype: Element;
+    readonly prototype: Element;
     new(): Element;
 };
 
@@ -5318,7 +5318,7 @@ interface ErrorEvent extends Event {
 }
 
 declare var ErrorEvent: {
-    prototype: ErrorEvent;
+    readonly prototype: ErrorEvent;
     new(type: string, eventInitDict?: ErrorEventInit): ErrorEvent;
 };
 
@@ -5392,7 +5392,7 @@ interface Event {
 }
 
 declare var Event: {
-    prototype: Event;
+    readonly prototype: Event;
     new(type: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
@@ -5440,7 +5440,7 @@ interface EventSource extends EventTarget {
 }
 
 declare var EventSource: {
-    prototype: EventSource;
+    readonly prototype: EventSource;
     new(url: string, eventSourceInitDict?: EventSourceInit): EventSource;
     readonly CLOSED: number;
     readonly CONNECTING: number;
@@ -5474,7 +5474,7 @@ interface EventTarget {
 }
 
 declare var EventTarget: {
-    prototype: EventTarget;
+    readonly prototype: EventTarget;
     new(): EventTarget;
 };
 
@@ -5491,7 +5491,7 @@ interface ExtensionScriptApis {
 }
 
 declare var ExtensionScriptApis: {
-    prototype: ExtensionScriptApis;
+    readonly prototype: ExtensionScriptApis;
     new(): ExtensionScriptApis;
 };
 
@@ -5503,7 +5503,7 @@ interface External {
 }
 
 declare var External: {
-    prototype: External;
+    readonly prototype: External;
     new(): External;
 };
 
@@ -5514,7 +5514,7 @@ interface File extends Blob {
 }
 
 declare var File: {
-    prototype: File;
+    readonly prototype: File;
     new(fileBits: BlobPart[], fileName: string, options?: FilePropertyBag): File;
 };
 
@@ -5526,7 +5526,7 @@ interface FileList {
 }
 
 declare var FileList: {
-    prototype: FileList;
+    readonly prototype: FileList;
     new(): FileList;
 };
 
@@ -5565,7 +5565,7 @@ interface FileReader extends EventTarget {
 }
 
 declare var FileReader: {
-    prototype: FileReader;
+    readonly prototype: FileReader;
     new(): FileReader;
     readonly DONE: number;
     readonly EMPTY: number;
@@ -5578,7 +5578,7 @@ interface FocusEvent extends UIEvent {
 }
 
 declare var FocusEvent: {
-    prototype: FocusEvent;
+    readonly prototype: FocusEvent;
     new(type: string, eventInitDict?: FocusEventInit): FocusEvent;
 };
 
@@ -5592,7 +5592,7 @@ interface FocusNavigationEvent extends Event {
 }
 
 declare var FocusNavigationEvent: {
-    prototype: FocusNavigationEvent;
+    readonly prototype: FocusNavigationEvent;
     new(type: string, eventInitDict?: FocusNavigationEventInit): FocusNavigationEvent;
 };
 
@@ -5608,7 +5608,7 @@ interface FormData {
 }
 
 declare var FormData: {
-    prototype: FormData;
+    readonly prototype: FormData;
     new(form?: HTMLFormElement): FormData;
 };
 
@@ -5618,7 +5618,7 @@ interface GainNode extends AudioNode {
 }
 
 declare var GainNode: {
-    prototype: GainNode;
+    readonly prototype: GainNode;
     new(context: BaseAudioContext, options?: GainOptions): GainNode;
 };
 
@@ -5637,7 +5637,7 @@ interface Gamepad {
 }
 
 declare var Gamepad: {
-    prototype: Gamepad;
+    readonly prototype: Gamepad;
     new(): Gamepad;
 };
 
@@ -5649,7 +5649,7 @@ interface GamepadButton {
 }
 
 declare var GamepadButton: {
-    prototype: GamepadButton;
+    readonly prototype: GamepadButton;
     new(): GamepadButton;
 };
 
@@ -5659,7 +5659,7 @@ interface GamepadEvent extends Event {
 }
 
 declare var GamepadEvent: {
-    prototype: GamepadEvent;
+    readonly prototype: GamepadEvent;
     new(type: string, eventInitDict: GamepadEventInit): GamepadEvent;
 };
 
@@ -5670,7 +5670,7 @@ interface GamepadHapticActuator {
 }
 
 declare var GamepadHapticActuator: {
-    prototype: GamepadHapticActuator;
+    readonly prototype: GamepadHapticActuator;
     new(): GamepadHapticActuator;
 };
 
@@ -5687,7 +5687,7 @@ interface GamepadPose {
 }
 
 declare var GamepadPose: {
-    prototype: GamepadPose;
+    readonly prototype: GamepadPose;
     new(): GamepadPose;
 };
 
@@ -5704,7 +5704,7 @@ interface Geolocation {
 }
 
 declare var Geolocation: {
-    prototype: Geolocation;
+    readonly prototype: Geolocation;
     new(): Geolocation;
 };
 
@@ -5719,7 +5719,7 @@ interface GeolocationCoordinates {
 }
 
 declare var GeolocationCoordinates: {
-    prototype: GeolocationCoordinates;
+    readonly prototype: GeolocationCoordinates;
     new(): GeolocationCoordinates;
 };
 
@@ -5729,7 +5729,7 @@ interface GeolocationPosition {
 }
 
 declare var GeolocationPosition: {
-    prototype: GeolocationPosition;
+    readonly prototype: GeolocationPosition;
     new(): GeolocationPosition;
 };
 
@@ -5742,7 +5742,7 @@ interface GeolocationPositionError {
 }
 
 declare var GeolocationPositionError: {
-    prototype: GeolocationPositionError;
+    readonly prototype: GeolocationPositionError;
     new(): GeolocationPositionError;
     readonly PERMISSION_DENIED: number;
     readonly POSITION_UNAVAILABLE: number;
@@ -6136,7 +6136,7 @@ interface HTMLAllCollection {
 }
 
 declare var HTMLAllCollection: {
-    prototype: HTMLAllCollection;
+    readonly prototype: HTMLAllCollection;
     new(): HTMLAllCollection;
 };
 
@@ -6195,7 +6195,7 @@ interface HTMLAnchorElement extends HTMLElement, HTMLHyperlinkElementUtils {
 }
 
 declare var HTMLAnchorElement: {
-    prototype: HTMLAnchorElement;
+    readonly prototype: HTMLAnchorElement;
     new(): HTMLAnchorElement;
 };
 
@@ -6245,7 +6245,7 @@ interface HTMLAppletElement extends HTMLElement {
 }
 
 declare var HTMLAppletElement: {
-    prototype: HTMLAppletElement;
+    readonly prototype: HTMLAppletElement;
     new(): HTMLAppletElement;
 };
 
@@ -6284,7 +6284,7 @@ interface HTMLAreaElement extends HTMLElement, HTMLHyperlinkElementUtils {
 }
 
 declare var HTMLAreaElement: {
-    prototype: HTMLAreaElement;
+    readonly prototype: HTMLAreaElement;
     new(): HTMLAreaElement;
 };
 
@@ -6297,7 +6297,7 @@ interface HTMLAudioElement extends HTMLMediaElement {
 }
 
 declare var HTMLAudioElement: {
-    prototype: HTMLAudioElement;
+    readonly prototype: HTMLAudioElement;
     new(): HTMLAudioElement;
 };
 
@@ -6315,7 +6315,7 @@ interface HTMLBRElement extends HTMLElement {
 }
 
 declare var HTMLBRElement: {
-    prototype: HTMLBRElement;
+    readonly prototype: HTMLBRElement;
     new(): HTMLBRElement;
 };
 
@@ -6336,7 +6336,7 @@ interface HTMLBaseElement extends HTMLElement {
 }
 
 declare var HTMLBaseElement: {
-    prototype: HTMLBaseElement;
+    readonly prototype: HTMLBaseElement;
     new(): HTMLBaseElement;
 };
 
@@ -6359,7 +6359,7 @@ interface HTMLBaseFontElement extends HTMLElement, DOML2DeprecatedColorProperty 
 }
 
 declare var HTMLBaseFontElement: {
-    prototype: HTMLBaseFontElement;
+    readonly prototype: HTMLBaseFontElement;
     new(): HTMLBaseFontElement;
 };
 
@@ -6390,7 +6390,7 @@ interface HTMLBodyElement extends HTMLElement, WindowEventHandlers {
 }
 
 declare var HTMLBodyElement: {
-    prototype: HTMLBodyElement;
+    readonly prototype: HTMLBodyElement;
     new(): HTMLBodyElement;
 };
 
@@ -6463,7 +6463,7 @@ interface HTMLButtonElement extends HTMLElement {
 }
 
 declare var HTMLButtonElement: {
-    prototype: HTMLButtonElement;
+    readonly prototype: HTMLButtonElement;
     new(): HTMLButtonElement;
 };
 
@@ -6500,7 +6500,7 @@ interface HTMLCanvasElement extends HTMLElement {
 }
 
 declare var HTMLCanvasElement: {
-    prototype: HTMLCanvasElement;
+    readonly prototype: HTMLCanvasElement;
     new(): HTMLCanvasElement;
 };
 
@@ -6525,7 +6525,7 @@ interface HTMLCollection extends HTMLCollectionBase {
 }
 
 declare var HTMLCollection: {
-    prototype: HTMLCollection;
+    readonly prototype: HTMLCollection;
     new(): HTMLCollection;
 };
 
@@ -6546,7 +6546,7 @@ interface HTMLDListElement extends HTMLElement {
 }
 
 declare var HTMLDListElement: {
-    prototype: HTMLDListElement;
+    readonly prototype: HTMLDListElement;
     new(): HTMLDListElement;
 };
 
@@ -6560,7 +6560,7 @@ interface HTMLDataElement extends HTMLElement {
 }
 
 declare var HTMLDataElement: {
-    prototype: HTMLDataElement;
+    readonly prototype: HTMLDataElement;
     new(): HTMLDataElement;
 };
 
@@ -6574,7 +6574,7 @@ interface HTMLDataListElement extends HTMLElement {
 }
 
 declare var HTMLDataListElement: {
-    prototype: HTMLDataListElement;
+    readonly prototype: HTMLDataListElement;
     new(): HTMLDataListElement;
 };
 
@@ -6587,7 +6587,7 @@ interface HTMLDetailsElement extends HTMLElement {
 }
 
 declare var HTMLDetailsElement: {
-    prototype: HTMLDetailsElement;
+    readonly prototype: HTMLDetailsElement;
     new(): HTMLDetailsElement;
 };
 
@@ -6604,7 +6604,7 @@ interface HTMLDialogElement extends HTMLElement {
 }
 
 declare var HTMLDialogElement: {
-    prototype: HTMLDialogElement;
+    readonly prototype: HTMLDialogElement;
     new(): HTMLDialogElement;
 };
 
@@ -6618,7 +6618,7 @@ interface HTMLDirectoryElement extends HTMLElement {
 }
 
 declare var HTMLDirectoryElement: {
-    prototype: HTMLDirectoryElement;
+    readonly prototype: HTMLDirectoryElement;
     new(): HTMLDirectoryElement;
 };
 
@@ -6636,7 +6636,7 @@ interface HTMLDivElement extends HTMLElement {
 }
 
 declare var HTMLDivElement: {
-    prototype: HTMLDivElement;
+    readonly prototype: HTMLDivElement;
     new(): HTMLDivElement;
 };
 
@@ -6649,7 +6649,7 @@ interface HTMLDocument extends Document {
 }
 
 declare var HTMLDocument: {
-    prototype: HTMLDocument;
+    readonly prototype: HTMLDocument;
     new(): HTMLDocument;
 };
 
@@ -6683,7 +6683,7 @@ interface HTMLElement extends Element, DocumentAndElementEventHandlers, ElementC
 }
 
 declare var HTMLElement: {
-    prototype: HTMLElement;
+    readonly prototype: HTMLElement;
     new(): HTMLElement;
 };
 
@@ -6717,7 +6717,7 @@ interface HTMLEmbedElement extends HTMLElement {
 }
 
 declare var HTMLEmbedElement: {
-    prototype: HTMLEmbedElement;
+    readonly prototype: HTMLEmbedElement;
     new(): HTMLEmbedElement;
 };
 
@@ -6760,7 +6760,7 @@ interface HTMLFieldSetElement extends HTMLElement {
 }
 
 declare var HTMLFieldSetElement: {
-    prototype: HTMLFieldSetElement;
+    readonly prototype: HTMLFieldSetElement;
     new(): HTMLFieldSetElement;
 };
 
@@ -6782,7 +6782,7 @@ interface HTMLFontElement extends HTMLElement {
 }
 
 declare var HTMLFontElement: {
-    prototype: HTMLFontElement;
+    readonly prototype: HTMLFontElement;
     new(): HTMLFontElement;
 };
 
@@ -6797,7 +6797,7 @@ interface HTMLFormControlsCollection extends HTMLCollectionBase {
 }
 
 declare var HTMLFormControlsCollection: {
-    prototype: HTMLFormControlsCollection;
+    readonly prototype: HTMLFormControlsCollection;
     new(): HTMLFormControlsCollection;
 };
 
@@ -6869,7 +6869,7 @@ interface HTMLFormElement extends HTMLElement {
 }
 
 declare var HTMLFormElement: {
-    prototype: HTMLFormElement;
+    readonly prototype: HTMLFormElement;
     new(): HTMLFormElement;
 };
 
@@ -6931,7 +6931,7 @@ interface HTMLFrameElement extends HTMLElement {
 }
 
 declare var HTMLFrameElement: {
-    prototype: HTMLFrameElement;
+    readonly prototype: HTMLFrameElement;
     new(): HTMLFrameElement;
 };
 
@@ -6957,7 +6957,7 @@ interface HTMLFrameSetElement extends HTMLElement, WindowEventHandlers {
 }
 
 declare var HTMLFrameSetElement: {
-    prototype: HTMLFrameSetElement;
+    readonly prototype: HTMLFrameSetElement;
     new(): HTMLFrameSetElement;
 };
 
@@ -6989,7 +6989,7 @@ interface HTMLHRElement extends HTMLElement {
 }
 
 declare var HTMLHRElement: {
-    prototype: HTMLHRElement;
+    readonly prototype: HTMLHRElement;
     new(): HTMLHRElement;
 };
 
@@ -7002,7 +7002,7 @@ interface HTMLHeadElement extends HTMLElement {
 }
 
 declare var HTMLHeadElement: {
-    prototype: HTMLHeadElement;
+    readonly prototype: HTMLHeadElement;
     new(): HTMLHeadElement;
 };
 
@@ -7020,7 +7020,7 @@ interface HTMLHeadingElement extends HTMLElement {
 }
 
 declare var HTMLHeadingElement: {
-    prototype: HTMLHeadingElement;
+    readonly prototype: HTMLHeadingElement;
     new(): HTMLHeadingElement;
 };
 
@@ -7038,7 +7038,7 @@ interface HTMLHtmlElement extends HTMLElement {
 }
 
 declare var HTMLHtmlElement: {
-    prototype: HTMLHtmlElement;
+    readonly prototype: HTMLHtmlElement;
     new(): HTMLHtmlElement;
 };
 
@@ -7130,7 +7130,7 @@ interface HTMLIFrameElement extends HTMLElement {
 }
 
 declare var HTMLIFrameElement: {
-    prototype: HTMLIFrameElement;
+    readonly prototype: HTMLIFrameElement;
     new(): HTMLIFrameElement;
 };
 
@@ -7221,7 +7221,7 @@ interface HTMLImageElement extends HTMLElement {
 }
 
 declare var HTMLImageElement: {
-    prototype: HTMLImageElement;
+    readonly prototype: HTMLImageElement;
     new(): HTMLImageElement;
 };
 
@@ -7425,7 +7425,7 @@ interface HTMLInputElement extends HTMLElement {
 }
 
 declare var HTMLInputElement: {
-    prototype: HTMLInputElement;
+    readonly prototype: HTMLInputElement;
     new(): HTMLInputElement;
 };
 
@@ -7444,7 +7444,7 @@ interface HTMLLIElement extends HTMLElement {
 }
 
 declare var HTMLLIElement: {
-    prototype: HTMLLIElement;
+    readonly prototype: HTMLLIElement;
     new(): HTMLLIElement;
 };
 
@@ -7466,7 +7466,7 @@ interface HTMLLabelElement extends HTMLElement {
 }
 
 declare var HTMLLabelElement: {
-    prototype: HTMLLabelElement;
+    readonly prototype: HTMLLabelElement;
     new(): HTMLLabelElement;
 };
 
@@ -7485,7 +7485,7 @@ interface HTMLLegendElement extends HTMLElement {
 }
 
 declare var HTMLLegendElement: {
-    prototype: HTMLLegendElement;
+    readonly prototype: HTMLLegendElement;
     new(): HTMLLegendElement;
 };
 
@@ -7542,7 +7542,7 @@ interface HTMLLinkElement extends HTMLElement, LinkStyle {
 }
 
 declare var HTMLLinkElement: {
-    prototype: HTMLLinkElement;
+    readonly prototype: HTMLLinkElement;
     new(): HTMLLinkElement;
 };
 
@@ -7563,7 +7563,7 @@ interface HTMLMapElement extends HTMLElement {
 }
 
 declare var HTMLMapElement: {
-    prototype: HTMLMapElement;
+    readonly prototype: HTMLMapElement;
     new(): HTMLMapElement;
 };
 
@@ -7614,7 +7614,7 @@ interface HTMLMarqueeElement extends HTMLElement {
 }
 
 declare var HTMLMarqueeElement: {
-    prototype: HTMLMarqueeElement;
+    readonly prototype: HTMLMarqueeElement;
     new(): HTMLMarqueeElement;
 };
 
@@ -7748,7 +7748,7 @@ interface HTMLMediaElement extends HTMLElement {
 }
 
 declare var HTMLMediaElement: {
-    prototype: HTMLMediaElement;
+    readonly prototype: HTMLMediaElement;
     new(): HTMLMediaElement;
     readonly HAVE_CURRENT_DATA: number;
     readonly HAVE_ENOUGH_DATA: number;
@@ -7771,7 +7771,7 @@ interface HTMLMenuElement extends HTMLElement {
 }
 
 declare var HTMLMenuElement: {
-    prototype: HTMLMenuElement;
+    readonly prototype: HTMLMenuElement;
     new(): HTMLMenuElement;
 };
 
@@ -7801,7 +7801,7 @@ interface HTMLMetaElement extends HTMLElement {
 }
 
 declare var HTMLMetaElement: {
-    prototype: HTMLMetaElement;
+    readonly prototype: HTMLMetaElement;
     new(): HTMLMetaElement;
 };
 
@@ -7821,7 +7821,7 @@ interface HTMLMeterElement extends HTMLElement {
 }
 
 declare var HTMLMeterElement: {
-    prototype: HTMLMeterElement;
+    readonly prototype: HTMLMeterElement;
     new(): HTMLMeterElement;
 };
 
@@ -7842,7 +7842,7 @@ interface HTMLModElement extends HTMLElement {
 }
 
 declare var HTMLModElement: {
-    prototype: HTMLModElement;
+    readonly prototype: HTMLModElement;
     new(): HTMLModElement;
 };
 
@@ -7863,7 +7863,7 @@ interface HTMLOListElement extends HTMLElement {
 }
 
 declare var HTMLOListElement: {
-    prototype: HTMLOListElement;
+    readonly prototype: HTMLOListElement;
     new(): HTMLOListElement;
 };
 
@@ -7967,7 +7967,7 @@ interface HTMLObjectElement extends HTMLElement {
 }
 
 declare var HTMLObjectElement: {
-    prototype: HTMLObjectElement;
+    readonly prototype: HTMLObjectElement;
     new(): HTMLObjectElement;
 };
 
@@ -7989,7 +7989,7 @@ interface HTMLOptGroupElement extends HTMLElement {
 }
 
 declare var HTMLOptGroupElement: {
-    prototype: HTMLOptGroupElement;
+    readonly prototype: HTMLOptGroupElement;
     new(): HTMLOptGroupElement;
 };
 
@@ -8031,7 +8031,7 @@ interface HTMLOptionElement extends HTMLElement {
 }
 
 declare var HTMLOptionElement: {
-    prototype: HTMLOptionElement;
+    readonly prototype: HTMLOptionElement;
     new(): HTMLOptionElement;
 };
 
@@ -8068,7 +8068,7 @@ interface HTMLOptionsCollection extends HTMLCollectionOf<HTMLOptionElement> {
 }
 
 declare var HTMLOptionsCollection: {
-    prototype: HTMLOptionsCollection;
+    readonly prototype: HTMLOptionsCollection;
     new(): HTMLOptionsCollection;
 };
 
@@ -8103,7 +8103,7 @@ interface HTMLOutputElement extends HTMLElement {
 }
 
 declare var HTMLOutputElement: {
-    prototype: HTMLOutputElement;
+    readonly prototype: HTMLOutputElement;
     new(): HTMLOutputElement;
 };
 
@@ -8121,7 +8121,7 @@ interface HTMLParagraphElement extends HTMLElement {
 }
 
 declare var HTMLParagraphElement: {
-    prototype: HTMLParagraphElement;
+    readonly prototype: HTMLParagraphElement;
     new(): HTMLParagraphElement;
 };
 
@@ -8152,7 +8152,7 @@ interface HTMLParamElement extends HTMLElement {
 }
 
 declare var HTMLParamElement: {
-    prototype: HTMLParamElement;
+    readonly prototype: HTMLParamElement;
     new(): HTMLParamElement;
 };
 
@@ -8165,7 +8165,7 @@ interface HTMLPictureElement extends HTMLElement {
 }
 
 declare var HTMLPictureElement: {
-    prototype: HTMLPictureElement;
+    readonly prototype: HTMLPictureElement;
     new(): HTMLPictureElement;
 };
 
@@ -8183,7 +8183,7 @@ interface HTMLPreElement extends HTMLElement {
 }
 
 declare var HTMLPreElement: {
-    prototype: HTMLPreElement;
+    readonly prototype: HTMLPreElement;
     new(): HTMLPreElement;
 };
 
@@ -8209,7 +8209,7 @@ interface HTMLProgressElement extends HTMLElement {
 }
 
 declare var HTMLProgressElement: {
-    prototype: HTMLProgressElement;
+    readonly prototype: HTMLProgressElement;
     new(): HTMLProgressElement;
 };
 
@@ -8226,7 +8226,7 @@ interface HTMLQuoteElement extends HTMLElement {
 }
 
 declare var HTMLQuoteElement: {
-    prototype: HTMLQuoteElement;
+    readonly prototype: HTMLQuoteElement;
     new(): HTMLQuoteElement;
 };
 
@@ -8275,7 +8275,7 @@ interface HTMLScriptElement extends HTMLElement {
 }
 
 declare var HTMLScriptElement: {
-    prototype: HTMLScriptElement;
+    readonly prototype: HTMLScriptElement;
     new(): HTMLScriptElement;
 };
 
@@ -8375,7 +8375,7 @@ interface HTMLSelectElement extends HTMLElement {
 }
 
 declare var HTMLSelectElement: {
-    prototype: HTMLSelectElement;
+    readonly prototype: HTMLSelectElement;
     new(): HTMLSelectElement;
 };
 
@@ -8390,7 +8390,7 @@ interface HTMLSlotElement extends HTMLElement {
 }
 
 declare var HTMLSlotElement: {
-    prototype: HTMLSlotElement;
+    readonly prototype: HTMLSlotElement;
     new(): HTMLSlotElement;
 };
 
@@ -8417,7 +8417,7 @@ interface HTMLSourceElement extends HTMLElement {
 }
 
 declare var HTMLSourceElement: {
-    prototype: HTMLSourceElement;
+    readonly prototype: HTMLSourceElement;
     new(): HTMLSourceElement;
 };
 
@@ -8430,7 +8430,7 @@ interface HTMLSpanElement extends HTMLElement {
 }
 
 declare var HTMLSpanElement: {
-    prototype: HTMLSpanElement;
+    readonly prototype: HTMLSpanElement;
     new(): HTMLSpanElement;
 };
 
@@ -8452,7 +8452,7 @@ interface HTMLStyleElement extends HTMLElement, LinkStyle {
 }
 
 declare var HTMLStyleElement: {
-    prototype: HTMLStyleElement;
+    readonly prototype: HTMLStyleElement;
     new(): HTMLStyleElement;
 };
 
@@ -8470,7 +8470,7 @@ interface HTMLTableCaptionElement extends HTMLElement {
 }
 
 declare var HTMLTableCaptionElement: {
-    prototype: HTMLTableCaptionElement;
+    readonly prototype: HTMLTableCaptionElement;
     new(): HTMLTableCaptionElement;
 };
 
@@ -8540,7 +8540,7 @@ interface HTMLTableCellElement extends HTMLElement {
 }
 
 declare var HTMLTableCellElement: {
-    prototype: HTMLTableCellElement;
+    readonly prototype: HTMLTableCellElement;
     new(): HTMLTableCellElement;
 };
 
@@ -8573,7 +8573,7 @@ interface HTMLTableColElement extends HTMLElement {
 }
 
 declare var HTMLTableColElement: {
-    prototype: HTMLTableColElement;
+    readonly prototype: HTMLTableColElement;
     new(): HTMLTableColElement;
 };
 
@@ -8585,7 +8585,7 @@ interface HTMLTableDataCellElement extends HTMLTableCellElement {
 }
 
 declare var HTMLTableDataCellElement: {
-    prototype: HTMLTableDataCellElement;
+    readonly prototype: HTMLTableDataCellElement;
     new(): HTMLTableDataCellElement;
 };
 
@@ -8698,7 +8698,7 @@ interface HTMLTableElement extends HTMLElement {
 }
 
 declare var HTMLTableElement: {
-    prototype: HTMLTableElement;
+    readonly prototype: HTMLTableElement;
     new(): HTMLTableElement;
 };
 
@@ -8710,7 +8710,7 @@ interface HTMLTableHeaderCellElement extends HTMLTableCellElement {
 }
 
 declare var HTMLTableHeaderCellElement: {
-    prototype: HTMLTableHeaderCellElement;
+    readonly prototype: HTMLTableHeaderCellElement;
     new(): HTMLTableHeaderCellElement;
 };
 
@@ -8758,7 +8758,7 @@ interface HTMLTableRowElement extends HTMLElement {
 }
 
 declare var HTMLTableRowElement: {
-    prototype: HTMLTableRowElement;
+    readonly prototype: HTMLTableRowElement;
     new(): HTMLTableRowElement;
 };
 
@@ -8796,7 +8796,7 @@ interface HTMLTableSectionElement extends HTMLElement {
 }
 
 declare var HTMLTableSectionElement: {
-    prototype: HTMLTableSectionElement;
+    readonly prototype: HTMLTableSectionElement;
     new(): HTMLTableSectionElement;
 };
 
@@ -8810,7 +8810,7 @@ interface HTMLTemplateElement extends HTMLElement {
 }
 
 declare var HTMLTemplateElement: {
-    prototype: HTMLTemplateElement;
+    readonly prototype: HTMLTemplateElement;
     new(): HTMLTemplateElement;
 };
 
@@ -8921,7 +8921,7 @@ interface HTMLTextAreaElement extends HTMLElement {
 }
 
 declare var HTMLTextAreaElement: {
-    prototype: HTMLTextAreaElement;
+    readonly prototype: HTMLTextAreaElement;
     new(): HTMLTextAreaElement;
 };
 
@@ -8935,7 +8935,7 @@ interface HTMLTimeElement extends HTMLElement {
 }
 
 declare var HTMLTimeElement: {
-    prototype: HTMLTimeElement;
+    readonly prototype: HTMLTimeElement;
     new(): HTMLTimeElement;
 };
 
@@ -8952,7 +8952,7 @@ interface HTMLTitleElement extends HTMLElement {
 }
 
 declare var HTMLTitleElement: {
-    prototype: HTMLTitleElement;
+    readonly prototype: HTMLTitleElement;
     new(): HTMLTitleElement;
 };
 
@@ -8976,7 +8976,7 @@ interface HTMLTrackElement extends HTMLElement {
 }
 
 declare var HTMLTrackElement: {
-    prototype: HTMLTrackElement;
+    readonly prototype: HTMLTrackElement;
     new(): HTMLTrackElement;
     readonly ERROR: number;
     readonly LOADED: number;
@@ -8997,7 +8997,7 @@ interface HTMLUListElement extends HTMLElement {
 }
 
 declare var HTMLUListElement: {
-    prototype: HTMLUListElement;
+    readonly prototype: HTMLUListElement;
     new(): HTMLUListElement;
 };
 
@@ -9010,7 +9010,7 @@ interface HTMLUnknownElement extends HTMLElement {
 }
 
 declare var HTMLUnknownElement: {
-    prototype: HTMLUnknownElement;
+    readonly prototype: HTMLUnknownElement;
     new(): HTMLUnknownElement;
 };
 
@@ -9048,7 +9048,7 @@ interface HTMLVideoElement extends HTMLMediaElement {
 }
 
 declare var HTMLVideoElement: {
-    prototype: HTMLVideoElement;
+    readonly prototype: HTMLVideoElement;
     new(): HTMLVideoElement;
 };
 
@@ -9065,7 +9065,7 @@ interface HashChangeEvent extends Event {
 }
 
 declare var HashChangeEvent: {
-    prototype: HashChangeEvent;
+    readonly prototype: HashChangeEvent;
     new(type: string, eventInitDict?: HashChangeEventInit): HashChangeEvent;
 };
 
@@ -9080,7 +9080,7 @@ interface Headers {
 }
 
 declare var Headers: {
-    prototype: Headers;
+    readonly prototype: Headers;
     new(init?: HeadersInit): Headers;
 };
 
@@ -9097,7 +9097,7 @@ interface History {
 }
 
 declare var History: {
-    prototype: History;
+    readonly prototype: History;
     new(): History;
 };
 
@@ -9151,7 +9151,7 @@ interface IDBCursor {
 }
 
 declare var IDBCursor: {
-    prototype: IDBCursor;
+    readonly prototype: IDBCursor;
     new(): IDBCursor;
 };
 
@@ -9164,7 +9164,7 @@ interface IDBCursorWithValue extends IDBCursor {
 }
 
 declare var IDBCursorWithValue: {
-    prototype: IDBCursorWithValue;
+    readonly prototype: IDBCursorWithValue;
     new(): IDBCursorWithValue;
 };
 
@@ -9220,7 +9220,7 @@ interface IDBDatabase extends EventTarget {
 }
 
 declare var IDBDatabase: {
-    prototype: IDBDatabase;
+    readonly prototype: IDBDatabase;
     new(): IDBDatabase;
 };
 
@@ -9243,7 +9243,7 @@ interface IDBFactory {
 }
 
 declare var IDBFactory: {
-    prototype: IDBFactory;
+    readonly prototype: IDBFactory;
     new(): IDBFactory;
 };
 
@@ -9305,7 +9305,7 @@ interface IDBIndex {
 }
 
 declare var IDBIndex: {
-    prototype: IDBIndex;
+    readonly prototype: IDBIndex;
     new(): IDBIndex;
 };
 
@@ -9334,7 +9334,7 @@ interface IDBKeyRange {
 }
 
 declare var IDBKeyRange: {
-    prototype: IDBKeyRange;
+    readonly prototype: IDBKeyRange;
     new(): IDBKeyRange;
     /**
      * Returns a new IDBKeyRange spanning from lower to upper. If lowerOpen is true, lower is not included in the range. If upperOpen is true, upper is not included in the range.
@@ -9466,7 +9466,7 @@ interface IDBObjectStore {
 }
 
 declare var IDBObjectStore: {
-    prototype: IDBObjectStore;
+    readonly prototype: IDBObjectStore;
     new(): IDBObjectStore;
 };
 
@@ -9486,7 +9486,7 @@ interface IDBOpenDBRequest extends IDBRequest<IDBDatabase> {
 }
 
 declare var IDBOpenDBRequest: {
-    prototype: IDBOpenDBRequest;
+    readonly prototype: IDBOpenDBRequest;
     new(): IDBOpenDBRequest;
 };
 
@@ -9526,7 +9526,7 @@ interface IDBRequest<T = any> extends EventTarget {
 }
 
 declare var IDBRequest: {
-    prototype: IDBRequest;
+    readonly prototype: IDBRequest;
     new(): IDBRequest;
 };
 
@@ -9571,7 +9571,7 @@ interface IDBTransaction extends EventTarget {
 }
 
 declare var IDBTransaction: {
-    prototype: IDBTransaction;
+    readonly prototype: IDBTransaction;
     new(): IDBTransaction;
 };
 
@@ -9582,7 +9582,7 @@ interface IDBVersionChangeEvent extends Event {
 }
 
 declare var IDBVersionChangeEvent: {
-    prototype: IDBVersionChangeEvent;
+    readonly prototype: IDBVersionChangeEvent;
     new(type: string, eventInitDict?: IDBVersionChangeEventInit): IDBVersionChangeEvent;
 };
 
@@ -9592,7 +9592,7 @@ interface IIRFilterNode extends AudioNode {
 }
 
 declare var IIRFilterNode: {
-    prototype: IIRFilterNode;
+    readonly prototype: IIRFilterNode;
     new(context: BaseAudioContext, options: IIRFilterOptions): IIRFilterNode;
 };
 
@@ -9612,7 +9612,7 @@ interface ImageBitmap {
 }
 
 declare var ImageBitmap: {
-    prototype: ImageBitmap;
+    readonly prototype: ImageBitmap;
     new(): ImageBitmap;
 };
 
@@ -9628,7 +9628,7 @@ interface ImageBitmapRenderingContext {
 }
 
 declare var ImageBitmapRenderingContext: {
-    prototype: ImageBitmapRenderingContext;
+    readonly prototype: ImageBitmapRenderingContext;
     new(): ImageBitmapRenderingContext;
 };
 
@@ -9649,7 +9649,7 @@ interface ImageData {
 }
 
 declare var ImageData: {
-    prototype: ImageData;
+    readonly prototype: ImageData;
     new(sw: number, sh: number): ImageData;
     new(data: Uint8ClampedArray, sw: number, sh?: number): ImageData;
 };
@@ -9663,7 +9663,7 @@ interface InputDeviceInfo extends MediaDeviceInfo {
 }
 
 declare var InputDeviceInfo: {
-    prototype: InputDeviceInfo;
+    readonly prototype: InputDeviceInfo;
     new(): InputDeviceInfo;
 };
 
@@ -9674,7 +9674,7 @@ interface InputEvent extends UIEvent {
 }
 
 declare var InputEvent: {
-    prototype: InputEvent;
+    readonly prototype: InputEvent;
     new(type: string, eventInitDict?: InputEventInit): InputEvent;
 };
 
@@ -9690,7 +9690,7 @@ interface IntersectionObserver {
 }
 
 declare var IntersectionObserver: {
-    prototype: IntersectionObserver;
+    readonly prototype: IntersectionObserver;
     new(callback: IntersectionObserverCallback, options?: IntersectionObserverInit): IntersectionObserver;
 };
 
@@ -9706,7 +9706,7 @@ interface IntersectionObserverEntry {
 }
 
 declare var IntersectionObserverEntry: {
-    prototype: IntersectionObserverEntry;
+    readonly prototype: IntersectionObserverEntry;
     new(intersectionObserverEntryInit: IntersectionObserverEntryInit): IntersectionObserverEntry;
 };
 
@@ -9735,7 +9735,7 @@ interface KeyboardEvent extends UIEvent {
 }
 
 declare var KeyboardEvent: {
-    prototype: KeyboardEvent;
+    readonly prototype: KeyboardEvent;
     new(type: string, eventInitDict?: KeyboardEventInit): KeyboardEvent;
     readonly DOM_KEY_LOCATION_LEFT: number;
     readonly DOM_KEY_LOCATION_NUMPAD: number;
@@ -9752,7 +9752,7 @@ interface KeyframeEffect extends AnimationEffect {
 }
 
 declare var KeyframeEffect: {
-    prototype: KeyframeEffect;
+    readonly prototype: KeyframeEffect;
     new(target: Element | null, keyframes: Keyframe[] | PropertyIndexedKeyframes | null, options?: number | KeyframeEffectOptions): KeyframeEffect;
     new(source: KeyframeEffect): KeyframeEffect;
 };
@@ -9767,7 +9767,7 @@ interface ListeningStateChangedEvent extends Event {
 }
 
 declare var ListeningStateChangedEvent: {
-    prototype: ListeningStateChangedEvent;
+    readonly prototype: ListeningStateChangedEvent;
     new(): ListeningStateChangedEvent;
 };
 
@@ -9847,7 +9847,7 @@ interface Location {
 }
 
 declare var Location: {
-    prototype: Location;
+    readonly prototype: Location;
     new(): Location;
 };
 
@@ -9857,7 +9857,7 @@ interface MSAssertion {
 }
 
 declare var MSAssertion: {
-    prototype: MSAssertion;
+    readonly prototype: MSAssertion;
     new(): MSAssertion;
 };
 
@@ -9867,7 +9867,7 @@ interface MSBlobBuilder {
 }
 
 declare var MSBlobBuilder: {
-    prototype: MSBlobBuilder;
+    readonly prototype: MSBlobBuilder;
     new(): MSBlobBuilder;
 };
 
@@ -9879,7 +9879,7 @@ interface MSFIDOCredentialAssertion extends MSAssertion {
 }
 
 declare var MSFIDOCredentialAssertion: {
-    prototype: MSFIDOCredentialAssertion;
+    readonly prototype: MSFIDOCredentialAssertion;
     new(): MSFIDOCredentialAssertion;
 };
 
@@ -9890,7 +9890,7 @@ interface MSFIDOSignature {
 }
 
 declare var MSFIDOSignature: {
-    prototype: MSFIDOSignature;
+    readonly prototype: MSFIDOSignature;
     new(): MSFIDOSignature;
 };
 
@@ -9899,7 +9899,7 @@ interface MSFIDOSignatureAssertion extends MSAssertion {
 }
 
 declare var MSFIDOSignatureAssertion: {
-    prototype: MSFIDOSignatureAssertion;
+    readonly prototype: MSFIDOSignatureAssertion;
     new(): MSFIDOSignatureAssertion;
 };
 
@@ -9915,7 +9915,7 @@ interface MSGesture {
 }
 
 declare var MSGesture: {
-    prototype: MSGesture;
+    readonly prototype: MSGesture;
     new(): MSGesture;
 };
 
@@ -9947,7 +9947,7 @@ interface MSGestureEvent extends UIEvent {
 }
 
 declare var MSGestureEvent: {
-    prototype: MSGestureEvent;
+    readonly prototype: MSGestureEvent;
     new(): MSGestureEvent;
     readonly MSGESTURE_FLAG_BEGIN: number;
     readonly MSGESTURE_FLAG_CANCEL: number;
@@ -9963,7 +9963,7 @@ interface MSGraphicsTrust {
 }
 
 declare var MSGraphicsTrust: {
-    prototype: MSGraphicsTrust;
+    readonly prototype: MSGraphicsTrust;
     new(): MSGraphicsTrust;
 };
 
@@ -9991,7 +9991,7 @@ interface MSInputMethodContext extends EventTarget {
 }
 
 declare var MSInputMethodContext: {
-    prototype: MSInputMethodContext;
+    readonly prototype: MSInputMethodContext;
     new(): MSInputMethodContext;
 };
 
@@ -10007,7 +10007,7 @@ interface MSMediaKeyError {
 }
 
 declare var MSMediaKeyError: {
-    prototype: MSMediaKeyError;
+    readonly prototype: MSMediaKeyError;
     new(): MSMediaKeyError;
     readonly MS_MEDIA_KEYERR_CLIENT: number;
     readonly MS_MEDIA_KEYERR_DOMAIN: number;
@@ -10023,7 +10023,7 @@ interface MSMediaKeyMessageEvent extends Event {
 }
 
 declare var MSMediaKeyMessageEvent: {
-    prototype: MSMediaKeyMessageEvent;
+    readonly prototype: MSMediaKeyMessageEvent;
     new(): MSMediaKeyMessageEvent;
 };
 
@@ -10032,7 +10032,7 @@ interface MSMediaKeyNeededEvent extends Event {
 }
 
 declare var MSMediaKeyNeededEvent: {
-    prototype: MSMediaKeyNeededEvent;
+    readonly prototype: MSMediaKeyNeededEvent;
     new(): MSMediaKeyNeededEvent;
 };
 
@@ -10045,7 +10045,7 @@ interface MSMediaKeySession extends EventTarget {
 }
 
 declare var MSMediaKeySession: {
-    prototype: MSMediaKeySession;
+    readonly prototype: MSMediaKeySession;
     new(): MSMediaKeySession;
 };
 
@@ -10055,7 +10055,7 @@ interface MSMediaKeys {
 }
 
 declare var MSMediaKeys: {
-    prototype: MSMediaKeys;
+    readonly prototype: MSMediaKeys;
     new(keySystem: string): MSMediaKeys;
     isTypeSupported(keySystem: string, type?: string | null): boolean;
     isTypeSupportedWithFeatures(keySystem: string, type?: string | null): string;
@@ -10089,7 +10089,7 @@ interface MSPointerEvent extends MouseEvent {
 }
 
 declare var MSPointerEvent: {
-    prototype: MSPointerEvent;
+    readonly prototype: MSPointerEvent;
     new(typeArg: string, eventInitDict?: PointerEventInit): MSPointerEvent;
 };
 
@@ -10100,7 +10100,7 @@ interface MSStream {
 }
 
 declare var MSStream: {
-    prototype: MSStream;
+    readonly prototype: MSStream;
     new(): MSStream;
 };
 
@@ -10114,7 +10114,7 @@ interface MediaDeviceInfo {
 }
 
 declare var MediaDeviceInfo: {
-    prototype: MediaDeviceInfo;
+    readonly prototype: MediaDeviceInfo;
     new(): MediaDeviceInfo;
 };
 
@@ -10135,7 +10135,7 @@ interface MediaDevices extends EventTarget {
 }
 
 declare var MediaDevices: {
-    prototype: MediaDevices;
+    readonly prototype: MediaDevices;
     new(): MediaDevices;
 };
 
@@ -10145,7 +10145,7 @@ interface MediaElementAudioSourceNode extends AudioNode {
 }
 
 declare var MediaElementAudioSourceNode: {
-    prototype: MediaElementAudioSourceNode;
+    readonly prototype: MediaElementAudioSourceNode;
     new(context: AudioContext, options: MediaElementAudioSourceOptions): MediaElementAudioSourceNode;
 };
 
@@ -10155,7 +10155,7 @@ interface MediaEncryptedEvent extends Event {
 }
 
 declare var MediaEncryptedEvent: {
-    prototype: MediaEncryptedEvent;
+    readonly prototype: MediaEncryptedEvent;
     new(type: string, eventInitDict?: MediaEncryptedEventInit): MediaEncryptedEvent;
 };
 
@@ -10170,7 +10170,7 @@ interface MediaError {
 }
 
 declare var MediaError: {
-    prototype: MediaError;
+    readonly prototype: MediaError;
     new(): MediaError;
     readonly MEDIA_ERR_ABORTED: number;
     readonly MEDIA_ERR_DECODE: number;
@@ -10185,7 +10185,7 @@ interface MediaKeyMessageEvent extends Event {
 }
 
 declare var MediaKeyMessageEvent: {
-    prototype: MediaKeyMessageEvent;
+    readonly prototype: MediaKeyMessageEvent;
     new(type: string, eventInitDict: MediaKeyMessageEventInit): MediaKeyMessageEvent;
 };
 
@@ -10214,7 +10214,7 @@ interface MediaKeySession extends EventTarget {
 }
 
 declare var MediaKeySession: {
-    prototype: MediaKeySession;
+    readonly prototype: MediaKeySession;
     new(): MediaKeySession;
 };
 
@@ -10227,7 +10227,7 @@ interface MediaKeyStatusMap {
 }
 
 declare var MediaKeyStatusMap: {
-    prototype: MediaKeyStatusMap;
+    readonly prototype: MediaKeyStatusMap;
     new(): MediaKeyStatusMap;
 };
 
@@ -10239,7 +10239,7 @@ interface MediaKeySystemAccess {
 }
 
 declare var MediaKeySystemAccess: {
-    prototype: MediaKeySystemAccess;
+    readonly prototype: MediaKeySystemAccess;
     new(): MediaKeySystemAccess;
 };
 
@@ -10250,7 +10250,7 @@ interface MediaKeys {
 }
 
 declare var MediaKeys: {
-    prototype: MediaKeys;
+    readonly prototype: MediaKeys;
     new(): MediaKeys;
 };
 
@@ -10265,7 +10265,7 @@ interface MediaList {
 }
 
 declare var MediaList: {
-    prototype: MediaList;
+    readonly prototype: MediaList;
     new(): MediaList;
 };
 
@@ -10289,7 +10289,7 @@ interface MediaQueryList extends EventTarget {
 }
 
 declare var MediaQueryList: {
-    prototype: MediaQueryList;
+    readonly prototype: MediaQueryList;
     new(): MediaQueryList;
 };
 
@@ -10299,7 +10299,7 @@ interface MediaQueryListEvent extends Event {
 }
 
 declare var MediaQueryListEvent: {
-    prototype: MediaQueryListEvent;
+    readonly prototype: MediaQueryListEvent;
     new(type: string, eventInitDict?: MediaQueryListEventInit): MediaQueryListEvent;
 };
 
@@ -10330,7 +10330,7 @@ interface MediaSource extends EventTarget {
 }
 
 declare var MediaSource: {
-    prototype: MediaSource;
+    readonly prototype: MediaSource;
     new(): MediaSource;
     isTypeSupported(type: string): boolean;
 };
@@ -10360,7 +10360,7 @@ interface MediaStream extends EventTarget {
 }
 
 declare var MediaStream: {
-    prototype: MediaStream;
+    readonly prototype: MediaStream;
     new(): MediaStream;
     new(stream: MediaStream): MediaStream;
     new(tracks: MediaStreamTrack[]): MediaStream;
@@ -10371,7 +10371,7 @@ interface MediaStreamAudioDestinationNode extends AudioNode {
 }
 
 declare var MediaStreamAudioDestinationNode: {
-    prototype: MediaStreamAudioDestinationNode;
+    readonly prototype: MediaStreamAudioDestinationNode;
     new(context: AudioContext, options?: AudioNodeOptions): MediaStreamAudioDestinationNode;
 };
 
@@ -10381,7 +10381,7 @@ interface MediaStreamAudioSourceNode extends AudioNode {
 }
 
 declare var MediaStreamAudioSourceNode: {
-    prototype: MediaStreamAudioSourceNode;
+    readonly prototype: MediaStreamAudioSourceNode;
     new(context: AudioContext, options: MediaStreamAudioSourceOptions): MediaStreamAudioSourceNode;
 };
 
@@ -10392,7 +10392,7 @@ interface MediaStreamError {
 }
 
 declare var MediaStreamError: {
-    prototype: MediaStreamError;
+    readonly prototype: MediaStreamError;
     new(): MediaStreamError;
 };
 
@@ -10401,7 +10401,7 @@ interface MediaStreamErrorEvent extends Event {
 }
 
 declare var MediaStreamErrorEvent: {
-    prototype: MediaStreamErrorEvent;
+    readonly prototype: MediaStreamErrorEvent;
     new(typeArg: string, eventInitDict?: MediaStreamErrorEventInit): MediaStreamErrorEvent;
 };
 
@@ -10411,7 +10411,7 @@ interface MediaStreamEvent extends Event {
 }
 
 declare var MediaStreamEvent: {
-    prototype: MediaStreamEvent;
+    readonly prototype: MediaStreamEvent;
     new(type: string, eventInitDict: MediaStreamEventInit): MediaStreamEvent;
 };
 
@@ -10448,7 +10448,7 @@ interface MediaStreamTrack extends EventTarget {
 }
 
 declare var MediaStreamTrack: {
-    prototype: MediaStreamTrack;
+    readonly prototype: MediaStreamTrack;
     new(): MediaStreamTrack;
 };
 
@@ -10456,7 +10456,7 @@ interface MediaStreamTrackAudioSourceNode extends AudioNode {
 }
 
 declare var MediaStreamTrackAudioSourceNode: {
-    prototype: MediaStreamTrackAudioSourceNode;
+    readonly prototype: MediaStreamTrackAudioSourceNode;
     new(context: AudioContext, options: MediaStreamTrackAudioSourceOptions): MediaStreamTrackAudioSourceNode;
 };
 
@@ -10466,7 +10466,7 @@ interface MediaStreamTrackEvent extends Event {
 }
 
 declare var MediaStreamTrackEvent: {
-    prototype: MediaStreamTrackEvent;
+    readonly prototype: MediaStreamTrackEvent;
     new(type: string, eventInitDict: MediaStreamTrackEventInit): MediaStreamTrackEvent;
 };
 
@@ -10483,7 +10483,7 @@ interface MessageChannel {
 }
 
 declare var MessageChannel: {
-    prototype: MessageChannel;
+    readonly prototype: MessageChannel;
     new(): MessageChannel;
 };
 
@@ -10512,7 +10512,7 @@ interface MessageEvent<T = any> extends Event {
 }
 
 declare var MessageEvent: {
-    prototype: MessageEvent;
+    readonly prototype: MessageEvent;
     new<T>(type: string, eventInitDict?: MessageEventInit<T>): MessageEvent<T>;
 };
 
@@ -10547,7 +10547,7 @@ interface MessagePort extends EventTarget {
 }
 
 declare var MessagePort: {
-    prototype: MessagePort;
+    readonly prototype: MessagePort;
     new(): MessagePort;
 };
 
@@ -10572,7 +10572,7 @@ interface MimeType {
 }
 
 declare var MimeType: {
-    prototype: MimeType;
+    readonly prototype: MimeType;
     new(): MimeType;
 };
 
@@ -10585,7 +10585,7 @@ interface MimeTypeArray {
 }
 
 declare var MimeTypeArray: {
-    prototype: MimeTypeArray;
+    readonly prototype: MimeTypeArray;
     new(): MimeTypeArray;
 };
 
@@ -10615,7 +10615,7 @@ interface MouseEvent extends UIEvent {
 }
 
 declare var MouseEvent: {
-    prototype: MouseEvent;
+    readonly prototype: MouseEvent;
     new(type: string, eventInitDict?: MouseEventInit): MouseEvent;
 };
 
@@ -10634,7 +10634,7 @@ interface MutationEvent extends Event {
 }
 
 declare var MutationEvent: {
-    prototype: MutationEvent;
+    readonly prototype: MutationEvent;
     new(): MutationEvent;
     readonly ADDITION: number;
     readonly MODIFICATION: number;
@@ -10660,7 +10660,7 @@ interface MutationObserver {
 }
 
 declare var MutationObserver: {
-    prototype: MutationObserver;
+    readonly prototype: MutationObserver;
     new(callback: MutationCallback): MutationObserver;
 };
 
@@ -10705,7 +10705,7 @@ interface MutationRecord {
 }
 
 declare var MutationRecord: {
-    prototype: MutationRecord;
+    readonly prototype: MutationRecord;
     new(): MutationRecord;
 };
 
@@ -10723,7 +10723,7 @@ interface NamedNodeMap {
 }
 
 declare var NamedNodeMap: {
-    prototype: NamedNodeMap;
+    readonly prototype: NamedNodeMap;
     new(): NamedNodeMap;
 };
 
@@ -10735,7 +10735,7 @@ interface NavigationPreloadManager {
 }
 
 declare var NavigationPreloadManager: {
-    prototype: NavigationPreloadManager;
+    readonly prototype: NavigationPreloadManager;
     new(): NavigationPreloadManager;
 };
 
@@ -10765,7 +10765,7 @@ interface Navigator extends MSFileSaver, MSNavigatorDoNotTrack, NavigatorAutomat
 }
 
 declare var Navigator: {
-    prototype: Navigator;
+    readonly prototype: Navigator;
     new(): Navigator;
 };
 
@@ -10971,7 +10971,7 @@ interface Node extends EventTarget {
 }
 
 declare var Node: {
-    prototype: Node;
+    readonly prototype: Node;
     new(): Node;
     readonly ATTRIBUTE_NODE: number;
     /**
@@ -11069,7 +11069,7 @@ interface NodeIterator {
 }
 
 declare var NodeIterator: {
-    prototype: NodeIterator;
+    readonly prototype: NodeIterator;
     new(): NodeIterator;
 };
 
@@ -11093,7 +11093,7 @@ interface NodeList {
 }
 
 declare var NodeList: {
-    prototype: NodeList;
+    readonly prototype: NodeList;
     new(): NodeList;
 };
 
@@ -11162,7 +11162,7 @@ interface Notification extends EventTarget {
 }
 
 declare var Notification: {
-    prototype: Notification;
+    readonly prototype: Notification;
     new(title: string, options?: NotificationOptions): Notification;
     readonly maxActions: number;
     readonly permission: NotificationPermission;
@@ -11209,7 +11209,7 @@ interface OfflineAudioCompletionEvent extends Event {
 }
 
 declare var OfflineAudioCompletionEvent: {
-    prototype: OfflineAudioCompletionEvent;
+    readonly prototype: OfflineAudioCompletionEvent;
     new(type: string, eventInitDict: OfflineAudioCompletionEventInit): OfflineAudioCompletionEvent;
 };
 
@@ -11231,7 +11231,7 @@ interface OfflineAudioContext extends BaseAudioContext {
 }
 
 declare var OfflineAudioContext: {
-    prototype: OfflineAudioContext;
+    readonly prototype: OfflineAudioContext;
     new(contextOptions: OfflineAudioContextOptions): OfflineAudioContext;
     new(numberOfChannels: number, length: number, sampleRate: number): OfflineAudioContext;
 };
@@ -11274,7 +11274,7 @@ interface OffscreenCanvas extends EventTarget {
 }
 
 declare var OffscreenCanvas: {
-    prototype: OffscreenCanvas;
+    readonly prototype: OffscreenCanvas;
     new(width: number, height: number): OffscreenCanvas;
 };
 
@@ -11284,7 +11284,7 @@ interface OffscreenCanvasRenderingContext2D extends CanvasCompositing, CanvasDra
 }
 
 declare var OffscreenCanvasRenderingContext2D: {
-    prototype: OffscreenCanvasRenderingContext2D;
+    readonly prototype: OffscreenCanvasRenderingContext2D;
     new(): OffscreenCanvasRenderingContext2D;
 };
 
@@ -11301,7 +11301,7 @@ interface OscillatorNode extends AudioScheduledSourceNode {
 }
 
 declare var OscillatorNode: {
-    prototype: OscillatorNode;
+    readonly prototype: OscillatorNode;
     new(context: BaseAudioContext, options?: OscillatorOptions): OscillatorNode;
 };
 
@@ -11310,7 +11310,7 @@ interface OverconstrainedError extends Error {
 }
 
 declare var OverconstrainedError: {
-    prototype: OverconstrainedError;
+    readonly prototype: OverconstrainedError;
     new(): OverconstrainedError;
 };
 
@@ -11324,7 +11324,7 @@ interface OverflowEvent extends UIEvent {
 }
 
 declare var OverflowEvent: {
-    prototype: OverflowEvent;
+    readonly prototype: OverflowEvent;
     new(): OverflowEvent;
     readonly BOTH: number;
     readonly HORIZONTAL: number;
@@ -11350,7 +11350,7 @@ interface PageTransitionEvent extends Event {
 }
 
 declare var PageTransitionEvent: {
-    prototype: PageTransitionEvent;
+    readonly prototype: PageTransitionEvent;
     new(type: string, eventInitDict?: PageTransitionEventInit): PageTransitionEvent;
 };
 
@@ -11377,7 +11377,7 @@ interface PannerNode extends AudioNode {
 }
 
 declare var PannerNode: {
-    prototype: PannerNode;
+    readonly prototype: PannerNode;
     new(context: BaseAudioContext, options?: PannerOptions): PannerNode;
 };
 
@@ -11430,7 +11430,7 @@ interface Path2D extends CanvasPath {
 }
 
 declare var Path2D: {
-    prototype: Path2D;
+    readonly prototype: Path2D;
     new(path?: Path2D | string): Path2D;
 };
 
@@ -11451,7 +11451,7 @@ interface PaymentAddress {
 }
 
 declare var PaymentAddress: {
-    prototype: PaymentAddress;
+    readonly prototype: PaymentAddress;
     new(): PaymentAddress;
 };
 
@@ -11478,7 +11478,7 @@ interface PaymentRequest extends EventTarget {
 }
 
 declare var PaymentRequest: {
-    prototype: PaymentRequest;
+    readonly prototype: PaymentRequest;
     new(methodData: PaymentMethodData[], details: PaymentDetailsInit, options?: PaymentOptions): PaymentRequest;
 };
 
@@ -11488,7 +11488,7 @@ interface PaymentRequestUpdateEvent extends Event {
 }
 
 declare var PaymentRequestUpdateEvent: {
-    prototype: PaymentRequestUpdateEvent;
+    readonly prototype: PaymentRequestUpdateEvent;
     new(type: string, eventInitDict?: PaymentRequestUpdateEventInit): PaymentRequestUpdateEvent;
 };
 
@@ -11507,7 +11507,7 @@ interface PaymentResponse {
 }
 
 declare var PaymentResponse: {
-    prototype: PaymentResponse;
+    readonly prototype: PaymentResponse;
     new(): PaymentResponse;
 };
 
@@ -11536,7 +11536,7 @@ interface PerfWidgetExternal {
 }
 
 declare var PerfWidgetExternal: {
-    prototype: PerfWidgetExternal;
+    readonly prototype: PerfWidgetExternal;
     new(): PerfWidgetExternal;
 };
 
@@ -11570,7 +11570,7 @@ interface Performance extends EventTarget {
 }
 
 declare var Performance: {
-    prototype: Performance;
+    readonly prototype: Performance;
     new(): Performance;
 };
 
@@ -11584,7 +11584,7 @@ interface PerformanceEntry {
 }
 
 declare var PerformanceEntry: {
-    prototype: PerformanceEntry;
+    readonly prototype: PerformanceEntry;
     new(): PerformanceEntry;
 };
 
@@ -11593,7 +11593,7 @@ interface PerformanceMark extends PerformanceEntry {
 }
 
 declare var PerformanceMark: {
-    prototype: PerformanceMark;
+    readonly prototype: PerformanceMark;
     new(): PerformanceMark;
 };
 
@@ -11602,7 +11602,7 @@ interface PerformanceMeasure extends PerformanceEntry {
 }
 
 declare var PerformanceMeasure: {
-    prototype: PerformanceMeasure;
+    readonly prototype: PerformanceMeasure;
     new(): PerformanceMeasure;
 };
 
@@ -11620,7 +11620,7 @@ interface PerformanceNavigation {
 }
 
 declare var PerformanceNavigation: {
-    prototype: PerformanceNavigation;
+    readonly prototype: PerformanceNavigation;
     new(): PerformanceNavigation;
     readonly TYPE_BACK_FORWARD: number;
     readonly TYPE_NAVIGATE: number;
@@ -11644,7 +11644,7 @@ interface PerformanceNavigationTiming extends PerformanceResourceTiming {
 }
 
 declare var PerformanceNavigationTiming: {
-    prototype: PerformanceNavigationTiming;
+    readonly prototype: PerformanceNavigationTiming;
     new(): PerformanceNavigationTiming;
 };
 
@@ -11655,7 +11655,7 @@ interface PerformanceObserver {
 }
 
 declare var PerformanceObserver: {
-    prototype: PerformanceObserver;
+    readonly prototype: PerformanceObserver;
     new(callback: PerformanceObserverCallback): PerformanceObserver;
     readonly supportedEntryTypes: ReadonlyArray<string>;
 };
@@ -11667,7 +11667,7 @@ interface PerformanceObserverEntryList {
 }
 
 declare var PerformanceObserverEntryList: {
-    prototype: PerformanceObserverEntryList;
+    readonly prototype: PerformanceObserverEntryList;
     new(): PerformanceObserverEntryList;
 };
 
@@ -11694,7 +11694,7 @@ interface PerformanceResourceTiming extends PerformanceEntry {
 }
 
 declare var PerformanceResourceTiming: {
-    prototype: PerformanceResourceTiming;
+    readonly prototype: PerformanceResourceTiming;
     new(): PerformanceResourceTiming;
 };
 
@@ -11727,7 +11727,7 @@ interface PerformanceTiming {
 }
 
 declare var PerformanceTiming: {
-    prototype: PerformanceTiming;
+    readonly prototype: PerformanceTiming;
     new(): PerformanceTiming;
 };
 
@@ -11736,7 +11736,7 @@ interface PeriodicWave {
 }
 
 declare var PeriodicWave: {
-    prototype: PeriodicWave;
+    readonly prototype: PeriodicWave;
     new(context: BaseAudioContext, options?: PeriodicWaveOptions): PeriodicWave;
 };
 
@@ -11746,7 +11746,7 @@ interface PermissionRequest extends DeferredPermissionRequest {
 }
 
 declare var PermissionRequest: {
-    prototype: PermissionRequest;
+    readonly prototype: PermissionRequest;
     new(): PermissionRequest;
 };
 
@@ -11755,7 +11755,7 @@ interface PermissionRequestedEvent extends Event {
 }
 
 declare var PermissionRequestedEvent: {
-    prototype: PermissionRequestedEvent;
+    readonly prototype: PermissionRequestedEvent;
     new(): PermissionRequestedEvent;
 };
 
@@ -11773,7 +11773,7 @@ interface PermissionStatus extends EventTarget {
 }
 
 declare var PermissionStatus: {
-    prototype: PermissionStatus;
+    readonly prototype: PermissionStatus;
     new(): PermissionStatus;
 };
 
@@ -11782,7 +11782,7 @@ interface Permissions {
 }
 
 declare var Permissions: {
-    prototype: Permissions;
+    readonly prototype: Permissions;
     new(): Permissions;
 };
 
@@ -11813,7 +11813,7 @@ interface Plugin {
 }
 
 declare var Plugin: {
-    prototype: Plugin;
+    readonly prototype: Plugin;
     new(): Plugin;
 };
 
@@ -11827,7 +11827,7 @@ interface PluginArray {
 }
 
 declare var PluginArray: {
-    prototype: PluginArray;
+    readonly prototype: PluginArray;
     new(): PluginArray;
 };
 
@@ -11848,7 +11848,7 @@ interface PointerEvent extends MouseEvent {
 }
 
 declare var PointerEvent: {
-    prototype: PointerEvent;
+    readonly prototype: PointerEvent;
     new(type: string, eventInitDict?: PointerEventInit): PointerEvent;
 };
 
@@ -11861,7 +11861,7 @@ interface PopStateEvent extends Event {
 }
 
 declare var PopStateEvent: {
-    prototype: PopStateEvent;
+    readonly prototype: PopStateEvent;
     new(type: string, eventInitDict?: PopStateEventInit): PopStateEvent;
 };
 
@@ -11872,7 +11872,7 @@ interface ProcessingInstruction extends CharacterData, LinkStyle {
 }
 
 declare var ProcessingInstruction: {
-    prototype: ProcessingInstruction;
+    readonly prototype: ProcessingInstruction;
     new(): ProcessingInstruction;
 };
 
@@ -11885,7 +11885,7 @@ interface ProgressEvent<T extends EventTarget = EventTarget> extends Event {
 }
 
 declare var ProgressEvent: {
-    prototype: ProgressEvent;
+    readonly prototype: ProgressEvent;
     new(type: string, eventInitDict?: ProgressEventInit): ProgressEvent;
 };
 
@@ -11895,7 +11895,7 @@ interface PromiseRejectionEvent extends Event {
 }
 
 declare var PromiseRejectionEvent: {
-    prototype: PromiseRejectionEvent;
+    readonly prototype: PromiseRejectionEvent;
     new(type: string, eventInitDict: PromiseRejectionEventInit): PromiseRejectionEvent;
 };
 
@@ -11906,7 +11906,7 @@ interface PublicKeyCredential extends Credential {
 }
 
 declare var PublicKeyCredential: {
-    prototype: PublicKeyCredential;
+    readonly prototype: PublicKeyCredential;
     new(): PublicKeyCredential;
     isUserVerifyingPlatformAuthenticatorAvailable(): Promise<boolean>;
 };
@@ -11919,7 +11919,7 @@ interface PushManager {
 }
 
 declare var PushManager: {
-    prototype: PushManager;
+    readonly prototype: PushManager;
     new(): PushManager;
     readonly supportedContentEncodings: ReadonlyArray<string>;
 };
@@ -11935,7 +11935,7 @@ interface PushSubscription {
 }
 
 declare var PushSubscription: {
-    prototype: PushSubscription;
+    readonly prototype: PushSubscription;
     new(): PushSubscription;
 };
 
@@ -11945,7 +11945,7 @@ interface PushSubscriptionOptions {
 }
 
 declare var PushSubscriptionOptions: {
-    prototype: PushSubscriptionOptions;
+    readonly prototype: PushSubscriptionOptions;
     new(): PushSubscriptionOptions;
 };
 
@@ -11955,7 +11955,7 @@ interface RTCCertificate {
 }
 
 declare var RTCCertificate: {
-    prototype: RTCCertificate;
+    readonly prototype: RTCCertificate;
     new(): RTCCertificate;
     getSupportedAlgorithms(): AlgorithmIdentifier[];
 };
@@ -11976,7 +11976,7 @@ interface RTCDTMFSender extends EventTarget {
 }
 
 declare var RTCDTMFSender: {
-    prototype: RTCDTMFSender;
+    readonly prototype: RTCDTMFSender;
     new(): RTCDTMFSender;
 };
 
@@ -11986,7 +11986,7 @@ interface RTCDTMFToneChangeEvent extends Event {
 }
 
 declare var RTCDTMFToneChangeEvent: {
-    prototype: RTCDTMFToneChangeEvent;
+    readonly prototype: RTCDTMFToneChangeEvent;
     new(type: string, eventInitDict: RTCDTMFToneChangeEventInit): RTCDTMFToneChangeEvent;
 };
 
@@ -12028,7 +12028,7 @@ interface RTCDataChannel extends EventTarget {
 }
 
 declare var RTCDataChannel: {
-    prototype: RTCDataChannel;
+    readonly prototype: RTCDataChannel;
     new(): RTCDataChannel;
 };
 
@@ -12037,7 +12037,7 @@ interface RTCDataChannelEvent extends Event {
 }
 
 declare var RTCDataChannelEvent: {
-    prototype: RTCDataChannelEvent;
+    readonly prototype: RTCDataChannelEvent;
     new(type: string, eventInitDict: RTCDataChannelEventInit): RTCDataChannelEvent;
 };
 
@@ -12059,7 +12059,7 @@ interface RTCDtlsTransport extends EventTarget {
 }
 
 declare var RTCDtlsTransport: {
-    prototype: RTCDtlsTransport;
+    readonly prototype: RTCDtlsTransport;
     new(): RTCDtlsTransport;
 };
 
@@ -12068,7 +12068,7 @@ interface RTCDtlsTransportStateChangedEvent extends Event {
 }
 
 declare var RTCDtlsTransportStateChangedEvent: {
-    prototype: RTCDtlsTransportStateChangedEvent;
+    readonly prototype: RTCDtlsTransportStateChangedEvent;
     new(): RTCDtlsTransportStateChangedEvent;
 };
 
@@ -12091,7 +12091,7 @@ interface RTCDtmfSender extends EventTarget {
 }
 
 declare var RTCDtmfSender: {
-    prototype: RTCDtmfSender;
+    readonly prototype: RTCDtmfSender;
     new(sender: RTCRtpSender): RTCDtmfSender;
 };
 
@@ -12105,7 +12105,7 @@ interface RTCError extends DOMException {
 }
 
 declare var RTCError: {
-    prototype: RTCError;
+    readonly prototype: RTCError;
     new(init: RTCErrorInit, message?: string): RTCError;
 };
 
@@ -12114,7 +12114,7 @@ interface RTCErrorEvent extends Event {
 }
 
 declare var RTCErrorEvent: {
-    prototype: RTCErrorEvent;
+    readonly prototype: RTCErrorEvent;
     new(type: string, eventInitDict: RTCErrorEventInit): RTCErrorEvent;
 };
 
@@ -12137,7 +12137,7 @@ interface RTCIceCandidate {
 }
 
 declare var RTCIceCandidate: {
-    prototype: RTCIceCandidate;
+    readonly prototype: RTCIceCandidate;
     new(candidateInitDict?: RTCIceCandidateInit): RTCIceCandidate;
 };
 
@@ -12146,7 +12146,7 @@ interface RTCIceCandidatePairChangedEvent extends Event {
 }
 
 declare var RTCIceCandidatePairChangedEvent: {
-    prototype: RTCIceCandidatePairChangedEvent;
+    readonly prototype: RTCIceCandidatePairChangedEvent;
     new(): RTCIceCandidatePairChangedEvent;
 };
 
@@ -12169,7 +12169,7 @@ interface RTCIceGatherer extends RTCStatsProvider {
 }
 
 declare var RTCIceGatherer: {
-    prototype: RTCIceGatherer;
+    readonly prototype: RTCIceGatherer;
     new(options: RTCIceGatherOptions): RTCIceGatherer;
 };
 
@@ -12178,7 +12178,7 @@ interface RTCIceGathererEvent extends Event {
 }
 
 declare var RTCIceGathererEvent: {
-    prototype: RTCIceGathererEvent;
+    readonly prototype: RTCIceGathererEvent;
     new(): RTCIceGathererEvent;
 };
 
@@ -12209,7 +12209,7 @@ interface RTCIceTransport extends EventTarget {
 }
 
 declare var RTCIceTransport: {
-    prototype: RTCIceTransport;
+    readonly prototype: RTCIceTransport;
     new(): RTCIceTransport;
 };
 
@@ -12218,7 +12218,7 @@ interface RTCIceTransportStateChangedEvent extends Event {
 }
 
 declare var RTCIceTransportStateChangedEvent: {
-    prototype: RTCIceTransportStateChangedEvent;
+    readonly prototype: RTCIceTransportStateChangedEvent;
     new(): RTCIceTransportStateChangedEvent;
 };
 
@@ -12228,7 +12228,7 @@ interface RTCIdentityAssertion {
 }
 
 declare var RTCIdentityAssertion: {
-    prototype: RTCIdentityAssertion;
+    readonly prototype: RTCIdentityAssertion;
     new(idp: string, name: string): RTCIdentityAssertion;
 };
 
@@ -12297,7 +12297,7 @@ interface RTCPeerConnection extends EventTarget {
 }
 
 declare var RTCPeerConnection: {
-    prototype: RTCPeerConnection;
+    readonly prototype: RTCPeerConnection;
     new(configuration?: RTCConfiguration): RTCPeerConnection;
     generateCertificate(keygenAlgorithm: AlgorithmIdentifier): Promise<RTCCertificate>;
     getDefaultIceServers(): RTCIceServer[];
@@ -12311,7 +12311,7 @@ interface RTCPeerConnectionIceErrorEvent extends Event {
 }
 
 declare var RTCPeerConnectionIceErrorEvent: {
-    prototype: RTCPeerConnectionIceErrorEvent;
+    readonly prototype: RTCPeerConnectionIceErrorEvent;
     new(type: string, eventInitDict: RTCPeerConnectionIceErrorEventInit): RTCPeerConnectionIceErrorEvent;
 };
 
@@ -12322,7 +12322,7 @@ interface RTCPeerConnectionIceEvent extends Event {
 }
 
 declare var RTCPeerConnectionIceEvent: {
-    prototype: RTCPeerConnectionIceEvent;
+    readonly prototype: RTCPeerConnectionIceEvent;
     new(type: string, eventInitDict?: RTCPeerConnectionIceEventInit): RTCPeerConnectionIceEvent;
 };
 
@@ -12338,7 +12338,7 @@ interface RTCRtpReceiver {
 }
 
 declare var RTCRtpReceiver: {
-    prototype: RTCRtpReceiver;
+    readonly prototype: RTCRtpReceiver;
     new(): RTCRtpReceiver;
     getCapabilities(kind: string): RTCRtpCapabilities | null;
 };
@@ -12357,7 +12357,7 @@ interface RTCRtpSender {
 }
 
 declare var RTCRtpSender: {
-    prototype: RTCRtpSender;
+    readonly prototype: RTCRtpSender;
     new(): RTCRtpSender;
     getCapabilities(kind: string): RTCRtpCapabilities | null;
 };
@@ -12373,7 +12373,7 @@ interface RTCRtpTransceiver {
 }
 
 declare var RTCRtpTransceiver: {
-    prototype: RTCRtpTransceiver;
+    readonly prototype: RTCRtpTransceiver;
     new(): RTCRtpTransceiver;
 };
 
@@ -12394,7 +12394,7 @@ interface RTCSctpTransport extends EventTarget {
 }
 
 declare var RTCSctpTransport: {
-    prototype: RTCSctpTransport;
+    readonly prototype: RTCSctpTransport;
     new(): RTCSctpTransport;
 };
 
@@ -12406,7 +12406,7 @@ interface RTCSessionDescription {
 }
 
 declare var RTCSessionDescription: {
-    prototype: RTCSessionDescription;
+    readonly prototype: RTCSessionDescription;
     new(descriptionInitDict?: RTCSessionDescriptionInit): RTCSessionDescription;
 };
 
@@ -12424,7 +12424,7 @@ interface RTCSrtpSdesTransport extends EventTarget {
 }
 
 declare var RTCSrtpSdesTransport: {
-    prototype: RTCSrtpSdesTransport;
+    readonly prototype: RTCSrtpSdesTransport;
     new(transport: RTCIceTransport, encryptParameters: RTCSrtpSdesParameters, decryptParameters: RTCSrtpSdesParameters): RTCSrtpSdesTransport;
     getLocalParameters(): RTCSrtpSdesParameters[];
 };
@@ -12434,7 +12434,7 @@ interface RTCSsrcConflictEvent extends Event {
 }
 
 declare var RTCSsrcConflictEvent: {
-    prototype: RTCSsrcConflictEvent;
+    readonly prototype: RTCSsrcConflictEvent;
     new(): RTCSsrcConflictEvent;
 };
 
@@ -12443,7 +12443,7 @@ interface RTCStatsEvent extends Event {
 }
 
 declare var RTCStatsEvent: {
-    prototype: RTCStatsEvent;
+    readonly prototype: RTCStatsEvent;
     new(type: string, eventInitDict: RTCStatsEventInit): RTCStatsEvent;
 };
 
@@ -12453,7 +12453,7 @@ interface RTCStatsProvider extends EventTarget {
 }
 
 declare var RTCStatsProvider: {
-    prototype: RTCStatsProvider;
+    readonly prototype: RTCStatsProvider;
     new(): RTCStatsProvider;
 };
 
@@ -12462,7 +12462,7 @@ interface RTCStatsReport {
 }
 
 declare var RTCStatsReport: {
-    prototype: RTCStatsReport;
+    readonly prototype: RTCStatsReport;
     new(): RTCStatsReport;
 };
 
@@ -12474,7 +12474,7 @@ interface RTCTrackEvent extends Event {
 }
 
 declare var RTCTrackEvent: {
-    prototype: RTCTrackEvent;
+    readonly prototype: RTCTrackEvent;
     new(type: string, eventInitDict: RTCTrackEventInit): RTCTrackEvent;
 };
 
@@ -12483,7 +12483,7 @@ interface RadioNodeList extends NodeList {
 }
 
 declare var RadioNodeList: {
-    prototype: RadioNodeList;
+    readonly prototype: RadioNodeList;
     new(): RadioNodeList;
 };
 
@@ -12492,7 +12492,7 @@ interface RandomSource {
 }
 
 declare var RandomSource: {
-    prototype: RandomSource;
+    readonly prototype: RandomSource;
     new(): RandomSource;
 };
 
@@ -12539,7 +12539,7 @@ interface Range extends AbstractRange {
 }
 
 declare var Range: {
-    prototype: Range;
+    readonly prototype: Range;
     new(): Range;
     readonly END_TO_END: number;
     readonly END_TO_START: number;
@@ -12559,7 +12559,7 @@ interface ReadableStream<R = any> {
 }
 
 declare var ReadableStream: {
-    prototype: ReadableStream;
+    readonly prototype: ReadableStream;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
 };
 
@@ -12571,7 +12571,7 @@ interface ReadableStreamDefaultController<R = any> {
 }
 
 declare var ReadableStreamDefaultController: {
-    prototype: ReadableStreamDefaultController;
+    readonly prototype: ReadableStreamDefaultController;
     new(): ReadableStreamDefaultController;
 };
 
@@ -12581,7 +12581,7 @@ interface ReadableStreamDefaultReader<R = any> extends ReadableStreamGenericRead
 }
 
 declare var ReadableStreamDefaultReader: {
-    prototype: ReadableStreamDefaultReader;
+    readonly prototype: ReadableStreamDefaultReader;
     new<R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>;
 };
 
@@ -12656,7 +12656,7 @@ interface Request extends Body {
 }
 
 declare var Request: {
-    prototype: Request;
+    readonly prototype: Request;
     new(input: RequestInfo, init?: RequestInit): Request;
 };
 
@@ -12667,7 +12667,7 @@ interface ResizeObserver {
 }
 
 declare var ResizeObserver: {
-    prototype: ResizeObserver;
+    readonly prototype: ResizeObserver;
     new(callback: ResizeObserverCallback): ResizeObserver;
 };
 
@@ -12679,7 +12679,7 @@ interface ResizeObserverEntry {
 }
 
 declare var ResizeObserverEntry: {
-    prototype: ResizeObserverEntry;
+    readonly prototype: ResizeObserverEntry;
     new(): ResizeObserverEntry;
 };
 
@@ -12689,7 +12689,7 @@ interface ResizeObserverSize {
 }
 
 declare var ResizeObserverSize: {
-    prototype: ResizeObserverSize;
+    readonly prototype: ResizeObserverSize;
     new(): ResizeObserverSize;
 };
 
@@ -12707,7 +12707,7 @@ interface Response extends Body {
 }
 
 declare var Response: {
-    prototype: Response;
+    readonly prototype: Response;
     new(body?: BodyInit | null, init?: ResponseInit): Response;
     error(): Response;
     redirect(url: string, status?: number): Response;
@@ -12723,7 +12723,7 @@ interface SVGAElement extends SVGGraphicsElement, SVGURIReference {
 }
 
 declare var SVGAElement: {
-    prototype: SVGAElement;
+    readonly prototype: SVGAElement;
     new(): SVGAElement;
 };
 
@@ -12743,7 +12743,7 @@ interface SVGAngle {
 }
 
 declare var SVGAngle: {
-    prototype: SVGAngle;
+    readonly prototype: SVGAngle;
     new(): SVGAngle;
     readonly SVG_ANGLETYPE_DEG: number;
     readonly SVG_ANGLETYPE_GRAD: number;
@@ -12760,7 +12760,7 @@ interface SVGAnimateElement extends SVGAnimationElement {
 }
 
 declare var SVGAnimateElement: {
-    prototype: SVGAnimateElement;
+    readonly prototype: SVGAnimateElement;
     new(): SVGAnimateElement;
 };
 
@@ -12772,7 +12772,7 @@ interface SVGAnimateMotionElement extends SVGAnimationElement {
 }
 
 declare var SVGAnimateMotionElement: {
-    prototype: SVGAnimateMotionElement;
+    readonly prototype: SVGAnimateMotionElement;
     new(): SVGAnimateMotionElement;
 };
 
@@ -12784,7 +12784,7 @@ interface SVGAnimateTransformElement extends SVGAnimationElement {
 }
 
 declare var SVGAnimateTransformElement: {
-    prototype: SVGAnimateTransformElement;
+    readonly prototype: SVGAnimateTransformElement;
     new(): SVGAnimateTransformElement;
 };
 
@@ -12795,7 +12795,7 @@ interface SVGAnimatedAngle {
 }
 
 declare var SVGAnimatedAngle: {
-    prototype: SVGAnimatedAngle;
+    readonly prototype: SVGAnimatedAngle;
     new(): SVGAnimatedAngle;
 };
 
@@ -12806,7 +12806,7 @@ interface SVGAnimatedBoolean {
 }
 
 declare var SVGAnimatedBoolean: {
-    prototype: SVGAnimatedBoolean;
+    readonly prototype: SVGAnimatedBoolean;
     new(): SVGAnimatedBoolean;
 };
 
@@ -12817,7 +12817,7 @@ interface SVGAnimatedEnumeration {
 }
 
 declare var SVGAnimatedEnumeration: {
-    prototype: SVGAnimatedEnumeration;
+    readonly prototype: SVGAnimatedEnumeration;
     new(): SVGAnimatedEnumeration;
 };
 
@@ -12828,7 +12828,7 @@ interface SVGAnimatedInteger {
 }
 
 declare var SVGAnimatedInteger: {
-    prototype: SVGAnimatedInteger;
+    readonly prototype: SVGAnimatedInteger;
     new(): SVGAnimatedInteger;
 };
 
@@ -12839,7 +12839,7 @@ interface SVGAnimatedLength {
 }
 
 declare var SVGAnimatedLength: {
-    prototype: SVGAnimatedLength;
+    readonly prototype: SVGAnimatedLength;
     new(): SVGAnimatedLength;
 };
 
@@ -12850,7 +12850,7 @@ interface SVGAnimatedLengthList {
 }
 
 declare var SVGAnimatedLengthList: {
-    prototype: SVGAnimatedLengthList;
+    readonly prototype: SVGAnimatedLengthList;
     new(): SVGAnimatedLengthList;
 };
 
@@ -12861,7 +12861,7 @@ interface SVGAnimatedNumber {
 }
 
 declare var SVGAnimatedNumber: {
-    prototype: SVGAnimatedNumber;
+    readonly prototype: SVGAnimatedNumber;
     new(): SVGAnimatedNumber;
 };
 
@@ -12872,7 +12872,7 @@ interface SVGAnimatedNumberList {
 }
 
 declare var SVGAnimatedNumberList: {
-    prototype: SVGAnimatedNumberList;
+    readonly prototype: SVGAnimatedNumberList;
     new(): SVGAnimatedNumberList;
 };
 
@@ -12888,7 +12888,7 @@ interface SVGAnimatedPreserveAspectRatio {
 }
 
 declare var SVGAnimatedPreserveAspectRatio: {
-    prototype: SVGAnimatedPreserveAspectRatio;
+    readonly prototype: SVGAnimatedPreserveAspectRatio;
     new(): SVGAnimatedPreserveAspectRatio;
 };
 
@@ -12899,7 +12899,7 @@ interface SVGAnimatedRect {
 }
 
 declare var SVGAnimatedRect: {
-    prototype: SVGAnimatedRect;
+    readonly prototype: SVGAnimatedRect;
     new(): SVGAnimatedRect;
 };
 
@@ -12910,7 +12910,7 @@ interface SVGAnimatedString {
 }
 
 declare var SVGAnimatedString: {
-    prototype: SVGAnimatedString;
+    readonly prototype: SVGAnimatedString;
     new(): SVGAnimatedString;
 };
 
@@ -12921,7 +12921,7 @@ interface SVGAnimatedTransformList {
 }
 
 declare var SVGAnimatedTransformList: {
-    prototype: SVGAnimatedTransformList;
+    readonly prototype: SVGAnimatedTransformList;
     new(): SVGAnimatedTransformList;
 };
 
@@ -12937,7 +12937,7 @@ interface SVGAnimationElement extends SVGElement {
 }
 
 declare var SVGAnimationElement: {
-    prototype: SVGAnimationElement;
+    readonly prototype: SVGAnimationElement;
     new(): SVGAnimationElement;
 };
 
@@ -12953,7 +12953,7 @@ interface SVGCircleElement extends SVGGeometryElement {
 }
 
 declare var SVGCircleElement: {
-    prototype: SVGCircleElement;
+    readonly prototype: SVGCircleElement;
     new(): SVGCircleElement;
 };
 
@@ -12968,7 +12968,7 @@ interface SVGClipPathElement extends SVGElement {
 }
 
 declare var SVGClipPathElement: {
-    prototype: SVGClipPathElement;
+    readonly prototype: SVGClipPathElement;
     new(): SVGClipPathElement;
 };
 
@@ -12994,7 +12994,7 @@ interface SVGComponentTransferFunctionElement extends SVGElement {
 }
 
 declare var SVGComponentTransferFunctionElement: {
-    prototype: SVGComponentTransferFunctionElement;
+    readonly prototype: SVGComponentTransferFunctionElement;
     new(): SVGComponentTransferFunctionElement;
     readonly SVG_FECOMPONENTTRANSFER_TYPE_DISCRETE: number;
     readonly SVG_FECOMPONENTTRANSFER_TYPE_GAMMA: number;
@@ -13014,7 +13014,7 @@ interface SVGCursorElement extends SVGElement {
 }
 
 declare var SVGCursorElement: {
-    prototype: SVGCursorElement;
+    readonly prototype: SVGCursorElement;
     new(): SVGCursorElement;
 };
 
@@ -13027,7 +13027,7 @@ interface SVGDefsElement extends SVGGraphicsElement {
 }
 
 declare var SVGDefsElement: {
-    prototype: SVGDefsElement;
+    readonly prototype: SVGDefsElement;
     new(): SVGDefsElement;
 };
 
@@ -13040,7 +13040,7 @@ interface SVGDescElement extends SVGElement {
 }
 
 declare var SVGDescElement: {
-    prototype: SVGDescElement;
+    readonly prototype: SVGDescElement;
     new(): SVGDescElement;
 };
 
@@ -13062,7 +13062,7 @@ interface SVGElement extends Element, DocumentAndElementEventHandlers, DocumentA
 }
 
 declare var SVGElement: {
-    prototype: SVGElement;
+    readonly prototype: SVGElement;
     new(): SVGElement;
 };
 
@@ -13072,7 +13072,7 @@ interface SVGElementInstance extends EventTarget {
 }
 
 declare var SVGElementInstance: {
-    prototype: SVGElementInstance;
+    readonly prototype: SVGElementInstance;
     new(): SVGElementInstance;
 };
 
@@ -13084,7 +13084,7 @@ interface SVGElementInstanceList {
 }
 
 declare var SVGElementInstanceList: {
-    prototype: SVGElementInstanceList;
+    readonly prototype: SVGElementInstanceList;
     new(): SVGElementInstanceList;
 };
 
@@ -13101,7 +13101,7 @@ interface SVGEllipseElement extends SVGGeometryElement {
 }
 
 declare var SVGEllipseElement: {
-    prototype: SVGEllipseElement;
+    readonly prototype: SVGEllipseElement;
     new(): SVGEllipseElement;
 };
 
@@ -13134,7 +13134,7 @@ interface SVGFEBlendElement extends SVGElement, SVGFilterPrimitiveStandardAttrib
 }
 
 declare var SVGFEBlendElement: {
-    prototype: SVGFEBlendElement;
+    readonly prototype: SVGFEBlendElement;
     new(): SVGFEBlendElement;
     readonly SVG_FEBLEND_MODE_COLOR: number;
     readonly SVG_FEBLEND_MODE_COLOR_BURN: number;
@@ -13172,7 +13172,7 @@ interface SVGFEColorMatrixElement extends SVGElement, SVGFilterPrimitiveStandard
 }
 
 declare var SVGFEColorMatrixElement: {
-    prototype: SVGFEColorMatrixElement;
+    readonly prototype: SVGFEColorMatrixElement;
     new(): SVGFEColorMatrixElement;
     readonly SVG_FECOLORMATRIX_TYPE_HUEROTATE: number;
     readonly SVG_FECOLORMATRIX_TYPE_LUMINANCETOALPHA: number;
@@ -13191,7 +13191,7 @@ interface SVGFEComponentTransferElement extends SVGElement, SVGFilterPrimitiveSt
 }
 
 declare var SVGFEComponentTransferElement: {
-    prototype: SVGFEComponentTransferElement;
+    readonly prototype: SVGFEComponentTransferElement;
     new(): SVGFEComponentTransferElement;
 };
 
@@ -13218,7 +13218,7 @@ interface SVGFECompositeElement extends SVGElement, SVGFilterPrimitiveStandardAt
 }
 
 declare var SVGFECompositeElement: {
-    prototype: SVGFECompositeElement;
+    readonly prototype: SVGFECompositeElement;
     new(): SVGFECompositeElement;
     readonly SVG_FECOMPOSITE_OPERATOR_ARITHMETIC: number;
     readonly SVG_FECOMPOSITE_OPERATOR_ATOP: number;
@@ -13254,7 +13254,7 @@ interface SVGFEConvolveMatrixElement extends SVGElement, SVGFilterPrimitiveStand
 }
 
 declare var SVGFEConvolveMatrixElement: {
-    prototype: SVGFEConvolveMatrixElement;
+    readonly prototype: SVGFEConvolveMatrixElement;
     new(): SVGFEConvolveMatrixElement;
     readonly SVG_EDGEMODE_DUPLICATE: number;
     readonly SVG_EDGEMODE_NONE: number;
@@ -13276,7 +13276,7 @@ interface SVGFEDiffuseLightingElement extends SVGElement, SVGFilterPrimitiveStan
 }
 
 declare var SVGFEDiffuseLightingElement: {
-    prototype: SVGFEDiffuseLightingElement;
+    readonly prototype: SVGFEDiffuseLightingElement;
     new(): SVGFEDiffuseLightingElement;
 };
 
@@ -13299,7 +13299,7 @@ interface SVGFEDisplacementMapElement extends SVGElement, SVGFilterPrimitiveStan
 }
 
 declare var SVGFEDisplacementMapElement: {
-    prototype: SVGFEDisplacementMapElement;
+    readonly prototype: SVGFEDisplacementMapElement;
     new(): SVGFEDisplacementMapElement;
     readonly SVG_CHANNEL_A: number;
     readonly SVG_CHANNEL_B: number;
@@ -13319,7 +13319,7 @@ interface SVGFEDistantLightElement extends SVGElement {
 }
 
 declare var SVGFEDistantLightElement: {
-    prototype: SVGFEDistantLightElement;
+    readonly prototype: SVGFEDistantLightElement;
     new(): SVGFEDistantLightElement;
 };
 
@@ -13337,7 +13337,7 @@ interface SVGFEDropShadowElement extends SVGElement, SVGFilterPrimitiveStandardA
 }
 
 declare var SVGFEDropShadowElement: {
-    prototype: SVGFEDropShadowElement;
+    readonly prototype: SVGFEDropShadowElement;
     new(): SVGFEDropShadowElement;
 };
 
@@ -13350,7 +13350,7 @@ interface SVGFEFloodElement extends SVGElement, SVGFilterPrimitiveStandardAttrib
 }
 
 declare var SVGFEFloodElement: {
-    prototype: SVGFEFloodElement;
+    readonly prototype: SVGFEFloodElement;
     new(): SVGFEFloodElement;
 };
 
@@ -13363,7 +13363,7 @@ interface SVGFEFuncAElement extends SVGComponentTransferFunctionElement {
 }
 
 declare var SVGFEFuncAElement: {
-    prototype: SVGFEFuncAElement;
+    readonly prototype: SVGFEFuncAElement;
     new(): SVGFEFuncAElement;
 };
 
@@ -13376,7 +13376,7 @@ interface SVGFEFuncBElement extends SVGComponentTransferFunctionElement {
 }
 
 declare var SVGFEFuncBElement: {
-    prototype: SVGFEFuncBElement;
+    readonly prototype: SVGFEFuncBElement;
     new(): SVGFEFuncBElement;
 };
 
@@ -13389,7 +13389,7 @@ interface SVGFEFuncGElement extends SVGComponentTransferFunctionElement {
 }
 
 declare var SVGFEFuncGElement: {
-    prototype: SVGFEFuncGElement;
+    readonly prototype: SVGFEFuncGElement;
     new(): SVGFEFuncGElement;
 };
 
@@ -13402,7 +13402,7 @@ interface SVGFEFuncRElement extends SVGComponentTransferFunctionElement {
 }
 
 declare var SVGFEFuncRElement: {
-    prototype: SVGFEFuncRElement;
+    readonly prototype: SVGFEFuncRElement;
     new(): SVGFEFuncRElement;
 };
 
@@ -13419,7 +13419,7 @@ interface SVGFEGaussianBlurElement extends SVGElement, SVGFilterPrimitiveStandar
 }
 
 declare var SVGFEGaussianBlurElement: {
-    prototype: SVGFEGaussianBlurElement;
+    readonly prototype: SVGFEGaussianBlurElement;
     new(): SVGFEGaussianBlurElement;
 };
 
@@ -13433,7 +13433,7 @@ interface SVGFEImageElement extends SVGElement, SVGFilterPrimitiveStandardAttrib
 }
 
 declare var SVGFEImageElement: {
-    prototype: SVGFEImageElement;
+    readonly prototype: SVGFEImageElement;
     new(): SVGFEImageElement;
 };
 
@@ -13446,7 +13446,7 @@ interface SVGFEMergeElement extends SVGElement, SVGFilterPrimitiveStandardAttrib
 }
 
 declare var SVGFEMergeElement: {
-    prototype: SVGFEMergeElement;
+    readonly prototype: SVGFEMergeElement;
     new(): SVGFEMergeElement;
 };
 
@@ -13460,7 +13460,7 @@ interface SVGFEMergeNodeElement extends SVGElement {
 }
 
 declare var SVGFEMergeNodeElement: {
-    prototype: SVGFEMergeNodeElement;
+    readonly prototype: SVGFEMergeNodeElement;
     new(): SVGFEMergeNodeElement;
 };
 
@@ -13480,7 +13480,7 @@ interface SVGFEMorphologyElement extends SVGElement, SVGFilterPrimitiveStandardA
 }
 
 declare var SVGFEMorphologyElement: {
-    prototype: SVGFEMorphologyElement;
+    readonly prototype: SVGFEMorphologyElement;
     new(): SVGFEMorphologyElement;
     readonly SVG_MORPHOLOGY_OPERATOR_DILATE: number;
     readonly SVG_MORPHOLOGY_OPERATOR_ERODE: number;
@@ -13499,7 +13499,7 @@ interface SVGFEOffsetElement extends SVGElement, SVGFilterPrimitiveStandardAttri
 }
 
 declare var SVGFEOffsetElement: {
-    prototype: SVGFEOffsetElement;
+    readonly prototype: SVGFEOffsetElement;
     new(): SVGFEOffsetElement;
 };
 
@@ -13515,7 +13515,7 @@ interface SVGFEPointLightElement extends SVGElement {
 }
 
 declare var SVGFEPointLightElement: {
-    prototype: SVGFEPointLightElement;
+    readonly prototype: SVGFEPointLightElement;
     new(): SVGFEPointLightElement;
 };
 
@@ -13534,7 +13534,7 @@ interface SVGFESpecularLightingElement extends SVGElement, SVGFilterPrimitiveSta
 }
 
 declare var SVGFESpecularLightingElement: {
-    prototype: SVGFESpecularLightingElement;
+    readonly prototype: SVGFESpecularLightingElement;
     new(): SVGFESpecularLightingElement;
 };
 
@@ -13555,7 +13555,7 @@ interface SVGFESpotLightElement extends SVGElement {
 }
 
 declare var SVGFESpotLightElement: {
-    prototype: SVGFESpotLightElement;
+    readonly prototype: SVGFESpotLightElement;
     new(): SVGFESpotLightElement;
 };
 
@@ -13569,7 +13569,7 @@ interface SVGFETileElement extends SVGElement, SVGFilterPrimitiveStandardAttribu
 }
 
 declare var SVGFETileElement: {
-    prototype: SVGFETileElement;
+    readonly prototype: SVGFETileElement;
     new(): SVGFETileElement;
 };
 
@@ -13594,7 +13594,7 @@ interface SVGFETurbulenceElement extends SVGElement, SVGFilterPrimitiveStandardA
 }
 
 declare var SVGFETurbulenceElement: {
-    prototype: SVGFETurbulenceElement;
+    readonly prototype: SVGFETurbulenceElement;
     new(): SVGFETurbulenceElement;
     readonly SVG_STITCHTYPE_NOSTITCH: number;
     readonly SVG_STITCHTYPE_STITCH: number;
@@ -13619,7 +13619,7 @@ interface SVGFilterElement extends SVGElement, SVGURIReference {
 }
 
 declare var SVGFilterElement: {
-    prototype: SVGFilterElement;
+    readonly prototype: SVGFilterElement;
     new(): SVGFilterElement;
 };
 
@@ -13650,7 +13650,7 @@ interface SVGForeignObjectElement extends SVGGraphicsElement {
 }
 
 declare var SVGForeignObjectElement: {
-    prototype: SVGForeignObjectElement;
+    readonly prototype: SVGForeignObjectElement;
     new(): SVGForeignObjectElement;
 };
 
@@ -13663,7 +13663,7 @@ interface SVGGElement extends SVGGraphicsElement {
 }
 
 declare var SVGGElement: {
-    prototype: SVGGElement;
+    readonly prototype: SVGGElement;
     new(): SVGGElement;
 };
 
@@ -13680,7 +13680,7 @@ interface SVGGeometryElement extends SVGGraphicsElement {
 }
 
 declare var SVGGeometryElement: {
-    prototype: SVGGeometryElement;
+    readonly prototype: SVGGeometryElement;
     new(): SVGGeometryElement;
 };
 
@@ -13700,7 +13700,7 @@ interface SVGGradientElement extends SVGElement, SVGURIReference {
 }
 
 declare var SVGGradientElement: {
-    prototype: SVGGradientElement;
+    readonly prototype: SVGGradientElement;
     new(): SVGGradientElement;
     readonly SVG_SPREADMETHOD_PAD: number;
     readonly SVG_SPREADMETHOD_REFLECT: number;
@@ -13721,7 +13721,7 @@ interface SVGGraphicsElement extends SVGElement, SVGTests {
 }
 
 declare var SVGGraphicsElement: {
-    prototype: SVGGraphicsElement;
+    readonly prototype: SVGGraphicsElement;
     new(): SVGGraphicsElement;
 };
 
@@ -13739,7 +13739,7 @@ interface SVGImageElement extends SVGGraphicsElement, SVGURIReference {
 }
 
 declare var SVGImageElement: {
-    prototype: SVGImageElement;
+    readonly prototype: SVGImageElement;
     new(): SVGImageElement;
 };
 
@@ -13765,7 +13765,7 @@ interface SVGLength {
 }
 
 declare var SVGLength: {
-    prototype: SVGLength;
+    readonly prototype: SVGLength;
     new(): SVGLength;
     readonly SVG_LENGTHTYPE_CM: number;
     readonly SVG_LENGTHTYPE_EMS: number;
@@ -13795,7 +13795,7 @@ interface SVGLengthList {
 }
 
 declare var SVGLengthList: {
-    prototype: SVGLengthList;
+    readonly prototype: SVGLengthList;
     new(): SVGLengthList;
 };
 
@@ -13812,7 +13812,7 @@ interface SVGLineElement extends SVGGeometryElement {
 }
 
 declare var SVGLineElement: {
-    prototype: SVGLineElement;
+    readonly prototype: SVGLineElement;
     new(): SVGLineElement;
 };
 
@@ -13829,7 +13829,7 @@ interface SVGLinearGradientElement extends SVGGradientElement {
 }
 
 declare var SVGLinearGradientElement: {
-    prototype: SVGLinearGradientElement;
+    readonly prototype: SVGLinearGradientElement;
     new(): SVGLinearGradientElement;
 };
 
@@ -13856,7 +13856,7 @@ interface SVGMarkerElement extends SVGElement, SVGFitToViewBox {
 }
 
 declare var SVGMarkerElement: {
-    prototype: SVGMarkerElement;
+    readonly prototype: SVGMarkerElement;
     new(): SVGMarkerElement;
     readonly SVG_MARKERUNITS_STROKEWIDTH: number;
     readonly SVG_MARKERUNITS_UNKNOWN: number;
@@ -13881,7 +13881,7 @@ interface SVGMaskElement extends SVGElement {
 }
 
 declare var SVGMaskElement: {
-    prototype: SVGMaskElement;
+    readonly prototype: SVGMaskElement;
     new(): SVGMaskElement;
 };
 
@@ -13894,7 +13894,7 @@ interface SVGMetadataElement extends SVGElement {
 }
 
 declare var SVGMetadataElement: {
-    prototype: SVGMetadataElement;
+    readonly prototype: SVGMetadataElement;
     new(): SVGMetadataElement;
 };
 
@@ -13904,7 +13904,7 @@ interface SVGNumber {
 }
 
 declare var SVGNumber: {
-    prototype: SVGNumber;
+    readonly prototype: SVGNumber;
     new(): SVGNumber;
 };
 
@@ -13923,7 +13923,7 @@ interface SVGNumberList {
 }
 
 declare var SVGNumberList: {
-    prototype: SVGNumberList;
+    readonly prototype: SVGNumberList;
     new(): SVGNumberList;
 };
 
@@ -13980,7 +13980,7 @@ interface SVGPathElement extends SVGGraphicsElement {
 }
 
 declare var SVGPathElement: {
-    prototype: SVGPathElement;
+    readonly prototype: SVGPathElement;
     new(): SVGPathElement;
 };
 
@@ -14010,7 +14010,7 @@ interface SVGPathSeg {
 }
 
 declare var SVGPathSeg: {
-    prototype: SVGPathSeg;
+    readonly prototype: SVGPathSeg;
     new(): SVGPathSeg;
     readonly PATHSEG_ARC_ABS: number;
     readonly PATHSEG_ARC_REL: number;
@@ -14045,7 +14045,7 @@ interface SVGPathSegArcAbs extends SVGPathSeg {
 }
 
 declare var SVGPathSegArcAbs: {
-    prototype: SVGPathSegArcAbs;
+    readonly prototype: SVGPathSegArcAbs;
     new(): SVGPathSegArcAbs;
 };
 
@@ -14060,7 +14060,7 @@ interface SVGPathSegArcRel extends SVGPathSeg {
 }
 
 declare var SVGPathSegArcRel: {
-    prototype: SVGPathSegArcRel;
+    readonly prototype: SVGPathSegArcRel;
     new(): SVGPathSegArcRel;
 };
 
@@ -14068,7 +14068,7 @@ interface SVGPathSegClosePath extends SVGPathSeg {
 }
 
 declare var SVGPathSegClosePath: {
-    prototype: SVGPathSegClosePath;
+    readonly prototype: SVGPathSegClosePath;
     new(): SVGPathSegClosePath;
 };
 
@@ -14082,7 +14082,7 @@ interface SVGPathSegCurvetoCubicAbs extends SVGPathSeg {
 }
 
 declare var SVGPathSegCurvetoCubicAbs: {
-    prototype: SVGPathSegCurvetoCubicAbs;
+    readonly prototype: SVGPathSegCurvetoCubicAbs;
     new(): SVGPathSegCurvetoCubicAbs;
 };
 
@@ -14096,7 +14096,7 @@ interface SVGPathSegCurvetoCubicRel extends SVGPathSeg {
 }
 
 declare var SVGPathSegCurvetoCubicRel: {
-    prototype: SVGPathSegCurvetoCubicRel;
+    readonly prototype: SVGPathSegCurvetoCubicRel;
     new(): SVGPathSegCurvetoCubicRel;
 };
 
@@ -14108,7 +14108,7 @@ interface SVGPathSegCurvetoCubicSmoothAbs extends SVGPathSeg {
 }
 
 declare var SVGPathSegCurvetoCubicSmoothAbs: {
-    prototype: SVGPathSegCurvetoCubicSmoothAbs;
+    readonly prototype: SVGPathSegCurvetoCubicSmoothAbs;
     new(): SVGPathSegCurvetoCubicSmoothAbs;
 };
 
@@ -14120,7 +14120,7 @@ interface SVGPathSegCurvetoCubicSmoothRel extends SVGPathSeg {
 }
 
 declare var SVGPathSegCurvetoCubicSmoothRel: {
-    prototype: SVGPathSegCurvetoCubicSmoothRel;
+    readonly prototype: SVGPathSegCurvetoCubicSmoothRel;
     new(): SVGPathSegCurvetoCubicSmoothRel;
 };
 
@@ -14132,7 +14132,7 @@ interface SVGPathSegCurvetoQuadraticAbs extends SVGPathSeg {
 }
 
 declare var SVGPathSegCurvetoQuadraticAbs: {
-    prototype: SVGPathSegCurvetoQuadraticAbs;
+    readonly prototype: SVGPathSegCurvetoQuadraticAbs;
     new(): SVGPathSegCurvetoQuadraticAbs;
 };
 
@@ -14144,7 +14144,7 @@ interface SVGPathSegCurvetoQuadraticRel extends SVGPathSeg {
 }
 
 declare var SVGPathSegCurvetoQuadraticRel: {
-    prototype: SVGPathSegCurvetoQuadraticRel;
+    readonly prototype: SVGPathSegCurvetoQuadraticRel;
     new(): SVGPathSegCurvetoQuadraticRel;
 };
 
@@ -14154,7 +14154,7 @@ interface SVGPathSegCurvetoQuadraticSmoothAbs extends SVGPathSeg {
 }
 
 declare var SVGPathSegCurvetoQuadraticSmoothAbs: {
-    prototype: SVGPathSegCurvetoQuadraticSmoothAbs;
+    readonly prototype: SVGPathSegCurvetoQuadraticSmoothAbs;
     new(): SVGPathSegCurvetoQuadraticSmoothAbs;
 };
 
@@ -14164,7 +14164,7 @@ interface SVGPathSegCurvetoQuadraticSmoothRel extends SVGPathSeg {
 }
 
 declare var SVGPathSegCurvetoQuadraticSmoothRel: {
-    prototype: SVGPathSegCurvetoQuadraticSmoothRel;
+    readonly prototype: SVGPathSegCurvetoQuadraticSmoothRel;
     new(): SVGPathSegCurvetoQuadraticSmoothRel;
 };
 
@@ -14174,7 +14174,7 @@ interface SVGPathSegLinetoAbs extends SVGPathSeg {
 }
 
 declare var SVGPathSegLinetoAbs: {
-    prototype: SVGPathSegLinetoAbs;
+    readonly prototype: SVGPathSegLinetoAbs;
     new(): SVGPathSegLinetoAbs;
 };
 
@@ -14183,7 +14183,7 @@ interface SVGPathSegLinetoHorizontalAbs extends SVGPathSeg {
 }
 
 declare var SVGPathSegLinetoHorizontalAbs: {
-    prototype: SVGPathSegLinetoHorizontalAbs;
+    readonly prototype: SVGPathSegLinetoHorizontalAbs;
     new(): SVGPathSegLinetoHorizontalAbs;
 };
 
@@ -14192,7 +14192,7 @@ interface SVGPathSegLinetoHorizontalRel extends SVGPathSeg {
 }
 
 declare var SVGPathSegLinetoHorizontalRel: {
-    prototype: SVGPathSegLinetoHorizontalRel;
+    readonly prototype: SVGPathSegLinetoHorizontalRel;
     new(): SVGPathSegLinetoHorizontalRel;
 };
 
@@ -14202,7 +14202,7 @@ interface SVGPathSegLinetoRel extends SVGPathSeg {
 }
 
 declare var SVGPathSegLinetoRel: {
-    prototype: SVGPathSegLinetoRel;
+    readonly prototype: SVGPathSegLinetoRel;
     new(): SVGPathSegLinetoRel;
 };
 
@@ -14211,7 +14211,7 @@ interface SVGPathSegLinetoVerticalAbs extends SVGPathSeg {
 }
 
 declare var SVGPathSegLinetoVerticalAbs: {
-    prototype: SVGPathSegLinetoVerticalAbs;
+    readonly prototype: SVGPathSegLinetoVerticalAbs;
     new(): SVGPathSegLinetoVerticalAbs;
 };
 
@@ -14220,7 +14220,7 @@ interface SVGPathSegLinetoVerticalRel extends SVGPathSeg {
 }
 
 declare var SVGPathSegLinetoVerticalRel: {
-    prototype: SVGPathSegLinetoVerticalRel;
+    readonly prototype: SVGPathSegLinetoVerticalRel;
     new(): SVGPathSegLinetoVerticalRel;
 };
 
@@ -14236,7 +14236,7 @@ interface SVGPathSegList {
 }
 
 declare var SVGPathSegList: {
-    prototype: SVGPathSegList;
+    readonly prototype: SVGPathSegList;
     new(): SVGPathSegList;
 };
 
@@ -14246,7 +14246,7 @@ interface SVGPathSegMovetoAbs extends SVGPathSeg {
 }
 
 declare var SVGPathSegMovetoAbs: {
-    prototype: SVGPathSegMovetoAbs;
+    readonly prototype: SVGPathSegMovetoAbs;
     new(): SVGPathSegMovetoAbs;
 };
 
@@ -14256,7 +14256,7 @@ interface SVGPathSegMovetoRel extends SVGPathSeg {
 }
 
 declare var SVGPathSegMovetoRel: {
-    prototype: SVGPathSegMovetoRel;
+    readonly prototype: SVGPathSegMovetoRel;
     new(): SVGPathSegMovetoRel;
 };
 
@@ -14276,7 +14276,7 @@ interface SVGPatternElement extends SVGElement, SVGFitToViewBox, SVGURIReference
 }
 
 declare var SVGPatternElement: {
-    prototype: SVGPatternElement;
+    readonly prototype: SVGPatternElement;
     new(): SVGPatternElement;
 };
 
@@ -14294,7 +14294,7 @@ interface SVGPointList {
 }
 
 declare var SVGPointList: {
-    prototype: SVGPointList;
+    readonly prototype: SVGPointList;
     new(): SVGPointList;
 };
 
@@ -14307,7 +14307,7 @@ interface SVGPolygonElement extends SVGGeometryElement, SVGAnimatedPoints {
 }
 
 declare var SVGPolygonElement: {
-    prototype: SVGPolygonElement;
+    readonly prototype: SVGPolygonElement;
     new(): SVGPolygonElement;
 };
 
@@ -14320,7 +14320,7 @@ interface SVGPolylineElement extends SVGGeometryElement, SVGAnimatedPoints {
 }
 
 declare var SVGPolylineElement: {
-    prototype: SVGPolylineElement;
+    readonly prototype: SVGPolylineElement;
     new(): SVGPolylineElement;
 };
 
@@ -14345,7 +14345,7 @@ interface SVGPreserveAspectRatio {
 }
 
 declare var SVGPreserveAspectRatio: {
-    prototype: SVGPreserveAspectRatio;
+    readonly prototype: SVGPreserveAspectRatio;
     new(): SVGPreserveAspectRatio;
     readonly SVG_MEETORSLICE_MEET: number;
     readonly SVG_MEETORSLICE_SLICE: number;
@@ -14378,7 +14378,7 @@ interface SVGRadialGradientElement extends SVGGradientElement {
 }
 
 declare var SVGRadialGradientElement: {
-    prototype: SVGRadialGradientElement;
+    readonly prototype: SVGRadialGradientElement;
     new(): SVGRadialGradientElement;
 };
 
@@ -14397,7 +14397,7 @@ interface SVGRectElement extends SVGGeometryElement {
 }
 
 declare var SVGRectElement: {
-    prototype: SVGRectElement;
+    readonly prototype: SVGRectElement;
     new(): SVGRectElement;
 };
 
@@ -14465,7 +14465,7 @@ interface SVGSVGElement extends SVGGraphicsElement, DocumentEvent, SVGFitToViewB
 }
 
 declare var SVGSVGElement: {
-    prototype: SVGSVGElement;
+    readonly prototype: SVGSVGElement;
     new(): SVGSVGElement;
     readonly SVG_ZOOMANDPAN_DISABLE: number;
     readonly SVG_ZOOMANDPAN_MAGNIFY: number;
@@ -14482,7 +14482,7 @@ interface SVGScriptElement extends SVGElement, SVGURIReference {
 }
 
 declare var SVGScriptElement: {
-    prototype: SVGScriptElement;
+    readonly prototype: SVGScriptElement;
     new(): SVGScriptElement;
 };
 
@@ -14496,7 +14496,7 @@ interface SVGStopElement extends SVGElement {
 }
 
 declare var SVGStopElement: {
-    prototype: SVGStopElement;
+    readonly prototype: SVGStopElement;
     new(): SVGStopElement;
 };
 
@@ -14515,7 +14515,7 @@ interface SVGStringList {
 }
 
 declare var SVGStringList: {
-    prototype: SVGStringList;
+    readonly prototype: SVGStringList;
     new(): SVGStringList;
 };
 
@@ -14532,7 +14532,7 @@ interface SVGStyleElement extends SVGElement, LinkStyle {
 }
 
 declare var SVGStyleElement: {
-    prototype: SVGStyleElement;
+    readonly prototype: SVGStyleElement;
     new(): SVGStyleElement;
 };
 
@@ -14545,7 +14545,7 @@ interface SVGSwitchElement extends SVGGraphicsElement {
 }
 
 declare var SVGSwitchElement: {
-    prototype: SVGSwitchElement;
+    readonly prototype: SVGSwitchElement;
     new(): SVGSwitchElement;
 };
 
@@ -14558,7 +14558,7 @@ interface SVGSymbolElement extends SVGElement, SVGFitToViewBox {
 }
 
 declare var SVGSymbolElement: {
-    prototype: SVGSymbolElement;
+    readonly prototype: SVGSymbolElement;
     new(): SVGSymbolElement;
 };
 
@@ -14571,7 +14571,7 @@ interface SVGTSpanElement extends SVGTextPositioningElement {
 }
 
 declare var SVGTSpanElement: {
-    prototype: SVGTSpanElement;
+    readonly prototype: SVGTSpanElement;
     new(): SVGTSpanElement;
 };
 
@@ -14603,7 +14603,7 @@ interface SVGTextContentElement extends SVGGraphicsElement {
 }
 
 declare var SVGTextContentElement: {
-    prototype: SVGTextContentElement;
+    readonly prototype: SVGTextContentElement;
     new(): SVGTextContentElement;
     readonly LENGTHADJUST_SPACING: number;
     readonly LENGTHADJUST_SPACINGANDGLYPHS: number;
@@ -14619,7 +14619,7 @@ interface SVGTextElement extends SVGTextPositioningElement {
 }
 
 declare var SVGTextElement: {
-    prototype: SVGTextElement;
+    readonly prototype: SVGTextElement;
     new(): SVGTextElement;
 };
 
@@ -14641,7 +14641,7 @@ interface SVGTextPathElement extends SVGTextContentElement, SVGURIReference {
 }
 
 declare var SVGTextPathElement: {
-    prototype: SVGTextPathElement;
+    readonly prototype: SVGTextPathElement;
     new(): SVGTextPathElement;
     readonly TEXTPATH_METHODTYPE_ALIGN: number;
     readonly TEXTPATH_METHODTYPE_STRETCH: number;
@@ -14665,7 +14665,7 @@ interface SVGTextPositioningElement extends SVGTextContentElement {
 }
 
 declare var SVGTextPositioningElement: {
-    prototype: SVGTextPositioningElement;
+    readonly prototype: SVGTextPositioningElement;
     new(): SVGTextPositioningElement;
 };
 
@@ -14678,7 +14678,7 @@ interface SVGTitleElement extends SVGElement {
 }
 
 declare var SVGTitleElement: {
-    prototype: SVGTitleElement;
+    readonly prototype: SVGTitleElement;
     new(): SVGTitleElement;
 };
 
@@ -14703,7 +14703,7 @@ interface SVGTransform {
 }
 
 declare var SVGTransform: {
-    prototype: SVGTransform;
+    readonly prototype: SVGTransform;
     new(): SVGTransform;
     readonly SVG_TRANSFORM_MATRIX: number;
     readonly SVG_TRANSFORM_ROTATE: number;
@@ -14729,7 +14729,7 @@ interface SVGTransformList {
 }
 
 declare var SVGTransformList: {
-    prototype: SVGTransformList;
+    readonly prototype: SVGTransformList;
     new(): SVGTransformList;
 };
 
@@ -14745,7 +14745,7 @@ interface SVGUnitTypes {
 }
 
 declare var SVGUnitTypes: {
-    prototype: SVGUnitTypes;
+    readonly prototype: SVGUnitTypes;
     new(): SVGUnitTypes;
     readonly SVG_UNIT_TYPE_OBJECTBOUNDINGBOX: number;
     readonly SVG_UNIT_TYPE_UNKNOWN: number;
@@ -14767,7 +14767,7 @@ interface SVGUseElement extends SVGGraphicsElement, SVGURIReference {
 }
 
 declare var SVGUseElement: {
-    prototype: SVGUseElement;
+    readonly prototype: SVGUseElement;
     new(): SVGUseElement;
 };
 
@@ -14782,7 +14782,7 @@ interface SVGViewElement extends SVGElement, SVGFitToViewBox, SVGZoomAndPan {
 }
 
 declare var SVGViewElement: {
-    prototype: SVGViewElement;
+    readonly prototype: SVGViewElement;
     new(): SVGViewElement;
     readonly SVG_ZOOMANDPAN_DISABLE: number;
     readonly SVG_ZOOMANDPAN_MAGNIFY: number;
@@ -14809,7 +14809,7 @@ interface SVGZoomEvent extends UIEvent {
 }
 
 declare var SVGZoomEvent: {
-    prototype: SVGZoomEvent;
+    readonly prototype: SVGZoomEvent;
     new(): SVGZoomEvent;
 };
 
@@ -14819,7 +14819,7 @@ interface ScopedCredential {
 }
 
 declare var ScopedCredential: {
-    prototype: ScopedCredential;
+    readonly prototype: ScopedCredential;
     new(): ScopedCredential;
 };
 
@@ -14829,7 +14829,7 @@ interface ScopedCredentialInfo {
 }
 
 declare var ScopedCredentialInfo: {
-    prototype: ScopedCredentialInfo;
+    readonly prototype: ScopedCredentialInfo;
     new(): ScopedCredentialInfo;
 };
 
@@ -14845,7 +14845,7 @@ interface Screen {
 }
 
 declare var Screen: {
-    prototype: Screen;
+    readonly prototype: Screen;
     new(): Screen;
 };
 
@@ -14866,7 +14866,7 @@ interface ScreenOrientation extends EventTarget {
 }
 
 declare var ScreenOrientation: {
-    prototype: ScreenOrientation;
+    readonly prototype: ScreenOrientation;
     new(): ScreenOrientation;
 };
 
@@ -14889,7 +14889,7 @@ interface ScriptProcessorNode extends AudioNode {
 }
 
 declare var ScriptProcessorNode: {
-    prototype: ScriptProcessorNode;
+    readonly prototype: ScriptProcessorNode;
     new(): ScriptProcessorNode;
 };
 
@@ -14908,7 +14908,7 @@ interface SecurityPolicyViolationEvent extends Event {
 }
 
 declare var SecurityPolicyViolationEvent: {
-    prototype: SecurityPolicyViolationEvent;
+    readonly prototype: SecurityPolicyViolationEvent;
     new(type: string, eventInitDict?: SecurityPolicyViolationEventInit): SecurityPolicyViolationEvent;
 };
 
@@ -14939,7 +14939,7 @@ interface Selection {
 }
 
 declare var Selection: {
-    prototype: Selection;
+    readonly prototype: Selection;
     new(): Selection;
     toString(): string;
 };
@@ -14968,7 +14968,7 @@ interface ServiceWorker extends EventTarget, AbstractWorker {
 }
 
 declare var ServiceWorker: {
-    prototype: ServiceWorker;
+    readonly prototype: ServiceWorker;
     new(): ServiceWorker;
 };
 
@@ -14996,7 +14996,7 @@ interface ServiceWorkerContainer extends EventTarget {
 }
 
 declare var ServiceWorkerContainer: {
-    prototype: ServiceWorkerContainer;
+    readonly prototype: ServiceWorkerContainer;
     new(): ServiceWorkerContainer;
 };
 
@@ -15012,7 +15012,7 @@ interface ServiceWorkerMessageEvent extends Event {
 }
 
 declare var ServiceWorkerMessageEvent: {
-    prototype: ServiceWorkerMessageEvent;
+    readonly prototype: ServiceWorkerMessageEvent;
     new(type: string, eventInitDict?: ServiceWorkerMessageEventInit): ServiceWorkerMessageEvent;
 };
 
@@ -15042,7 +15042,7 @@ interface ServiceWorkerRegistration extends EventTarget {
 }
 
 declare var ServiceWorkerRegistration: {
-    prototype: ServiceWorkerRegistration;
+    readonly prototype: ServiceWorkerRegistration;
     new(): ServiceWorkerRegistration;
 };
 
@@ -15055,7 +15055,7 @@ interface ShadowRoot extends DocumentFragment, DocumentOrShadowRoot, InnerHTML {
 }
 
 declare var ShadowRoot: {
-    prototype: ShadowRoot;
+    readonly prototype: ShadowRoot;
     new(): ShadowRoot;
 };
 
@@ -15071,7 +15071,7 @@ interface SharedWorker extends EventTarget, AbstractWorker {
 }
 
 declare var SharedWorker: {
-    prototype: SharedWorker;
+    readonly prototype: SharedWorker;
     new(scriptURL: string, options?: string | WorkerOptions): SharedWorker;
 };
 
@@ -15110,7 +15110,7 @@ interface SourceBuffer extends EventTarget {
 }
 
 declare var SourceBuffer: {
-    prototype: SourceBuffer;
+    readonly prototype: SourceBuffer;
     new(): SourceBuffer;
 };
 
@@ -15132,7 +15132,7 @@ interface SourceBufferList extends EventTarget {
 }
 
 declare var SourceBufferList: {
-    prototype: SourceBufferList;
+    readonly prototype: SourceBufferList;
     new(): SourceBufferList;
 };
 
@@ -15142,7 +15142,7 @@ interface SpeechGrammar {
 }
 
 declare var SpeechGrammar: {
-    prototype: SpeechGrammar;
+    readonly prototype: SpeechGrammar;
     new(): SpeechGrammar;
 };
 
@@ -15155,7 +15155,7 @@ interface SpeechGrammarList {
 }
 
 declare var SpeechGrammarList: {
-    prototype: SpeechGrammarList;
+    readonly prototype: SpeechGrammarList;
     new(): SpeechGrammarList;
 };
 
@@ -15200,7 +15200,7 @@ interface SpeechRecognition extends EventTarget {
 }
 
 declare var SpeechRecognition: {
-    prototype: SpeechRecognition;
+    readonly prototype: SpeechRecognition;
     new(): SpeechRecognition;
 };
 
@@ -15210,7 +15210,7 @@ interface SpeechRecognitionAlternative {
 }
 
 declare var SpeechRecognitionAlternative: {
-    prototype: SpeechRecognitionAlternative;
+    readonly prototype: SpeechRecognitionAlternative;
     new(): SpeechRecognitionAlternative;
 };
 
@@ -15220,7 +15220,7 @@ interface SpeechRecognitionErrorEvent extends Event {
 }
 
 declare var SpeechRecognitionErrorEvent: {
-    prototype: SpeechRecognitionErrorEvent;
+    readonly prototype: SpeechRecognitionErrorEvent;
     new(type: string, eventInitDict: SpeechRecognitionErrorEventInit): SpeechRecognitionErrorEvent;
 };
 
@@ -15230,7 +15230,7 @@ interface SpeechRecognitionEvent extends Event {
 }
 
 declare var SpeechRecognitionEvent: {
-    prototype: SpeechRecognitionEvent;
+    readonly prototype: SpeechRecognitionEvent;
     new(type: string, eventInitDict: SpeechRecognitionEventInit): SpeechRecognitionEvent;
 };
 
@@ -15242,7 +15242,7 @@ interface SpeechRecognitionResult {
 }
 
 declare var SpeechRecognitionResult: {
-    prototype: SpeechRecognitionResult;
+    readonly prototype: SpeechRecognitionResult;
     new(): SpeechRecognitionResult;
 };
 
@@ -15253,7 +15253,7 @@ interface SpeechRecognitionResultList {
 }
 
 declare var SpeechRecognitionResultList: {
-    prototype: SpeechRecognitionResultList;
+    readonly prototype: SpeechRecognitionResultList;
     new(): SpeechRecognitionResultList;
 };
 
@@ -15279,7 +15279,7 @@ interface SpeechSynthesis extends EventTarget {
 }
 
 declare var SpeechSynthesis: {
-    prototype: SpeechSynthesis;
+    readonly prototype: SpeechSynthesis;
     new(): SpeechSynthesis;
 };
 
@@ -15288,7 +15288,7 @@ interface SpeechSynthesisErrorEvent extends SpeechSynthesisEvent {
 }
 
 declare var SpeechSynthesisErrorEvent: {
-    prototype: SpeechSynthesisErrorEvent;
+    readonly prototype: SpeechSynthesisErrorEvent;
     new(type: string, eventInitDict: SpeechSynthesisErrorEventInit): SpeechSynthesisErrorEvent;
 };
 
@@ -15302,7 +15302,7 @@ interface SpeechSynthesisEvent extends Event {
 }
 
 declare var SpeechSynthesisEvent: {
-    prototype: SpeechSynthesisEvent;
+    readonly prototype: SpeechSynthesisEvent;
     new(type: string, eventInitDict: SpeechSynthesisEventInit): SpeechSynthesisEvent;
 };
 
@@ -15338,7 +15338,7 @@ interface SpeechSynthesisUtterance extends EventTarget {
 }
 
 declare var SpeechSynthesisUtterance: {
-    prototype: SpeechSynthesisUtterance;
+    readonly prototype: SpeechSynthesisUtterance;
     new(text?: string): SpeechSynthesisUtterance;
 };
 
@@ -15352,7 +15352,7 @@ interface SpeechSynthesisVoice {
 }
 
 declare var SpeechSynthesisVoice: {
-    prototype: SpeechSynthesisVoice;
+    readonly prototype: SpeechSynthesisVoice;
     new(): SpeechSynthesisVoice;
 };
 
@@ -15360,7 +15360,7 @@ interface StaticRange extends AbstractRange {
 }
 
 declare var StaticRange: {
-    prototype: StaticRange;
+    readonly prototype: StaticRange;
     new(init: StaticRangeInit): StaticRange;
 };
 
@@ -15370,7 +15370,7 @@ interface StereoPannerNode extends AudioNode {
 }
 
 declare var StereoPannerNode: {
-    prototype: StereoPannerNode;
+    readonly prototype: StereoPannerNode;
     new(context: BaseAudioContext, options?: StereoPannerOptions): StereoPannerNode;
 };
 
@@ -15406,7 +15406,7 @@ interface Storage {
 }
 
 declare var Storage: {
-    prototype: Storage;
+    readonly prototype: Storage;
     new(): Storage;
 };
 
@@ -15435,7 +15435,7 @@ interface StorageEvent extends Event {
 }
 
 declare var StorageEvent: {
-    prototype: StorageEvent;
+    readonly prototype: StorageEvent;
     new(type: string, eventInitDict?: StorageEventInit): StorageEvent;
 };
 
@@ -15446,7 +15446,7 @@ interface StorageManager {
 }
 
 declare var StorageManager: {
-    prototype: StorageManager;
+    readonly prototype: StorageManager;
     new(): StorageManager;
 };
 
@@ -15456,7 +15456,7 @@ interface StyleMedia {
 }
 
 declare var StyleMedia: {
-    prototype: StyleMedia;
+    readonly prototype: StyleMedia;
     new(): StyleMedia;
 };
 
@@ -15472,7 +15472,7 @@ interface StyleSheet {
 }
 
 declare var StyleSheet: {
-    prototype: StyleSheet;
+    readonly prototype: StyleSheet;
     new(): StyleSheet;
 };
 
@@ -15484,7 +15484,7 @@ interface StyleSheetList {
 }
 
 declare var StyleSheetList: {
-    prototype: StyleSheetList;
+    readonly prototype: StyleSheetList;
     new(): StyleSheetList;
 };
 
@@ -15511,7 +15511,7 @@ interface SubtleCrypto {
 }
 
 declare var SubtleCrypto: {
-    prototype: SubtleCrypto;
+    readonly prototype: SubtleCrypto;
     new(): SubtleCrypto;
 };
 
@@ -15522,7 +15522,7 @@ interface SyncManager {
 }
 
 declare var SyncManager: {
-    prototype: SyncManager;
+    readonly prototype: SyncManager;
     new(): SyncManager;
 };
 
@@ -15540,7 +15540,7 @@ interface Text extends CharacterData, Slottable {
 }
 
 declare var Text: {
-    prototype: Text;
+    readonly prototype: Text;
     new(data?: string): Text;
 };
 
@@ -15563,7 +15563,7 @@ interface TextDecoder extends TextDecoderCommon {
 }
 
 declare var TextDecoder: {
-    prototype: TextDecoder;
+    readonly prototype: TextDecoder;
     new(label?: string, options?: TextDecoderOptions): TextDecoder;
 };
 
@@ -15588,7 +15588,7 @@ interface TextDecoderStream extends GenericTransformStream, TextDecoderCommon {
 }
 
 declare var TextDecoderStream: {
-    prototype: TextDecoderStream;
+    readonly prototype: TextDecoderStream;
     new(label?: string, options?: TextDecoderOptions): TextDecoderStream;
 };
 
@@ -15605,7 +15605,7 @@ interface TextEncoder extends TextEncoderCommon {
 }
 
 declare var TextEncoder: {
-    prototype: TextEncoder;
+    readonly prototype: TextEncoder;
     new(): TextEncoder;
 };
 
@@ -15622,7 +15622,7 @@ interface TextEncoderStream extends GenericTransformStream, TextEncoderCommon {
 }
 
 declare var TextEncoderStream: {
-    prototype: TextEncoderStream;
+    readonly prototype: TextEncoderStream;
     new(): TextEncoderStream;
 };
 
@@ -15642,7 +15642,7 @@ interface TextEvent extends UIEvent {
 }
 
 declare var TextEvent: {
-    prototype: TextEvent;
+    readonly prototype: TextEvent;
     new(): TextEvent;
     readonly DOM_INPUT_METHOD_DROP: number;
     readonly DOM_INPUT_METHOD_HANDWRITING: number;
@@ -15709,7 +15709,7 @@ interface TextMetrics {
 }
 
 declare var TextMetrics: {
-    prototype: TextMetrics;
+    readonly prototype: TextMetrics;
     new(): TextMetrics;
 };
 
@@ -15774,7 +15774,7 @@ interface TextTrack extends EventTarget {
 }
 
 declare var TextTrack: {
-    prototype: TextTrack;
+    readonly prototype: TextTrack;
     new(): TextTrack;
 };
 
@@ -15822,7 +15822,7 @@ interface TextTrackCue extends EventTarget {
 }
 
 declare var TextTrackCue: {
-    prototype: TextTrackCue;
+    readonly prototype: TextTrackCue;
     new(): TextTrackCue;
 };
 
@@ -15841,7 +15841,7 @@ interface TextTrackCueList {
 }
 
 declare var TextTrackCueList: {
-    prototype: TextTrackCueList;
+    readonly prototype: TextTrackCueList;
     new(): TextTrackCueList;
 };
 
@@ -15865,7 +15865,7 @@ interface TextTrackList extends EventTarget {
 }
 
 declare var TextTrackList: {
-    prototype: TextTrackList;
+    readonly prototype: TextTrackList;
     new(): TextTrackList;
 };
 
@@ -15890,7 +15890,7 @@ interface TimeRanges {
 }
 
 declare var TimeRanges: {
-    prototype: TimeRanges;
+    readonly prototype: TimeRanges;
     new(): TimeRanges;
 };
 
@@ -15914,7 +15914,7 @@ interface Touch {
 }
 
 declare var Touch: {
-    prototype: Touch;
+    readonly prototype: Touch;
     new(touchInitDict: TouchInit): Touch;
 };
 
@@ -15930,7 +15930,7 @@ interface TouchEvent extends UIEvent {
 }
 
 declare var TouchEvent: {
-    prototype: TouchEvent;
+    readonly prototype: TouchEvent;
     new(type: string, eventInitDict?: TouchEventInit): TouchEvent;
 };
 
@@ -15942,7 +15942,7 @@ interface TouchList {
 }
 
 declare var TouchList: {
-    prototype: TouchList;
+    readonly prototype: TouchList;
     new(): TouchList;
 };
 
@@ -15955,7 +15955,7 @@ interface TrackEvent extends Event {
 }
 
 declare var TrackEvent: {
-    prototype: TrackEvent;
+    readonly prototype: TrackEvent;
     new(type: string, eventInitDict?: TrackEventInit): TrackEvent;
 };
 
@@ -15965,7 +15965,7 @@ interface TransformStream<I = any, O = any> {
 }
 
 declare var TransformStream: {
-    prototype: TransformStream;
+    readonly prototype: TransformStream;
     new<I = any, O = any>(transformer?: Transformer<I, O>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<O>): TransformStream<I, O>;
 };
 
@@ -15977,7 +15977,7 @@ interface TransformStreamDefaultController<O = any> {
 }
 
 declare var TransformStreamDefaultController: {
-    prototype: TransformStreamDefaultController;
+    readonly prototype: TransformStreamDefaultController;
     new(): TransformStreamDefaultController;
 };
 
@@ -15989,7 +15989,7 @@ interface TransitionEvent extends Event {
 }
 
 declare var TransitionEvent: {
-    prototype: TransitionEvent;
+    readonly prototype: TransitionEvent;
     new(type: string, transitionEventInitDict?: TransitionEventInit): TransitionEvent;
 };
 
@@ -16009,7 +16009,7 @@ interface TreeWalker {
 }
 
 declare var TreeWalker: {
-    prototype: TreeWalker;
+    readonly prototype: TreeWalker;
     new(): TreeWalker;
 };
 
@@ -16022,7 +16022,7 @@ interface UIEvent extends Event {
 }
 
 declare var UIEvent: {
-    prototype: UIEvent;
+    readonly prototype: UIEvent;
     new(type: string, eventInitDict?: UIEventInit): UIEvent;
 };
 
@@ -16045,7 +16045,7 @@ interface URL {
 }
 
 declare var URL: {
-    prototype: URL;
+    readonly prototype: URL;
     new(url: string, base?: string | URL): URL;
     createObjectURL(object: any): string;
     revokeObjectURL(url: string): void;
@@ -16088,7 +16088,7 @@ interface URLSearchParams {
 }
 
 declare var URLSearchParams: {
-    prototype: URLSearchParams;
+    readonly prototype: URLSearchParams;
     new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
     toString(): string;
 };
@@ -16117,7 +16117,7 @@ interface VRDisplay extends EventTarget {
 }
 
 declare var VRDisplay: {
-    prototype: VRDisplay;
+    readonly prototype: VRDisplay;
     new(): VRDisplay;
 };
 
@@ -16131,7 +16131,7 @@ interface VRDisplayCapabilities {
 }
 
 declare var VRDisplayCapabilities: {
-    prototype: VRDisplayCapabilities;
+    readonly prototype: VRDisplayCapabilities;
     new(): VRDisplayCapabilities;
 };
 
@@ -16142,7 +16142,7 @@ interface VRDisplayEvent extends Event {
 }
 
 declare var VRDisplayEvent: {
-    prototype: VRDisplayEvent;
+    readonly prototype: VRDisplayEvent;
     new(type: string, eventInitDict: VRDisplayEventInit): VRDisplayEvent;
 };
 
@@ -16156,7 +16156,7 @@ interface VREyeParameters {
 }
 
 declare var VREyeParameters: {
-    prototype: VREyeParameters;
+    readonly prototype: VREyeParameters;
     new(): VREyeParameters;
 };
 
@@ -16169,7 +16169,7 @@ interface VRFieldOfView {
 }
 
 declare var VRFieldOfView: {
-    prototype: VRFieldOfView;
+    readonly prototype: VRFieldOfView;
     new(): VRFieldOfView;
 };
 
@@ -16184,7 +16184,7 @@ interface VRFrameData {
 }
 
 declare var VRFrameData: {
-    prototype: VRFrameData;
+    readonly prototype: VRFrameData;
     new(): VRFrameData;
 };
 
@@ -16200,7 +16200,7 @@ interface VRPose {
 }
 
 declare var VRPose: {
-    prototype: VRPose;
+    readonly prototype: VRPose;
     new(): VRPose;
 };
 
@@ -16223,7 +16223,7 @@ interface VTTCue extends TextTrackCue {
 }
 
 declare var VTTCue: {
-    prototype: VTTCue;
+    readonly prototype: VTTCue;
     new(startTime: number, endTime: number, text: string): VTTCue;
 };
 
@@ -16239,7 +16239,7 @@ interface VTTRegion {
 }
 
 declare var VTTRegion: {
-    prototype: VTTRegion;
+    readonly prototype: VTTRegion;
     new(): VTTRegion;
 };
 
@@ -16259,7 +16259,7 @@ interface ValidityState {
 }
 
 declare var ValidityState: {
-    prototype: ValidityState;
+    readonly prototype: ValidityState;
     new(): ValidityState;
 };
 
@@ -16271,7 +16271,7 @@ interface VideoPlaybackQuality {
 }
 
 declare var VideoPlaybackQuality: {
-    prototype: VideoPlaybackQuality;
+    readonly prototype: VideoPlaybackQuality;
     new(): VideoPlaybackQuality;
 };
 
@@ -16297,7 +16297,7 @@ interface VisualViewport extends EventTarget {
 }
 
 declare var VisualViewport: {
-    prototype: VisualViewport;
+    readonly prototype: VisualViewport;
     new(): VisualViewport;
 };
 
@@ -16419,7 +16419,7 @@ interface WaveShaperNode extends AudioNode {
 }
 
 declare var WaveShaperNode: {
-    prototype: WaveShaperNode;
+    readonly prototype: WaveShaperNode;
     new(context: BaseAudioContext, options?: WaveShaperOptions): WaveShaperNode;
 };
 
@@ -16429,7 +16429,7 @@ interface WebAuthentication {
 }
 
 declare var WebAuthentication: {
-    prototype: WebAuthentication;
+    readonly prototype: WebAuthentication;
     new(): WebAuthentication;
 };
 
@@ -16441,7 +16441,7 @@ interface WebAuthnAssertion {
 }
 
 declare var WebAuthnAssertion: {
-    prototype: WebAuthnAssertion;
+    readonly prototype: WebAuthnAssertion;
     new(): WebAuthnAssertion;
 };
 
@@ -16449,7 +16449,7 @@ interface WebGL2RenderingContext extends WebGL2RenderingContextBase, WebGL2Rende
 }
 
 declare var WebGL2RenderingContext: {
-    prototype: WebGL2RenderingContext;
+    readonly prototype: WebGL2RenderingContext;
     new(): WebGL2RenderingContext;
     readonly ACTIVE_ATTRIBUTES: GLenum;
     readonly ACTIVE_TEXTURE: GLenum;
@@ -17417,7 +17417,7 @@ interface WebGLActiveInfo {
 }
 
 declare var WebGLActiveInfo: {
-    prototype: WebGLActiveInfo;
+    readonly prototype: WebGLActiveInfo;
     new(): WebGLActiveInfo;
 };
 
@@ -17426,7 +17426,7 @@ interface WebGLBuffer extends WebGLObject {
 }
 
 declare var WebGLBuffer: {
-    prototype: WebGLBuffer;
+    readonly prototype: WebGLBuffer;
     new(): WebGLBuffer;
 };
 
@@ -17436,7 +17436,7 @@ interface WebGLContextEvent extends Event {
 }
 
 declare var WebGLContextEvent: {
-    prototype: WebGLContextEvent;
+    readonly prototype: WebGLContextEvent;
     new(type: string, eventInit?: WebGLContextEventInit): WebGLContextEvent;
 };
 
@@ -17445,7 +17445,7 @@ interface WebGLFramebuffer extends WebGLObject {
 }
 
 declare var WebGLFramebuffer: {
-    prototype: WebGLFramebuffer;
+    readonly prototype: WebGLFramebuffer;
     new(): WebGLFramebuffer;
 };
 
@@ -17453,7 +17453,7 @@ interface WebGLObject {
 }
 
 declare var WebGLObject: {
-    prototype: WebGLObject;
+    readonly prototype: WebGLObject;
     new(): WebGLObject;
 };
 
@@ -17462,7 +17462,7 @@ interface WebGLProgram extends WebGLObject {
 }
 
 declare var WebGLProgram: {
-    prototype: WebGLProgram;
+    readonly prototype: WebGLProgram;
     new(): WebGLProgram;
 };
 
@@ -17470,7 +17470,7 @@ interface WebGLQuery extends WebGLObject {
 }
 
 declare var WebGLQuery: {
-    prototype: WebGLQuery;
+    readonly prototype: WebGLQuery;
     new(): WebGLQuery;
 };
 
@@ -17479,7 +17479,7 @@ interface WebGLRenderbuffer extends WebGLObject {
 }
 
 declare var WebGLRenderbuffer: {
-    prototype: WebGLRenderbuffer;
+    readonly prototype: WebGLRenderbuffer;
     new(): WebGLRenderbuffer;
 };
 
@@ -17488,7 +17488,7 @@ interface WebGLRenderingContext extends WebGLRenderingContextBase, WebGLRenderin
 }
 
 declare var WebGLRenderingContext: {
-    prototype: WebGLRenderingContext;
+    readonly prototype: WebGLRenderingContext;
     new(): WebGLRenderingContext;
     readonly ACTIVE_ATTRIBUTES: GLenum;
     readonly ACTIVE_TEXTURE: GLenum;
@@ -18258,7 +18258,7 @@ interface WebGLSampler extends WebGLObject {
 }
 
 declare var WebGLSampler: {
-    prototype: WebGLSampler;
+    readonly prototype: WebGLSampler;
     new(): WebGLSampler;
 };
 
@@ -18267,7 +18267,7 @@ interface WebGLShader extends WebGLObject {
 }
 
 declare var WebGLShader: {
-    prototype: WebGLShader;
+    readonly prototype: WebGLShader;
     new(): WebGLShader;
 };
 
@@ -18279,7 +18279,7 @@ interface WebGLShaderPrecisionFormat {
 }
 
 declare var WebGLShaderPrecisionFormat: {
-    prototype: WebGLShaderPrecisionFormat;
+    readonly prototype: WebGLShaderPrecisionFormat;
     new(): WebGLShaderPrecisionFormat;
 };
 
@@ -18287,7 +18287,7 @@ interface WebGLSync extends WebGLObject {
 }
 
 declare var WebGLSync: {
-    prototype: WebGLSync;
+    readonly prototype: WebGLSync;
     new(): WebGLSync;
 };
 
@@ -18296,7 +18296,7 @@ interface WebGLTexture extends WebGLObject {
 }
 
 declare var WebGLTexture: {
-    prototype: WebGLTexture;
+    readonly prototype: WebGLTexture;
     new(): WebGLTexture;
 };
 
@@ -18304,7 +18304,7 @@ interface WebGLTransformFeedback extends WebGLObject {
 }
 
 declare var WebGLTransformFeedback: {
-    prototype: WebGLTransformFeedback;
+    readonly prototype: WebGLTransformFeedback;
     new(): WebGLTransformFeedback;
 };
 
@@ -18313,7 +18313,7 @@ interface WebGLUniformLocation {
 }
 
 declare var WebGLUniformLocation: {
-    prototype: WebGLUniformLocation;
+    readonly prototype: WebGLUniformLocation;
     new(): WebGLUniformLocation;
 };
 
@@ -18321,7 +18321,7 @@ interface WebGLVertexArrayObject extends WebGLObject {
 }
 
 declare var WebGLVertexArrayObject: {
-    prototype: WebGLVertexArrayObject;
+    readonly prototype: WebGLVertexArrayObject;
     new(): WebGLVertexArrayObject;
 };
 
@@ -18334,7 +18334,7 @@ interface WebKitPoint {
 }
 
 declare var WebKitPoint: {
-    prototype: WebKitPoint;
+    readonly prototype: WebKitPoint;
     new(x?: number, y?: number): WebKitPoint;
 };
 
@@ -18398,7 +18398,7 @@ interface WebSocket extends EventTarget {
 }
 
 declare var WebSocket: {
-    prototype: WebSocket;
+    readonly prototype: WebSocket;
     new(url: string, protocols?: string | string[]): WebSocket;
     readonly CLOSED: number;
     readonly CLOSING: number;
@@ -18418,7 +18418,7 @@ interface WheelEvent extends MouseEvent {
 }
 
 declare var WheelEvent: {
-    prototype: WheelEvent;
+    readonly prototype: WheelEvent;
     new(type: string, eventInitDict?: WheelEventInit): WheelEvent;
     readonly DOM_DELTA_LINE: number;
     readonly DOM_DELTA_PAGE: number;
@@ -18657,7 +18657,7 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
 }
 
 declare var Window: {
-    prototype: Window;
+    readonly prototype: Window;
     new(): Window;
 };
 
@@ -18755,7 +18755,7 @@ interface Worker extends EventTarget, AbstractWorker {
 }
 
 declare var Worker: {
-    prototype: Worker;
+    readonly prototype: Worker;
     new(stringUrl: string | URL, options?: WorkerOptions): Worker;
 };
 
@@ -18764,7 +18764,7 @@ interface Worklet {
 }
 
 declare var Worklet: {
-    prototype: Worklet;
+    readonly prototype: Worklet;
     new(): Worklet;
 };
 
@@ -18776,7 +18776,7 @@ interface WritableStream<W = any> {
 }
 
 declare var WritableStream: {
-    prototype: WritableStream;
+    readonly prototype: WritableStream;
     new<W = any>(underlyingSink?: UnderlyingSink<W>, strategy?: QueuingStrategy<W>): WritableStream<W>;
 };
 
@@ -18786,7 +18786,7 @@ interface WritableStreamDefaultController {
 }
 
 declare var WritableStreamDefaultController: {
-    prototype: WritableStreamDefaultController;
+    readonly prototype: WritableStreamDefaultController;
     new(): WritableStreamDefaultController;
 };
 
@@ -18802,7 +18802,7 @@ interface WritableStreamDefaultWriter<W = any> {
 }
 
 declare var WritableStreamDefaultWriter: {
-    prototype: WritableStreamDefaultWriter;
+    readonly prototype: WritableStreamDefaultWriter;
     new<W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>;
 };
 
@@ -18815,7 +18815,7 @@ interface XMLDocument extends Document {
 }
 
 declare var XMLDocument: {
-    prototype: XMLDocument;
+    readonly prototype: XMLDocument;
     new(): XMLDocument;
 };
 
@@ -18926,7 +18926,7 @@ interface XMLHttpRequest extends XMLHttpRequestEventTarget {
 }
 
 declare var XMLHttpRequest: {
-    prototype: XMLHttpRequest;
+    readonly prototype: XMLHttpRequest;
     new(): XMLHttpRequest;
     readonly DONE: number;
     readonly HEADERS_RECEIVED: number;
@@ -18960,7 +18960,7 @@ interface XMLHttpRequestEventTarget extends EventTarget {
 }
 
 declare var XMLHttpRequestEventTarget: {
-    prototype: XMLHttpRequestEventTarget;
+    readonly prototype: XMLHttpRequestEventTarget;
     new(): XMLHttpRequestEventTarget;
 };
 
@@ -18972,7 +18972,7 @@ interface XMLHttpRequestUpload extends XMLHttpRequestEventTarget {
 }
 
 declare var XMLHttpRequestUpload: {
-    prototype: XMLHttpRequestUpload;
+    readonly prototype: XMLHttpRequestUpload;
     new(): XMLHttpRequestUpload;
 };
 
@@ -18982,7 +18982,7 @@ interface XMLSerializer {
 }
 
 declare var XMLSerializer: {
-    prototype: XMLSerializer;
+    readonly prototype: XMLSerializer;
     new(): XMLSerializer;
 };
 
@@ -18991,7 +18991,7 @@ interface XPathEvaluator extends XPathEvaluatorBase {
 }
 
 declare var XPathEvaluator: {
-    prototype: XPathEvaluator;
+    readonly prototype: XPathEvaluator;
     new(): XPathEvaluator;
 };
 
@@ -19007,7 +19007,7 @@ interface XPathExpression {
 }
 
 declare var XPathExpression: {
-    prototype: XPathExpression;
+    readonly prototype: XPathExpression;
     new(): XPathExpression;
 };
 
@@ -19035,7 +19035,7 @@ interface XPathResult {
 }
 
 declare var XPathResult: {
-    prototype: XPathResult;
+    readonly prototype: XPathResult;
     new(): XPathResult;
     readonly ANY_TYPE: number;
     readonly ANY_UNORDERED_NODE_TYPE: number;
@@ -19062,7 +19062,7 @@ interface XSLTProcessor {
 }
 
 declare var XSLTProcessor: {
-    prototype: XSLTProcessor;
+    readonly prototype: XSLTProcessor;
     new(): XSLTProcessor;
 };
 
@@ -19074,7 +19074,7 @@ interface webkitRTCPeerConnection extends RTCPeerConnection {
 }
 
 declare var webkitRTCPeerConnection: {
-    prototype: webkitRTCPeerConnection;
+    readonly prototype: webkitRTCPeerConnection;
     new(configuration: RTCConfiguration): webkitRTCPeerConnection;
 };
 
@@ -19119,7 +19119,7 @@ declare namespace WebAssembly {
     }
     
     var CompileError: {
-        prototype: CompileError;
+        readonly prototype: CompileError;
         new(): CompileError;
     };
     
@@ -19129,7 +19129,7 @@ declare namespace WebAssembly {
     }
     
     var Global: {
-        prototype: Global;
+        readonly prototype: Global;
         new(descriptor: GlobalDescriptor, v?: any): Global;
     };
     
@@ -19138,7 +19138,7 @@ declare namespace WebAssembly {
     }
     
     var Instance: {
-        prototype: Instance;
+        readonly prototype: Instance;
         new(module: Module, importObject?: Imports): Instance;
     };
     
@@ -19146,7 +19146,7 @@ declare namespace WebAssembly {
     }
     
     var LinkError: {
-        prototype: LinkError;
+        readonly prototype: LinkError;
         new(): LinkError;
     };
     
@@ -19156,7 +19156,7 @@ declare namespace WebAssembly {
     }
     
     var Memory: {
-        prototype: Memory;
+        readonly prototype: Memory;
         new(descriptor: MemoryDescriptor): Memory;
     };
     
@@ -19164,7 +19164,7 @@ declare namespace WebAssembly {
     }
     
     var Module: {
-        prototype: Module;
+        readonly prototype: Module;
         new(bytes: BufferSource): Module;
         customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
         exports(moduleObject: Module): ModuleExportDescriptor[];
@@ -19175,7 +19175,7 @@ declare namespace WebAssembly {
     }
     
     var RuntimeError: {
-        prototype: RuntimeError;
+        readonly prototype: RuntimeError;
         new(): RuntimeError;
     };
     
@@ -19187,7 +19187,7 @@ declare namespace WebAssembly {
     }
     
     var Table: {
-        prototype: Table;
+        readonly prototype: Table;
         new(descriptor: TableDescriptor): Table;
     };
     

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -624,7 +624,7 @@ interface AbortController {
 }
 
 declare var AbortController: {
-    prototype: AbortController;
+    readonly prototype: AbortController;
     new(): AbortController;
 };
 
@@ -646,7 +646,7 @@ interface AbortSignal extends EventTarget {
 }
 
 declare var AbortSignal: {
-    prototype: AbortSignal;
+    readonly prototype: AbortSignal;
     new(): AbortSignal;
 };
 
@@ -686,7 +686,7 @@ interface Blob {
 }
 
 declare var Blob: {
-    prototype: Blob;
+    readonly prototype: Blob;
     new(blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
 };
 
@@ -727,7 +727,7 @@ interface BroadcastChannel extends EventTarget {
 }
 
 declare var BroadcastChannel: {
-    prototype: BroadcastChannel;
+    readonly prototype: BroadcastChannel;
     new(name: string): BroadcastChannel;
 };
 
@@ -738,7 +738,7 @@ interface ByteLengthQueuingStrategy extends QueuingStrategy<ArrayBufferView> {
 }
 
 declare var ByteLengthQueuingStrategy: {
-    prototype: ByteLengthQueuingStrategy;
+    readonly prototype: ByteLengthQueuingStrategy;
     new(init: QueuingStrategyInit): ByteLengthQueuingStrategy;
 };
 
@@ -754,7 +754,7 @@ interface Cache {
 }
 
 declare var Cache: {
-    prototype: Cache;
+    readonly prototype: Cache;
     new(): Cache;
 };
 
@@ -768,7 +768,7 @@ interface CacheStorage {
 }
 
 declare var CacheStorage: {
-    prototype: CacheStorage;
+    readonly prototype: CacheStorage;
     new(): CacheStorage;
 };
 
@@ -820,7 +820,7 @@ interface CanvasGradient {
 }
 
 declare var CanvasGradient: {
-    prototype: CanvasGradient;
+    readonly prototype: CanvasGradient;
     new(): CanvasGradient;
 };
 
@@ -868,7 +868,7 @@ interface CanvasPattern {
 }
 
 declare var CanvasPattern: {
-    prototype: CanvasPattern;
+    readonly prototype: CanvasPattern;
     new(): CanvasPattern;
 };
 
@@ -924,7 +924,7 @@ interface Client {
 }
 
 declare var Client: {
-    prototype: Client;
+    readonly prototype: Client;
     new(): Client;
 };
 
@@ -937,7 +937,7 @@ interface Clients {
 }
 
 declare var Clients: {
-    prototype: Clients;
+    readonly prototype: Clients;
     new(): Clients;
 };
 
@@ -958,7 +958,7 @@ interface CloseEvent extends Event {
 }
 
 declare var CloseEvent: {
-    prototype: CloseEvent;
+    readonly prototype: CloseEvent;
     new(type: string, eventInitDict?: CloseEventInit): CloseEvent;
 };
 
@@ -978,7 +978,7 @@ interface CountQueuingStrategy extends QueuingStrategy {
 }
 
 declare var CountQueuingStrategy: {
-    prototype: CountQueuingStrategy;
+    readonly prototype: CountQueuingStrategy;
     new(init: QueuingStrategyInit): CountQueuingStrategy;
 };
 
@@ -989,7 +989,7 @@ interface Crypto {
 }
 
 declare var Crypto: {
-    prototype: Crypto;
+    readonly prototype: Crypto;
     new(): Crypto;
 };
 
@@ -1002,7 +1002,7 @@ interface CryptoKey {
 }
 
 declare var CryptoKey: {
-    prototype: CryptoKey;
+    readonly prototype: CryptoKey;
     new(): CryptoKey;
 };
 
@@ -1015,7 +1015,7 @@ interface CustomEvent<T = any> extends Event {
 }
 
 declare var CustomEvent: {
-    prototype: CustomEvent;
+    readonly prototype: CustomEvent;
     new<T>(typeArg: string, eventInitDict?: CustomEventInit<T>): CustomEvent<T>;
 };
 
@@ -1052,7 +1052,7 @@ interface DOMException {
 }
 
 declare var DOMException: {
-    prototype: DOMException;
+    readonly prototype: DOMException;
     new(message?: string, name?: string): DOMException;
     readonly ABORT_ERR: number;
     readonly DATA_CLONE_ERR: number;
@@ -1118,7 +1118,7 @@ interface DOMMatrix extends DOMMatrixReadOnly {
 }
 
 declare var DOMMatrix: {
-    prototype: DOMMatrix;
+    readonly prototype: DOMMatrix;
     new(init?: string | number[]): DOMMatrix;
     fromFloat32Array(array32: Float32Array): DOMMatrix;
     fromFloat64Array(array64: Float64Array): DOMMatrix;
@@ -1171,7 +1171,7 @@ interface DOMMatrixReadOnly {
 }
 
 declare var DOMMatrixReadOnly: {
-    prototype: DOMMatrixReadOnly;
+    readonly prototype: DOMMatrixReadOnly;
     new(init?: string | number[]): DOMMatrixReadOnly;
     fromFloat32Array(array32: Float32Array): DOMMatrixReadOnly;
     fromFloat64Array(array64: Float64Array): DOMMatrixReadOnly;
@@ -1186,7 +1186,7 @@ interface DOMPoint extends DOMPointReadOnly {
 }
 
 declare var DOMPoint: {
-    prototype: DOMPoint;
+    readonly prototype: DOMPoint;
     new(x?: number, y?: number, z?: number, w?: number): DOMPoint;
     fromPoint(other?: DOMPointInit): DOMPoint;
 };
@@ -1201,7 +1201,7 @@ interface DOMPointReadOnly {
 }
 
 declare var DOMPointReadOnly: {
-    prototype: DOMPointReadOnly;
+    readonly prototype: DOMPointReadOnly;
     new(x?: number, y?: number, z?: number, w?: number): DOMPointReadOnly;
     fromPoint(other?: DOMPointInit): DOMPointReadOnly;
 };
@@ -1216,7 +1216,7 @@ interface DOMQuad {
 }
 
 declare var DOMQuad: {
-    prototype: DOMQuad;
+    readonly prototype: DOMQuad;
     new(p1?: DOMPointInit, p2?: DOMPointInit, p3?: DOMPointInit, p4?: DOMPointInit): DOMQuad;
     fromQuad(other?: DOMQuadInit): DOMQuad;
     fromRect(other?: DOMRectInit): DOMQuad;
@@ -1230,7 +1230,7 @@ interface DOMRect extends DOMRectReadOnly {
 }
 
 declare var DOMRect: {
-    prototype: DOMRect;
+    readonly prototype: DOMRect;
     new(x?: number, y?: number, width?: number, height?: number): DOMRect;
     fromRect(other?: DOMRectInit): DOMRect;
 };
@@ -1248,7 +1248,7 @@ interface DOMRectReadOnly {
 }
 
 declare var DOMRectReadOnly: {
-    prototype: DOMRectReadOnly;
+    readonly prototype: DOMRectReadOnly;
     new(x?: number, y?: number, width?: number, height?: number): DOMRectReadOnly;
     fromRect(other?: DOMRectInit): DOMRectReadOnly;
 };
@@ -1271,7 +1271,7 @@ interface DOMStringList {
 }
 
 declare var DOMStringList: {
-    prototype: DOMStringList;
+    readonly prototype: DOMStringList;
     new(): DOMStringList;
 };
 
@@ -1304,7 +1304,7 @@ interface DedicatedWorkerGlobalScope extends WorkerGlobalScope, AnimationFramePr
 }
 
 declare var DedicatedWorkerGlobalScope: {
-    prototype: DedicatedWorkerGlobalScope;
+    readonly prototype: DedicatedWorkerGlobalScope;
     new(): DedicatedWorkerGlobalScope;
 };
 
@@ -1362,7 +1362,7 @@ interface ErrorEvent extends Event {
 }
 
 declare var ErrorEvent: {
-    prototype: ErrorEvent;
+    readonly prototype: ErrorEvent;
     new(type: string, eventInitDict?: ErrorEventInit): ErrorEvent;
 };
 
@@ -1436,7 +1436,7 @@ interface Event {
 }
 
 declare var Event: {
-    prototype: Event;
+    readonly prototype: Event;
     new(type: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
@@ -1484,7 +1484,7 @@ interface EventSource extends EventTarget {
 }
 
 declare var EventSource: {
-    prototype: EventSource;
+    readonly prototype: EventSource;
     new(url: string, eventSourceInitDict?: EventSourceInit): EventSource;
     readonly CLOSED: number;
     readonly CONNECTING: number;
@@ -1518,7 +1518,7 @@ interface EventTarget {
 }
 
 declare var EventTarget: {
-    prototype: EventTarget;
+    readonly prototype: EventTarget;
     new(): EventTarget;
 };
 
@@ -1528,7 +1528,7 @@ interface ExtendableEvent extends Event {
 }
 
 declare var ExtendableEvent: {
-    prototype: ExtendableEvent;
+    readonly prototype: ExtendableEvent;
     new(type: string, eventInitDict?: ExtendableEventInit): ExtendableEvent;
 };
 
@@ -1542,7 +1542,7 @@ interface ExtendableMessageEvent extends ExtendableEvent {
 }
 
 declare var ExtendableMessageEvent: {
-    prototype: ExtendableMessageEvent;
+    readonly prototype: ExtendableMessageEvent;
     new(type: string, eventInitDict?: ExtendableMessageEventInit): ExtendableMessageEvent;
 };
 
@@ -1557,7 +1557,7 @@ interface FetchEvent extends ExtendableEvent {
 }
 
 declare var FetchEvent: {
-    prototype: FetchEvent;
+    readonly prototype: FetchEvent;
     new(type: string, eventInitDict: FetchEventInit): FetchEvent;
 };
 
@@ -1568,7 +1568,7 @@ interface File extends Blob {
 }
 
 declare var File: {
-    prototype: File;
+    readonly prototype: File;
     new(fileBits: BlobPart[], fileName: string, options?: FilePropertyBag): File;
 };
 
@@ -1580,7 +1580,7 @@ interface FileList {
 }
 
 declare var FileList: {
-    prototype: FileList;
+    readonly prototype: FileList;
     new(): FileList;
 };
 
@@ -1619,7 +1619,7 @@ interface FileReader extends EventTarget {
 }
 
 declare var FileReader: {
-    prototype: FileReader;
+    readonly prototype: FileReader;
     new(): FileReader;
     readonly DONE: number;
     readonly EMPTY: number;
@@ -1635,7 +1635,7 @@ interface FileReaderSync {
 }
 
 declare var FileReaderSync: {
-    prototype: FileReaderSync;
+    readonly prototype: FileReaderSync;
     new(): FileReaderSync;
 };
 
@@ -1651,7 +1651,7 @@ interface FormData {
 }
 
 declare var FormData: {
-    prototype: FormData;
+    readonly prototype: FormData;
     new(): FormData;
 };
 
@@ -1671,7 +1671,7 @@ interface Headers {
 }
 
 declare var Headers: {
-    prototype: Headers;
+    readonly prototype: Headers;
     new(init?: HeadersInit): Headers;
 };
 
@@ -1725,7 +1725,7 @@ interface IDBCursor {
 }
 
 declare var IDBCursor: {
-    prototype: IDBCursor;
+    readonly prototype: IDBCursor;
     new(): IDBCursor;
 };
 
@@ -1738,7 +1738,7 @@ interface IDBCursorWithValue extends IDBCursor {
 }
 
 declare var IDBCursorWithValue: {
-    prototype: IDBCursorWithValue;
+    readonly prototype: IDBCursorWithValue;
     new(): IDBCursorWithValue;
 };
 
@@ -1794,7 +1794,7 @@ interface IDBDatabase extends EventTarget {
 }
 
 declare var IDBDatabase: {
-    prototype: IDBDatabase;
+    readonly prototype: IDBDatabase;
     new(): IDBDatabase;
 };
 
@@ -1817,7 +1817,7 @@ interface IDBFactory {
 }
 
 declare var IDBFactory: {
-    prototype: IDBFactory;
+    readonly prototype: IDBFactory;
     new(): IDBFactory;
 };
 
@@ -1879,7 +1879,7 @@ interface IDBIndex {
 }
 
 declare var IDBIndex: {
-    prototype: IDBIndex;
+    readonly prototype: IDBIndex;
     new(): IDBIndex;
 };
 
@@ -1908,7 +1908,7 @@ interface IDBKeyRange {
 }
 
 declare var IDBKeyRange: {
-    prototype: IDBKeyRange;
+    readonly prototype: IDBKeyRange;
     new(): IDBKeyRange;
     /**
      * Returns a new IDBKeyRange spanning from lower to upper. If lowerOpen is true, lower is not included in the range. If upperOpen is true, upper is not included in the range.
@@ -2040,7 +2040,7 @@ interface IDBObjectStore {
 }
 
 declare var IDBObjectStore: {
-    prototype: IDBObjectStore;
+    readonly prototype: IDBObjectStore;
     new(): IDBObjectStore;
 };
 
@@ -2060,7 +2060,7 @@ interface IDBOpenDBRequest extends IDBRequest<IDBDatabase> {
 }
 
 declare var IDBOpenDBRequest: {
-    prototype: IDBOpenDBRequest;
+    readonly prototype: IDBOpenDBRequest;
     new(): IDBOpenDBRequest;
 };
 
@@ -2100,7 +2100,7 @@ interface IDBRequest<T = any> extends EventTarget {
 }
 
 declare var IDBRequest: {
-    prototype: IDBRequest;
+    readonly prototype: IDBRequest;
     new(): IDBRequest;
 };
 
@@ -2145,7 +2145,7 @@ interface IDBTransaction extends EventTarget {
 }
 
 declare var IDBTransaction: {
-    prototype: IDBTransaction;
+    readonly prototype: IDBTransaction;
     new(): IDBTransaction;
 };
 
@@ -2156,7 +2156,7 @@ interface IDBVersionChangeEvent extends Event {
 }
 
 declare var IDBVersionChangeEvent: {
-    prototype: IDBVersionChangeEvent;
+    readonly prototype: IDBVersionChangeEvent;
     new(type: string, eventInitDict?: IDBVersionChangeEventInit): IDBVersionChangeEvent;
 };
 
@@ -2176,7 +2176,7 @@ interface ImageBitmap {
 }
 
 declare var ImageBitmap: {
-    prototype: ImageBitmap;
+    readonly prototype: ImageBitmap;
     new(): ImageBitmap;
 };
 
@@ -2192,7 +2192,7 @@ interface ImageBitmapRenderingContext {
 }
 
 declare var ImageBitmapRenderingContext: {
-    prototype: ImageBitmapRenderingContext;
+    readonly prototype: ImageBitmapRenderingContext;
     new(): ImageBitmapRenderingContext;
 };
 
@@ -2213,7 +2213,7 @@ interface ImageData {
 }
 
 declare var ImageData: {
-    prototype: ImageData;
+    readonly prototype: ImageData;
     new(sw: number, sh: number): ImageData;
     new(data: Uint8ClampedArray, sw: number, sh?: number): ImageData;
 };
@@ -2231,7 +2231,7 @@ interface MessageChannel {
 }
 
 declare var MessageChannel: {
-    prototype: MessageChannel;
+    readonly prototype: MessageChannel;
     new(): MessageChannel;
 };
 
@@ -2260,7 +2260,7 @@ interface MessageEvent<T = any> extends Event {
 }
 
 declare var MessageEvent: {
-    prototype: MessageEvent;
+    readonly prototype: MessageEvent;
     new<T>(type: string, eventInitDict?: MessageEventInit<T>): MessageEvent<T>;
 };
 
@@ -2295,7 +2295,7 @@ interface MessagePort extends EventTarget {
 }
 
 declare var MessagePort: {
-    prototype: MessagePort;
+    readonly prototype: MessagePort;
     new(): MessagePort;
 };
 
@@ -2307,7 +2307,7 @@ interface NavigationPreloadManager {
 }
 
 declare var NavigationPreloadManager: {
-    prototype: NavigationPreloadManager;
+    readonly prototype: NavigationPreloadManager;
     new(): NavigationPreloadManager;
 };
 
@@ -2373,7 +2373,7 @@ interface Notification extends EventTarget {
 }
 
 declare var Notification: {
-    prototype: Notification;
+    readonly prototype: Notification;
     new(title: string, options?: NotificationOptions): Notification;
     readonly maxActions: number;
     readonly permission: NotificationPermission;
@@ -2386,7 +2386,7 @@ interface NotificationEvent extends ExtendableEvent {
 }
 
 declare var NotificationEvent: {
-    prototype: NotificationEvent;
+    readonly prototype: NotificationEvent;
     new(type: string, eventInitDict: NotificationEventInit): NotificationEvent;
 };
 
@@ -2462,7 +2462,7 @@ interface OffscreenCanvas extends EventTarget {
 }
 
 declare var OffscreenCanvas: {
-    prototype: OffscreenCanvas;
+    readonly prototype: OffscreenCanvas;
     new(width: number, height: number): OffscreenCanvas;
 };
 
@@ -2472,7 +2472,7 @@ interface OffscreenCanvasRenderingContext2D extends CanvasCompositing, CanvasDra
 }
 
 declare var OffscreenCanvasRenderingContext2D: {
-    prototype: OffscreenCanvasRenderingContext2D;
+    readonly prototype: OffscreenCanvasRenderingContext2D;
     new(): OffscreenCanvasRenderingContext2D;
 };
 
@@ -2485,7 +2485,7 @@ interface Path2D extends CanvasPath {
 }
 
 declare var Path2D: {
-    prototype: Path2D;
+    readonly prototype: Path2D;
     new(path?: Path2D | string): Path2D;
 };
 
@@ -2515,7 +2515,7 @@ interface Performance extends EventTarget {
 }
 
 declare var Performance: {
-    prototype: Performance;
+    readonly prototype: Performance;
     new(): Performance;
 };
 
@@ -2529,7 +2529,7 @@ interface PerformanceEntry {
 }
 
 declare var PerformanceEntry: {
-    prototype: PerformanceEntry;
+    readonly prototype: PerformanceEntry;
     new(): PerformanceEntry;
 };
 
@@ -2538,7 +2538,7 @@ interface PerformanceMark extends PerformanceEntry {
 }
 
 declare var PerformanceMark: {
-    prototype: PerformanceMark;
+    readonly prototype: PerformanceMark;
     new(): PerformanceMark;
 };
 
@@ -2547,7 +2547,7 @@ interface PerformanceMeasure extends PerformanceEntry {
 }
 
 declare var PerformanceMeasure: {
-    prototype: PerformanceMeasure;
+    readonly prototype: PerformanceMeasure;
     new(): PerformanceMeasure;
 };
 
@@ -2558,7 +2558,7 @@ interface PerformanceObserver {
 }
 
 declare var PerformanceObserver: {
-    prototype: PerformanceObserver;
+    readonly prototype: PerformanceObserver;
     new(callback: PerformanceObserverCallback): PerformanceObserver;
     readonly supportedEntryTypes: ReadonlyArray<string>;
 };
@@ -2570,7 +2570,7 @@ interface PerformanceObserverEntryList {
 }
 
 declare var PerformanceObserverEntryList: {
-    prototype: PerformanceObserverEntryList;
+    readonly prototype: PerformanceObserverEntryList;
     new(): PerformanceObserverEntryList;
 };
 
@@ -2597,7 +2597,7 @@ interface PerformanceResourceTiming extends PerformanceEntry {
 }
 
 declare var PerformanceResourceTiming: {
-    prototype: PerformanceResourceTiming;
+    readonly prototype: PerformanceResourceTiming;
     new(): PerformanceResourceTiming;
 };
 
@@ -2615,7 +2615,7 @@ interface PermissionStatus extends EventTarget {
 }
 
 declare var PermissionStatus: {
-    prototype: PermissionStatus;
+    readonly prototype: PermissionStatus;
     new(): PermissionStatus;
 };
 
@@ -2624,7 +2624,7 @@ interface Permissions {
 }
 
 declare var Permissions: {
-    prototype: Permissions;
+    readonly prototype: Permissions;
     new(): Permissions;
 };
 
@@ -2637,7 +2637,7 @@ interface ProgressEvent<T extends EventTarget = EventTarget> extends Event {
 }
 
 declare var ProgressEvent: {
-    prototype: ProgressEvent;
+    readonly prototype: ProgressEvent;
     new(type: string, eventInitDict?: ProgressEventInit): ProgressEvent;
 };
 
@@ -2647,7 +2647,7 @@ interface PromiseRejectionEvent extends Event {
 }
 
 declare var PromiseRejectionEvent: {
-    prototype: PromiseRejectionEvent;
+    readonly prototype: PromiseRejectionEvent;
     new(type: string, eventInitDict: PromiseRejectionEventInit): PromiseRejectionEvent;
 };
 
@@ -2657,7 +2657,7 @@ interface PushEvent extends ExtendableEvent {
 }
 
 declare var PushEvent: {
-    prototype: PushEvent;
+    readonly prototype: PushEvent;
     new(type: string, eventInitDict?: PushEventInit): PushEvent;
 };
 
@@ -2669,7 +2669,7 @@ interface PushManager {
 }
 
 declare var PushManager: {
-    prototype: PushManager;
+    readonly prototype: PushManager;
     new(): PushManager;
     readonly supportedContentEncodings: ReadonlyArray<string>;
 };
@@ -2683,7 +2683,7 @@ interface PushMessageData {
 }
 
 declare var PushMessageData: {
-    prototype: PushMessageData;
+    readonly prototype: PushMessageData;
     new(): PushMessageData;
 };
 
@@ -2698,7 +2698,7 @@ interface PushSubscription {
 }
 
 declare var PushSubscription: {
-    prototype: PushSubscription;
+    readonly prototype: PushSubscription;
     new(): PushSubscription;
 };
 
@@ -2708,7 +2708,7 @@ interface PushSubscriptionChangeEvent extends ExtendableEvent {
 }
 
 declare var PushSubscriptionChangeEvent: {
-    prototype: PushSubscriptionChangeEvent;
+    readonly prototype: PushSubscriptionChangeEvent;
     new(type: string, eventInitDict?: PushSubscriptionChangeEventInit): PushSubscriptionChangeEvent;
 };
 
@@ -2718,7 +2718,7 @@ interface PushSubscriptionOptions {
 }
 
 declare var PushSubscriptionOptions: {
-    prototype: PushSubscriptionOptions;
+    readonly prototype: PushSubscriptionOptions;
     new(): PushSubscriptionOptions;
 };
 
@@ -2733,7 +2733,7 @@ interface ReadableStream<R = any> {
 }
 
 declare var ReadableStream: {
-    prototype: ReadableStream;
+    readonly prototype: ReadableStream;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
 };
 
@@ -2745,7 +2745,7 @@ interface ReadableStreamDefaultController<R = any> {
 }
 
 declare var ReadableStreamDefaultController: {
-    prototype: ReadableStreamDefaultController;
+    readonly prototype: ReadableStreamDefaultController;
     new(): ReadableStreamDefaultController;
 };
 
@@ -2755,7 +2755,7 @@ interface ReadableStreamDefaultReader<R = any> extends ReadableStreamGenericRead
 }
 
 declare var ReadableStreamDefaultReader: {
-    prototype: ReadableStreamDefaultReader;
+    readonly prototype: ReadableStreamDefaultReader;
     new<R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>;
 };
 
@@ -2830,7 +2830,7 @@ interface Request extends Body {
 }
 
 declare var Request: {
-    prototype: Request;
+    readonly prototype: Request;
     new(input: RequestInfo, init?: RequestInit): Request;
 };
 
@@ -2848,7 +2848,7 @@ interface Response extends Body {
 }
 
 declare var Response: {
-    prototype: Response;
+    readonly prototype: Response;
     new(body?: BodyInit | null, init?: ResponseInit): Response;
     error(): Response;
     redirect(url: string, status?: number): Response;
@@ -2872,7 +2872,7 @@ interface ServiceWorker extends EventTarget, AbstractWorker {
 }
 
 declare var ServiceWorker: {
-    prototype: ServiceWorker;
+    readonly prototype: ServiceWorker;
     new(): ServiceWorker;
 };
 
@@ -2900,7 +2900,7 @@ interface ServiceWorkerContainer extends EventTarget {
 }
 
 declare var ServiceWorkerContainer: {
-    prototype: ServiceWorkerContainer;
+    readonly prototype: ServiceWorkerContainer;
     new(): ServiceWorkerContainer;
 };
 
@@ -2940,7 +2940,7 @@ interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
 }
 
 declare var ServiceWorkerGlobalScope: {
-    prototype: ServiceWorkerGlobalScope;
+    readonly prototype: ServiceWorkerGlobalScope;
     new(): ServiceWorkerGlobalScope;
 };
 
@@ -2970,7 +2970,7 @@ interface ServiceWorkerRegistration extends EventTarget {
 }
 
 declare var ServiceWorkerRegistration: {
-    prototype: ServiceWorkerRegistration;
+    readonly prototype: ServiceWorkerRegistration;
     new(): ServiceWorkerRegistration;
 };
 
@@ -2986,7 +2986,7 @@ interface SharedWorker extends EventTarget, AbstractWorker {
 }
 
 declare var SharedWorker: {
-    prototype: SharedWorker;
+    readonly prototype: SharedWorker;
     new(scriptURL: string, options?: string | WorkerOptions): SharedWorker;
 };
 
@@ -3011,7 +3011,7 @@ interface SharedWorkerGlobalScope extends WorkerGlobalScope {
 }
 
 declare var SharedWorkerGlobalScope: {
-    prototype: SharedWorkerGlobalScope;
+    readonly prototype: SharedWorkerGlobalScope;
     new(): SharedWorkerGlobalScope;
 };
 
@@ -3021,7 +3021,7 @@ interface StorageManager {
 }
 
 declare var StorageManager: {
-    prototype: StorageManager;
+    readonly prototype: StorageManager;
     new(): StorageManager;
 };
 
@@ -3048,7 +3048,7 @@ interface SubtleCrypto {
 }
 
 declare var SubtleCrypto: {
-    prototype: SubtleCrypto;
+    readonly prototype: SubtleCrypto;
     new(): SubtleCrypto;
 };
 
@@ -3059,7 +3059,7 @@ interface SyncEvent extends ExtendableEvent {
 }
 
 declare var SyncEvent: {
-    prototype: SyncEvent;
+    readonly prototype: SyncEvent;
     new(type: string, init: SyncEventInit): SyncEvent;
 };
 
@@ -3070,7 +3070,7 @@ interface SyncManager {
 }
 
 declare var SyncManager: {
-    prototype: SyncManager;
+    readonly prototype: SyncManager;
     new(): SyncManager;
 };
 
@@ -3093,7 +3093,7 @@ interface TextDecoder extends TextDecoderCommon {
 }
 
 declare var TextDecoder: {
-    prototype: TextDecoder;
+    readonly prototype: TextDecoder;
     new(label?: string, options?: TextDecoderOptions): TextDecoder;
 };
 
@@ -3118,7 +3118,7 @@ interface TextDecoderStream extends GenericTransformStream, TextDecoderCommon {
 }
 
 declare var TextDecoderStream: {
-    prototype: TextDecoderStream;
+    readonly prototype: TextDecoderStream;
     new(label?: string, options?: TextDecoderOptions): TextDecoderStream;
 };
 
@@ -3135,7 +3135,7 @@ interface TextEncoder extends TextEncoderCommon {
 }
 
 declare var TextEncoder: {
-    prototype: TextEncoder;
+    readonly prototype: TextEncoder;
     new(): TextEncoder;
 };
 
@@ -3152,7 +3152,7 @@ interface TextEncoderStream extends GenericTransformStream, TextEncoderCommon {
 }
 
 declare var TextEncoderStream: {
-    prototype: TextEncoderStream;
+    readonly prototype: TextEncoderStream;
     new(): TextEncoderStream;
 };
 
@@ -3209,7 +3209,7 @@ interface TextMetrics {
 }
 
 declare var TextMetrics: {
-    prototype: TextMetrics;
+    readonly prototype: TextMetrics;
     new(): TextMetrics;
 };
 
@@ -3219,7 +3219,7 @@ interface TransformStream<I = any, O = any> {
 }
 
 declare var TransformStream: {
-    prototype: TransformStream;
+    readonly prototype: TransformStream;
     new<I = any, O = any>(transformer?: Transformer<I, O>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<O>): TransformStream<I, O>;
 };
 
@@ -3231,7 +3231,7 @@ interface TransformStreamDefaultController<O = any> {
 }
 
 declare var TransformStreamDefaultController: {
-    prototype: TransformStreamDefaultController;
+    readonly prototype: TransformStreamDefaultController;
     new(): TransformStreamDefaultController;
 };
 
@@ -3254,7 +3254,7 @@ interface URL {
 }
 
 declare var URL: {
-    prototype: URL;
+    readonly prototype: URL;
     new(url: string, base?: string | URL): URL;
     createObjectURL(object: any): string;
     revokeObjectURL(url: string): void;
@@ -3294,7 +3294,7 @@ interface URLSearchParams {
 }
 
 declare var URLSearchParams: {
-    prototype: URLSearchParams;
+    readonly prototype: URLSearchParams;
     new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
     toString(): string;
 };
@@ -3414,7 +3414,7 @@ interface WebGL2RenderingContext extends WebGL2RenderingContextBase, WebGL2Rende
 }
 
 declare var WebGL2RenderingContext: {
-    prototype: WebGL2RenderingContext;
+    readonly prototype: WebGL2RenderingContext;
     new(): WebGL2RenderingContext;
     readonly ACTIVE_ATTRIBUTES: GLenum;
     readonly ACTIVE_TEXTURE: GLenum;
@@ -4382,7 +4382,7 @@ interface WebGLActiveInfo {
 }
 
 declare var WebGLActiveInfo: {
-    prototype: WebGLActiveInfo;
+    readonly prototype: WebGLActiveInfo;
     new(): WebGLActiveInfo;
 };
 
@@ -4391,7 +4391,7 @@ interface WebGLBuffer extends WebGLObject {
 }
 
 declare var WebGLBuffer: {
-    prototype: WebGLBuffer;
+    readonly prototype: WebGLBuffer;
     new(): WebGLBuffer;
 };
 
@@ -4401,7 +4401,7 @@ interface WebGLContextEvent extends Event {
 }
 
 declare var WebGLContextEvent: {
-    prototype: WebGLContextEvent;
+    readonly prototype: WebGLContextEvent;
     new(type: string, eventInit?: WebGLContextEventInit): WebGLContextEvent;
 };
 
@@ -4410,7 +4410,7 @@ interface WebGLFramebuffer extends WebGLObject {
 }
 
 declare var WebGLFramebuffer: {
-    prototype: WebGLFramebuffer;
+    readonly prototype: WebGLFramebuffer;
     new(): WebGLFramebuffer;
 };
 
@@ -4418,7 +4418,7 @@ interface WebGLObject {
 }
 
 declare var WebGLObject: {
-    prototype: WebGLObject;
+    readonly prototype: WebGLObject;
     new(): WebGLObject;
 };
 
@@ -4427,7 +4427,7 @@ interface WebGLProgram extends WebGLObject {
 }
 
 declare var WebGLProgram: {
-    prototype: WebGLProgram;
+    readonly prototype: WebGLProgram;
     new(): WebGLProgram;
 };
 
@@ -4435,7 +4435,7 @@ interface WebGLQuery extends WebGLObject {
 }
 
 declare var WebGLQuery: {
-    prototype: WebGLQuery;
+    readonly prototype: WebGLQuery;
     new(): WebGLQuery;
 };
 
@@ -4444,7 +4444,7 @@ interface WebGLRenderbuffer extends WebGLObject {
 }
 
 declare var WebGLRenderbuffer: {
-    prototype: WebGLRenderbuffer;
+    readonly prototype: WebGLRenderbuffer;
     new(): WebGLRenderbuffer;
 };
 
@@ -4453,7 +4453,7 @@ interface WebGLRenderingContext extends WebGLRenderingContextBase, WebGLRenderin
 }
 
 declare var WebGLRenderingContext: {
-    prototype: WebGLRenderingContext;
+    readonly prototype: WebGLRenderingContext;
     new(): WebGLRenderingContext;
     readonly ACTIVE_ATTRIBUTES: GLenum;
     readonly ACTIVE_TEXTURE: GLenum;
@@ -5223,7 +5223,7 @@ interface WebGLSampler extends WebGLObject {
 }
 
 declare var WebGLSampler: {
-    prototype: WebGLSampler;
+    readonly prototype: WebGLSampler;
     new(): WebGLSampler;
 };
 
@@ -5232,7 +5232,7 @@ interface WebGLShader extends WebGLObject {
 }
 
 declare var WebGLShader: {
-    prototype: WebGLShader;
+    readonly prototype: WebGLShader;
     new(): WebGLShader;
 };
 
@@ -5244,7 +5244,7 @@ interface WebGLShaderPrecisionFormat {
 }
 
 declare var WebGLShaderPrecisionFormat: {
-    prototype: WebGLShaderPrecisionFormat;
+    readonly prototype: WebGLShaderPrecisionFormat;
     new(): WebGLShaderPrecisionFormat;
 };
 
@@ -5252,7 +5252,7 @@ interface WebGLSync extends WebGLObject {
 }
 
 declare var WebGLSync: {
-    prototype: WebGLSync;
+    readonly prototype: WebGLSync;
     new(): WebGLSync;
 };
 
@@ -5261,7 +5261,7 @@ interface WebGLTexture extends WebGLObject {
 }
 
 declare var WebGLTexture: {
-    prototype: WebGLTexture;
+    readonly prototype: WebGLTexture;
     new(): WebGLTexture;
 };
 
@@ -5269,7 +5269,7 @@ interface WebGLTransformFeedback extends WebGLObject {
 }
 
 declare var WebGLTransformFeedback: {
-    prototype: WebGLTransformFeedback;
+    readonly prototype: WebGLTransformFeedback;
     new(): WebGLTransformFeedback;
 };
 
@@ -5278,7 +5278,7 @@ interface WebGLUniformLocation {
 }
 
 declare var WebGLUniformLocation: {
-    prototype: WebGLUniformLocation;
+    readonly prototype: WebGLUniformLocation;
     new(): WebGLUniformLocation;
 };
 
@@ -5286,7 +5286,7 @@ interface WebGLVertexArrayObject extends WebGLObject {
 }
 
 declare var WebGLVertexArrayObject: {
-    prototype: WebGLVertexArrayObject;
+    readonly prototype: WebGLVertexArrayObject;
     new(): WebGLVertexArrayObject;
 };
 
@@ -5353,7 +5353,7 @@ interface WebSocket extends EventTarget {
 }
 
 declare var WebSocket: {
-    prototype: WebSocket;
+    readonly prototype: WebSocket;
     new(url: string, protocols?: string | string[]): WebSocket;
     readonly CLOSED: number;
     readonly CLOSING: number;
@@ -5371,7 +5371,7 @@ interface WindowClient extends Client {
 }
 
 declare var WindowClient: {
-    prototype: WindowClient;
+    readonly prototype: WindowClient;
     new(): WindowClient;
 };
 
@@ -5419,7 +5419,7 @@ interface Worker extends EventTarget, AbstractWorker {
 }
 
 declare var Worker: {
-    prototype: Worker;
+    readonly prototype: Worker;
     new(stringUrl: string | URL, options?: WorkerOptions): Worker;
 };
 
@@ -5460,7 +5460,7 @@ interface WorkerGlobalScope extends EventTarget, WindowOrWorkerGlobalScope {
 }
 
 declare var WorkerGlobalScope: {
-    prototype: WorkerGlobalScope;
+    readonly prototype: WorkerGlobalScope;
     new(): WorkerGlobalScope;
 };
 
@@ -5479,7 +5479,7 @@ interface WorkerLocation {
 }
 
 declare var WorkerLocation: {
-    prototype: WorkerLocation;
+    readonly prototype: WorkerLocation;
     new(): WorkerLocation;
 };
 
@@ -5490,7 +5490,7 @@ interface WorkerNavigator extends NavigatorConcurrentHardware, NavigatorID, Navi
 }
 
 declare var WorkerNavigator: {
-    prototype: WorkerNavigator;
+    readonly prototype: WorkerNavigator;
     new(): WorkerNavigator;
 };
 
@@ -5502,7 +5502,7 @@ interface WritableStream<W = any> {
 }
 
 declare var WritableStream: {
-    prototype: WritableStream;
+    readonly prototype: WritableStream;
     new<W = any>(underlyingSink?: UnderlyingSink<W>, strategy?: QueuingStrategy<W>): WritableStream<W>;
 };
 
@@ -5512,7 +5512,7 @@ interface WritableStreamDefaultController {
 }
 
 declare var WritableStreamDefaultController: {
-    prototype: WritableStreamDefaultController;
+    readonly prototype: WritableStreamDefaultController;
     new(): WritableStreamDefaultController;
 };
 
@@ -5528,7 +5528,7 @@ interface WritableStreamDefaultWriter<W = any> {
 }
 
 declare var WritableStreamDefaultWriter: {
-    prototype: WritableStreamDefaultWriter;
+    readonly prototype: WritableStreamDefaultWriter;
     new<W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>;
 };
 
@@ -5633,7 +5633,7 @@ interface XMLHttpRequest extends XMLHttpRequestEventTarget {
 }
 
 declare var XMLHttpRequest: {
-    prototype: XMLHttpRequest;
+    readonly prototype: XMLHttpRequest;
     new(): XMLHttpRequest;
     readonly DONE: number;
     readonly HEADERS_RECEIVED: number;
@@ -5667,7 +5667,7 @@ interface XMLHttpRequestEventTarget extends EventTarget {
 }
 
 declare var XMLHttpRequestEventTarget: {
-    prototype: XMLHttpRequestEventTarget;
+    readonly prototype: XMLHttpRequestEventTarget;
     new(): XMLHttpRequestEventTarget;
 };
 
@@ -5679,7 +5679,7 @@ interface XMLHttpRequestUpload extends XMLHttpRequestEventTarget {
 }
 
 declare var XMLHttpRequestUpload: {
-    prototype: XMLHttpRequestUpload;
+    readonly prototype: XMLHttpRequestUpload;
     new(): XMLHttpRequestUpload;
 };
 
@@ -5719,7 +5719,7 @@ declare namespace WebAssembly {
     }
     
     var Global: {
-        prototype: Global;
+        readonly prototype: Global;
         new(descriptor: GlobalDescriptor, v?: any): Global;
     };
     
@@ -5728,7 +5728,7 @@ declare namespace WebAssembly {
     }
     
     var Instance: {
-        prototype: Instance;
+        readonly prototype: Instance;
         new(module: Module, importObject?: Imports): Instance;
     };
     
@@ -5738,7 +5738,7 @@ declare namespace WebAssembly {
     }
     
     var Memory: {
-        prototype: Memory;
+        readonly prototype: Memory;
         new(descriptor: MemoryDescriptor): Memory;
     };
     
@@ -5746,7 +5746,7 @@ declare namespace WebAssembly {
     }
     
     var Module: {
-        prototype: Module;
+        readonly prototype: Module;
         new(bytes: BufferSource): Module;
         customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
         exports(moduleObject: Module): ModuleExportDescriptor[];
@@ -5761,7 +5761,7 @@ declare namespace WebAssembly {
     }
     
     var Table: {
-        prototype: Table;
+        readonly prototype: Table;
         new(descriptor: TableDescriptor): Table;
     };
     

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -827,7 +827,7 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor, iterator: boo
         printer.printLine(`${prefix}var ${i.name}: {`);
         printer.increaseIndent();
 
-        printer.printLine(`prototype: ${i.name};`);
+        printer.printLine(`readonly prototype: ${i.name};`);
         emitConstructorSignature(i);
         emitConstants(i);
         if (iNameToConstParents[i.name] && iNameToConstParents[i.name].length) {


### PR DESCRIPTION
This more closely matches runtime behaviour.

---

It also causes code that would try to re‑assign the `prototype` property of **WebIDL** constructors to have the error caught at compile time, rather than at run time.