### PR TITLE
Reverts microsoft/TypeScript-DOM-lib-generator#885 - dom query changes

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4830,11 +4830,11 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
      * Returns a reference to the first object with the specified value of the ID attribute.
      * @param elementId String that specifies the ID value.
      */
-    getElementById<E extends Element = HTMLElement>(elementId: string): E | null;
+    getElementById(elementId: string): HTMLElement | null;
     /**
      * Returns a HTMLCollection of the elements in the object on which the method was invoked (a document or an element) that have all the classes given by classNames. The classNames argument is interpreted as a space-separated list of classes.
      */
-    getElementsByClassName<E extends Element = HTMLElement>(classNames: string): HTMLCollectionOf<E>;
+    getElementsByClassName(classNames: string): HTMLCollectionOf<Element>;
     /**
      * Gets a collection of objects based on the value of the NAME or ID attribute.
      * @param elementName Gets a collection of objects based on the value of the NAME or ID attribute.
@@ -5030,7 +5030,7 @@ interface DocumentEvent {
 /** A minimal document object that has no parent. It is used as a lightweight version of Document that stores a segment of a document structure comprised of nodes just like a standard document. The key difference is that because the document fragment isn't part of the active document tree structure, changes made to the fragment don't affect the document, cause reflow, or incur any performance impact that can occur when changes are made. */
 interface DocumentFragment extends Node, NonElementParentNode, ParentNode {
     readonly ownerDocument: Document;
-    getElementById<E extends Element = HTMLElement>(elementId: string): E | null;
+    getElementById(elementId: string): HTMLElement | null;
 }
 
 declare var DocumentFragment: {
@@ -5216,7 +5216,7 @@ interface Element extends Node, Animatable, ChildNode, InnerHTML, NonDocumentTyp
     /**
      * Returns a HTMLCollection of the elements in the object on which the method was invoked (a document or an element) that have all the classes given by classNames. The classNames argument is interpreted as a space-separated list of classes.
      */
-    getElementsByClassName<E extends Element = HTMLElement>(classNames: string): HTMLCollectionOf<E>;
+    getElementsByClassName(classNames: string): HTMLCollectionOf<Element>;
     getElementsByTagName<K extends keyof HTMLElementTagNameMap>(qualifiedName: K): HTMLCollectionOf<HTMLElementTagNameMap[K]>;
     getElementsByTagName<K extends keyof SVGElementTagNameMap>(qualifiedName: K): HTMLCollectionOf<SVGElementTagNameMap[K]>;
     getElementsByTagName(qualifiedName: string): HTMLCollectionOf<Element>;
@@ -6671,7 +6671,6 @@ interface HTMLElement extends Element, DocumentAndElementEventHandlers, ElementC
     readonly offsetParent: Element | null;
     readonly offsetTop: number;
     readonly offsetWidth: number;
-    readonly parentElement: HTMLElement | null;
     spellcheck: boolean;
     title: string;
     translate: boolean;
@@ -10865,7 +10864,7 @@ interface Node extends EventTarget {
     /**
      * Returns the parent element.
      */
-    readonly parentElement: Element | null;
+    readonly parentElement: HTMLElement | null;
     /**
      * Returns the parent.
      */
@@ -11123,7 +11122,7 @@ interface NonElementParentNode {
     /**
      * Returns the first element within node's descendants whose ID is elementId.
      */
-    getElementById<E extends Element = HTMLElement>(elementId: string): E | null;
+    getElementById(elementId: string): Element | null;
 }
 
 interface NotificationEventMap {
@@ -13052,9 +13051,7 @@ interface SVGElement extends Element, DocumentAndElementEventHandlers, DocumentA
     /** @deprecated */
     readonly className: any;
     readonly ownerSVGElement: SVGSVGElement | null;
-    readonly parentElement: SVGElement | null;
     readonly viewportElement: SVGElement | null;
-    getElementsByClassName<E extends Element = SVGElement>(classNames: string): HTMLCollectionOf<E>;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13642,7 +13639,6 @@ interface SVGForeignObjectElement extends SVGGraphicsElement {
     readonly width: SVGAnimatedLength;
     readonly x: SVGAnimatedLength;
     readonly y: SVGAnimatedLength;
-    getElementsByClassName<E extends Element = HTMLElement>(classNames: string): HTMLCollectionOf<E>;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGForeignObjectElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGForeignObjectElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14446,7 +14442,7 @@ interface SVGSVGElement extends SVGGraphicsElement, DocumentEvent, SVGFitToViewB
     forceRedraw(): void;
     getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleDeclaration;
     getCurrentTime(): number;
-    getElementById<E extends Element = HTMLElement>(elementId: string): E | null;
+    getElementById(elementId: string): Element;
     getEnclosureList(rect: SVGRect, referenceElement: SVGElement | null): NodeListOf<SVGCircleElement | SVGEllipseElement | SVGImageElement | SVGLineElement | SVGPathElement | SVGPolygonElement | SVGPolylineElement | SVGRectElement | SVGTextElement | SVGUseElement>;
     getIntersectionList(rect: SVGRect, referenceElement: SVGElement | null): NodeListOf<SVGCircleElement | SVGEllipseElement | SVGImageElement | SVGLineElement | SVGPathElement | SVGPolygonElement | SVGPolylineElement | SVGRectElement | SVGTextElement | SVGUseElement>;
     pauseAnimations(): void;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -626,7 +626,7 @@
                         "getElementsByClassName": {
                             "name": "getElementsByClassName",
                             "override-signatures": [
-                                "getElementsByClassName<E extends Element = HTMLElement>(classNames: string): HTMLCollectionOf<E>"
+                                "getElementsByClassName(classNames: string): HTMLCollectionOf<Element>"
                             ]
                         },
                         "closest": {
@@ -988,7 +988,7 @@
                             "name": "getElementById",
                             "exposed": "Window",
                             "override-signatures": [
-                                "getElementById<E extends Element = HTMLElement>(elementId: string): E | null"
+                                "getElementById(elementId: string): HTMLElement | null"
                             ]
                         }
                     }

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1,32 +1,6 @@
 {
     "mixins": {
         "mixin": {
-            "NonElementParentNode": {
-                "name": "NonElementParentNode",
-                "methods": {
-                    "method": {
-                        "getElementById": {
-                            "name": "getElementById",
-                            "override-signatures": [
-                                "getElementById<E extends Element = HTMLElement>(elementId: string): E | null"
-                            ]
-                        }
-                    }
-                }
-            },
-            "GlobalFetch": {
-                "name": "GlobalFetch",
-                "methods": {
-                    "method": {
-                        "fetch": {
-                            "name": "fetch",
-                            "override-signatures": [
-                                "fetch(input: RequestInfo, init?: RequestInit): Promise<Response>"
-                            ]
-                        }
-                    }
-                }
-            },
             "Animatable": {
                 "name": "Animatable",
                 "methods": {
@@ -528,18 +502,6 @@
                 },
                 "override-index-signatures": []
             },
-            "HTMLElement": {
-                "name": "HTMLElement",
-                "properties": {
-                    "property": {
-                        "parentElement": {
-                            "name": "parentElement",
-                            "read-only": 1,
-                            "override-type": "HTMLElement | null"
-                        }
-                    }
-                }
-            },
             "Document": {
                 "name": "Document",
                 "methods": {
@@ -565,7 +527,7 @@
                         "getElementById": {
                             "name": "getElementById",
                             "override-signatures": [
-                                "getElementById<E extends Element = HTMLElement>(elementId: string): E | null"
+                                "getElementById(elementId: string): HTMLElement | null"
                             ]
                         },
                         "getElementsByTagNameNS": {
@@ -579,7 +541,7 @@
                         "getElementsByClassName": {
                             "name": "getElementsByClassName",
                             "override-signatures": [
-                                "getElementsByClassName<E extends Element = HTMLElement>(classNames: string): HTMLCollectionOf<E>"
+                                "getElementsByClassName(classNames: string): HTMLCollectionOf<Element>"
                             ]
                         },
                         "getElementsByName": {
@@ -728,7 +690,7 @@
                             "override-type": "Node & ParentNode | null"
                         },
                         "parentElement": {
-                            "override-type": "Element | null"
+                            "override-type": "HTMLElement | null"
                         },
                         "childNodes": {
                             "override-type": "NodeListOf<ChildNode>"
@@ -939,21 +901,6 @@
                             "deprecated": 1,
                             "name": "className",
                             "type": "any"
-                        },
-                        "parentElement": {
-                            "name": "parentElement",
-                            "read-only": 1,
-                            "override-type": "SVGElement | null"
-                        }
-                    }
-                },
-                "methods": {
-                    "method": {
-                        "getElementsByClassName": {
-                            "name": "getElementsByClassName",
-                            "override-signatures": [
-                                "getElementsByClassName<E extends Element = SVGElement>(classNames: string): HTMLCollectionOf<E>"
-                            ]
                         }
                     }
                 }
@@ -962,12 +909,6 @@
                 "name": "SVGSVGElement",
                 "methods": {
                     "method": {
-                        "getElementById": {
-                            "name": "getElementById",
-                            "override-signatures": [
-                                "getElementById<E extends Element = HTMLElement>(elementId: string): E | null"
-                            ]
-                        },
                         "getEnclosureList": {
                             "name": "getEnclosureList",
                             "override-signatures": [
@@ -995,19 +936,6 @@
                         "getCurrentTime": {
                             "name": "getCurrentTime",
                             "deprecated": 0
-                        }
-                    }
-                }
-            },
-            "SVGForeignObjectElement": {
-                "name": "SVGForeignObjectElement",
-                "methods": {
-                    "method": {
-                        "getElementsByClassName": {
-                            "name": "getElementsByClassName",
-                            "override-signatures": [
-                                "getElementsByClassName<E extends Element = HTMLElement>(classNames: string): HTMLCollectionOf<E>"
-                            ]
                         }
                     }
                 }


### PR DESCRIPTION
Reverts microsoft/TypeScript-DOM-lib-generator#885 - so that we can release 4.2 without this, it's not that this represents an end to the idea, but it is too breaking to DefinitelyTyped and so it's likely to be very breaking to the rest of the TS/JS ecosystem and we'd like to give it a longer look.