### PR TITLE
fix: `window.opener` should be not be typed as any

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -18585,7 +18585,7 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
     onvrdisplaypointerrestricted: ((this: Window, ev: Event) => any) | null;
     onvrdisplaypointerunrestricted: ((this: Window, ev: Event) => any) | null;
     onvrdisplaypresentchange: ((this: Window, ev: Event) => any) | null;
-    opener: any;
+    opener: WindowProxy | null;
     /** @deprecated */
     readonly orientation: string | number;
     readonly outerHeight: number;
@@ -19635,7 +19635,7 @@ declare var onvrdisplayfocus: ((this: Window, ev: Event) => any) | null;
 declare var onvrdisplaypointerrestricted: ((this: Window, ev: Event) => any) | null;
 declare var onvrdisplaypointerunrestricted: ((this: Window, ev: Event) => any) | null;
 declare var onvrdisplaypresentchange: ((this: Window, ev: Event) => any) | null;
-declare var opener: any;
+declare var opener: WindowProxy | null;
 /** @deprecated */
 declare var orientation: string | number;
 declare var outerHeight: number;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -467,7 +467,7 @@
                         },
                         "opener": {
                             "name": "opener",
-                            "override-type": "any",
+                            "override-type": "WindowProxy | null",
                             "read-only": 0
                         },
                         "self": {


### PR DESCRIPTION
Fixes [microsoft/TypeScript#42433](https://github.com/microsoft/TypeScript/issues/42433)

I have not found a suitable IDL for window.opener, but you can find [here ](https://html.spec.whatwg.org/multipage/browsers.html#dom-opener) that window.opener can be specified as WindowProxy or null.



