### PR TITLE
Event type for readystatechange is not specific enough

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4446,7 +4446,7 @@ interface DocumentEventMap extends GlobalEventHandlersEventMap, DocumentAndEleme
     "fullscreenerror": Event;
     "pointerlockchange": Event;
     "pointerlockerror": Event;
-    "readystatechange": Event;
+    "readystatechange": ProgressEvent<Document>;
     "visibilitychange": Event;
 }
 
@@ -4601,7 +4601,7 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
      * Fires when the state of the object has changed.
      * @param ev The event
      */
-    onreadystatechange: ((this: Document, ev: Event) => any) | null;
+    onreadystatechange: ((this: Document, ev: ProgressEvent<Document>) => any) | null;
     onvisibilitychange: ((this: Document, ev: Event) => any) | null;
     readonly ownerDocument: null;
     /**
@@ -4742,6 +4742,7 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
     createEvent(eventInterface: "PointerEvent"): PointerEvent;
     createEvent(eventInterface: "PopStateEvent"): PopStateEvent;
     createEvent(eventInterface: "ProgressEvent"): ProgressEvent;
+    createEvent(eventInterface: "ProgressEvent<Document>"): ProgressEvent<Document>;
     createEvent(eventInterface: "PromiseRejectionEvent"): PromiseRejectionEvent;
     createEvent(eventInterface: "RTCDTMFToneChangeEvent"): RTCDTMFToneChangeEvent;
     createEvent(eventInterface: "RTCDataChannelEvent"): RTCDataChannelEvent;
@@ -4992,6 +4993,7 @@ interface DocumentEvent {
     createEvent(eventInterface: "PointerEvent"): PointerEvent;
     createEvent(eventInterface: "PopStateEvent"): PopStateEvent;
     createEvent(eventInterface: "ProgressEvent"): ProgressEvent;
+    createEvent(eventInterface: "ProgressEvent<Document>"): ProgressEvent<Document>;
     createEvent(eventInterface: "PromiseRejectionEvent"): PromiseRejectionEvent;
     createEvent(eventInterface: "RTCDTMFToneChangeEvent"): RTCDTMFToneChangeEvent;
     createEvent(eventInterface: "RTCDataChannelEvent"): RTCDataChannelEvent;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -687,7 +687,7 @@
                     "event": [
                         {
                             "name": "readystatechange",
-                            "type": "Event"
+                            "type": "ProgressEvent<Document>"
                         }
                     ]
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/41775

I was a little bit unsure whether its best to use `ProgressEvent<Document>` vs making `Event` generic (`Event<T extends EventTarget = EventTarget>`) and then using `Event<Document>`.