### PR TITLE
feat(emitter): support differing accessor types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4538,7 +4538,8 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
     /**
      * Contains information about the current URL.
      */
-    location: Location;
+    get location(): Location;
+    set location(href: string | Location);
     onfullscreenchange: ((this: Document, ev: Event) => any) | null;
     onfullscreenerror: ((this: Document, ev: Event) => any) | null;
     onpointerlockchange: ((this: Document, ev: Event) => any) | null;
@@ -18225,7 +18226,8 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
     readonly innerHeight: number;
     readonly innerWidth: number;
     readonly length: number;
-    location: Location;
+    get location(): Location;
+    set location(href: string | Location);
     readonly locationbar: BarProp;
     readonly menubar: BarProp;
     readonly msContentScript: ExtensionScriptApis;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prettier": "^2.2.1",
     "print-diff": "^1.0.0",
     "styleless-innertext": "^1.1.2",
-    "typescript": "^4.2.3",
-    "webidl2": "^23.13.0"
+    "typescript": "^4.3.0-dev.20210327",
+    "webidl2": "^23.13.1"
   }
 }

--- a/src/widlprocess.ts
+++ b/src/widlprocess.ts
@@ -357,6 +357,7 @@ function convertAttribute(
     exposed:
       getExtAttrConcatenated(attribute.extAttrs, "Exposed") ||
       inheritedExposure,
+    "put-forwards": getExtAttr(attribute.extAttrs, "PutForwards")[0],
   };
 }
 


### PR DESCRIPTION
Thanks to https://github.com/microsoft/TypeScript/pull/42425

This turns out to be less interesting than I expected because of the setter type limitation where the getter type must be assignable to the setter type. Thus the following can't be supported:

```webidl
[Exposed=Window]
interface CSSStyleRule : CSSRule {
  attribute CSSOMString selectorText;
  [SameObject, PutForwards=cssText] readonly attribute CSSStyleDeclaration style;
};
```

```ts
interface CSSStyleRule extends CSSRule {
    selectorText: string;
    get style(): CSSStyleDeclaration;
    set style(cssText: string); // error!
}
```

```ts
document.body.style = "display: none" // thus still an error 🤔
```

Probably worth to file an issue, or does TS team think this is not a very interesting case?