### PR TITLE
fix: add loading attributes

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7084,6 +7084,10 @@ interface HTMLIFrameElement extends HTMLElement {
      */
     height: string;
     /**
+     * Sets or retrieves the policy for loading iframe elements that are outside the viewport.
+     */
+    loading: string;
+    /**
      * Sets or retrieves a URI to a long description of the object.
      */
     /** @deprecated */
@@ -7169,6 +7173,9 @@ interface HTMLImageElement extends HTMLElement {
      * Sets or retrieves whether the image is a server-side image map.
      */
     isMap: boolean;
+    /**
+     * Sets or retrieves the policy for loading image elements that are outside the viewport.
+     */
     loading: string;
     /**
      * Sets or retrieves a Uniform Resource Identifier (URI) to a long description of the object.

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7086,7 +7086,7 @@ interface HTMLIFrameElement extends HTMLElement {
     /**
      * Sets or retrieves the policy for loading iframe elements that are outside the viewport.
      */
-    loading: string;
+    loading: "eager" | "lazy";
     /**
      * Sets or retrieves a URI to a long description of the object.
      */
@@ -7176,7 +7176,7 @@ interface HTMLImageElement extends HTMLElement {
     /**
      * Sets or retrieves the policy for loading image elements that are outside the viewport.
      */
-    loading: string;
+    loading: "eager" | "lazy";
     /**
      * Sets or retrieves a Uniform Resource Identifier (URI) to a long description of the object.
      */

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -377,6 +377,10 @@
                         "decoding": {
                             "name": "decoding",
                             "override-type": "\"async\" | \"sync\" | \"auto\""
+                        },
+                        "loading": {
+                            "name": "loading",
+                            "override-type": "\"eager\" | \"lazy\""
                         }
                     }
                 },
@@ -738,6 +742,10 @@
                     "property": {
                         "referrerPolicy": {
                             "type": "ReferrerPolicy"
+                        },
+                        "loading": {
+                            "name": "loading",
+                            "override-type": "\"eager\" | \"lazy\""
                         }
                     }
                 },

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -567,6 +567,9 @@
                         "hspace": {
                             "comment": "/**\n * Sets or retrieves the width of the border to draw around the object.\n */"
                         },
+                        "loading": {
+                          "comment": "/**\n * Sets or retrieves the policy for loading image elements that are outside the viewport.\n */"
+                        },
                         "longDesc": {
                             "comment": "/**\n * Sets or retrieves a Uniform Resource Identifier (URI) to a long description of the object.\n */"
                         },
@@ -1028,6 +1031,9 @@
                         },
                         "contentDocument": {
                             "comment": "/**\n * Retrieves the document object of the page or frame.\n */"
+                        },
+                        "loading": {
+                          "comment": "/**\n * Sets or retrieves the policy for loading iframe elements that are outside the viewport.\n */"
                         },
                         "longDesc": {
                             "comment": "/**\n * Sets or retrieves a URI to a long description of the object.\n */"


### PR DESCRIPTION
- Add [`loading` attribuets for `<iframe>` element](https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element).
- Add a description of [`loading` attribuets for `<img>` element](https://html.spec.whatwg.org/#the-img-element).
- Use [`'eager' | 'lazy'` instead of `string` as a type for `loading` attributes](https://html.spec.whatwg.org/#lazy-loading-attributes)