### PR TITLE
add performanceservertiming

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -11687,6 +11687,7 @@ interface PerformanceResourceTiming extends PerformanceEntry {
     readonly responseEnd: number;
     readonly responseStart: number;
     readonly secureConnectionStart: number;
+    readonly serverTiming: ReadonlyArray<PerformanceServerTiming>;
     readonly transferSize: number;
     readonly workerStart: number;
     toJSON(): any;
@@ -11695,6 +11696,18 @@ interface PerformanceResourceTiming extends PerformanceEntry {
 declare var PerformanceResourceTiming: {
     prototype: PerformanceResourceTiming;
     new(): PerformanceResourceTiming;
+};
+
+interface PerformanceServerTiming {
+    readonly description: string;
+    readonly duration: number;
+    readonly name: string;
+    toJSON(): any;
+}
+
+declare var PerformanceServerTiming: {
+    prototype: PerformanceServerTiming;
+    new(): PerformanceServerTiming;
 };
 
 /** A legacy interface kept for backwards compatibility and contains properties that offer performance timing information for various events which occur during the loading and use of the current page. You get a PerformanceTiming object describing your page using the window.performance.timing property.

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2591,6 +2591,7 @@ interface PerformanceResourceTiming extends PerformanceEntry {
     readonly responseEnd: number;
     readonly responseStart: number;
     readonly secureConnectionStart: number;
+    readonly serverTiming: ReadonlyArray<PerformanceServerTiming>;
     readonly transferSize: number;
     readonly workerStart: number;
     toJSON(): any;
@@ -2599,6 +2600,18 @@ interface PerformanceResourceTiming extends PerformanceEntry {
 declare var PerformanceResourceTiming: {
     prototype: PerformanceResourceTiming;
     new(): PerformanceResourceTiming;
+};
+
+interface PerformanceServerTiming {
+    readonly description: string;
+    readonly duration: number;
+    readonly name: string;
+    toJSON(): any;
+}
+
+declare var PerformanceServerTiming: {
+    prototype: PerformanceServerTiming;
+    new(): PerformanceServerTiming;
 };
 
 interface PermissionStatusEventMap {

--- a/inputfiles/idl/Server Timing.widl
+++ b/inputfiles/idl/Server Timing.widl
@@ -1,0 +1,12 @@
+[Exposed=(Window,Worker)]
+interface PerformanceServerTiming {
+  readonly attribute DOMString name;
+  readonly attribute DOMHighResTimeStamp duration;
+  readonly attribute DOMString description;
+  [Default] object toJSON();
+};
+
+[Exposed=(Window,Worker)]
+partial interface PerformanceResourceTiming {
+  readonly attribute FrozenArray<PerformanceServerTiming> serverTiming;
+};

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -459,6 +459,10 @@
         "title": "Selection"
     },
     {
+        "url": "https://www.w3.org/TR/server-timing/",
+        "title": "Server Timing"
+    },
+    {
         "url": "https://w3c.github.io/ServiceWorker/",
         "title": "Service Workers"
     },


### PR DESCRIPTION
In the hopes of getting a discussion going around [PerformanceServerTiming](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceServerTiming) this implements the basic types as specified in [the WD spec](https://w3c.github.io/server-timing/#the-performanceservertiming-interface).

From the contributor guidelines:


 - [x] Does the new objects or fields show up in mdn/browser-compat-data? If not, it's likely too soon. (See [browser-compat-data](https://github.com/mdn/browser-compat-data/blob/master/api/PerformanceServerTiming.json))
- [ ] Is the IDL source from WHATWG? (No, W3C)
    - [x] Are the additions available in at least two of [Firefox](https://searchfox.org/mozilla-central/search?q=&path=), [Safari](https://webkit-search.igalia.com/webkit/search?q=&path=) and Chromium?
- [x] Is the IDL source from W3C?
    - [ ] What stage of the [W3C process](https://en.wikipedia.org/wiki/World_Wide_Web_Consortium#Specification_maturation) is the proposal for these changes: We aim for Proposed recommendation, but can accept Candidate recommendation for stable looking proposals. (Working Draft)
    - [x] If it's at Working draft the additions available in all three of Firefox, Safari and Chromium (Not Safari yet, but Chrome, Edge & Firefox)
- [x] Could any types added at the global scope have naming conflicts? (Doubtful unless someone is polyfilling these?)
- [x] Are the new features going to be used by a lot of people? (We'd like to use this on GitHub :shrug:)

From the [browser compat table on mdn](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceServerTiming#browser_compatibility) this API is available in Firefox 61, Chrome 65, Edge 79

[![browser compat table](https://user-images.githubusercontent.com/118266/109152914-0a68b000-7764-11eb-9d18-21b590909a3b.png)](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceServerTiming#browser_compatibility)
