### PR TITLE
fix: `DOMTokenList.replace` should return boolean

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4135,7 +4135,7 @@ interface DOMTokenList {
      *
      * Throws an "InvalidCharacterError" DOMException if one of the arguments contains any ASCII whitespace.
      */
-    replace(oldToken: string, newToken: string): void;
+    replace(token: string, newToken: string): boolean;
     /**
      * Returns true if token is in the associated attribute's supported tokens. Returns false otherwise.
      *

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1100,20 +1100,6 @@
                     }
                 }
             },
-            "DOMTokenList": {
-                "name": "DOMTokenList",
-                "exposed": "Window",
-                "methods": {
-                    "method": {
-                        "replace": {
-                            "name": "replace",
-                            "override-signatures": [
-                                "replace(oldToken: string, newToken: string): void"
-                            ]
-                        }
-                    }
-                }
-            },
             "EventSource": {
                 "events": {
                     "event": [


### PR DESCRIPTION
[`DOMTokenList.replace()` - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/replace)

[*Can I use...*](https://caniuse.com/mdn-api_domtokenlist_replace_boolean_value) website reports 91.93% support.