### PR TITLE
Make ImportMeta's url match the version in @types/node

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -595,7 +595,7 @@ interface ImageEncodeOptions {
 }
 
 interface ImportMeta {
-    url?: string;
+    url: string;
 }
 
 interface InputEventInit extends UIEventInit {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -244,7 +244,7 @@ interface ImageEncodeOptions {
 }
 
 interface ImportMeta {
-    url?: string;
+    url: string;
 }
 
 interface JsonWebKey {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -2301,7 +2301,8 @@
                     "member": {
                         "url": {
                             "name": "url",
-                            "type": "DOMString"
+                            "type": "DOMString",
+                            "required": 1
                         }
                     }
                 }


### PR DESCRIPTION
Correctly implements the hotfix I added to https://github.com/microsoft/TypeScript/pull/42230