### PR TITLE
Add support for User-Agent Client Hints

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -859,6 +859,11 @@ interface NavigationPreloadState {
     headerValue?: string;
 }
 
+interface NavigatorUABrandVersion {
+    brand?: string;
+    version?: string;
+}
+
 interface NotificationAction {
     action: string;
     icon?: string;
@@ -1848,6 +1853,23 @@ interface TransitionEventInit extends EventInit {
     elapsedTime?: number;
     propertyName?: string;
     pseudoElement?: string;
+}
+
+interface UADataValues {
+    architecture?: string;
+    bitness?: string;
+    brands?: NavigatorUABrandVersion[];
+    mobile?: boolean;
+    model?: string;
+    platform?: string;
+    platformVersion?: string;
+    uaFullVersion?: string;
+}
+
+interface UALowEntropyJSON {
+    brands?: NavigatorUABrandVersion[];
+    mobile?: boolean;
+    platform?: string;
 }
 
 interface UIEventInit extends EventInit {
@@ -10569,7 +10591,7 @@ declare var NavigationPreloadManager: {
 };
 
 /** The state and the identity of the user agent. It allows scripts to query it and to register themselves to carry on some activities. */
-interface Navigator extends MSFileSaver, MSNavigatorDoNotTrack, NavigatorAutomationInformation, NavigatorBeacon, NavigatorConcurrentHardware, NavigatorContentUtils, NavigatorCookies, NavigatorID, NavigatorLanguage, NavigatorOnLine, NavigatorPlugins, NavigatorStorage {
+interface Navigator extends MSFileSaver, MSNavigatorDoNotTrack, NavigatorAutomationInformation, NavigatorBeacon, NavigatorConcurrentHardware, NavigatorContentUtils, NavigatorCookies, NavigatorID, NavigatorLanguage, NavigatorOnLine, NavigatorPlugins, NavigatorStorage, NavigatorUA {
     readonly activeVRDisplays: ReadonlyArray<VRDisplay>;
     readonly clipboard: Clipboard;
     readonly credentials: CredentialsContainer;
@@ -10649,6 +10671,23 @@ interface NavigatorPlugins {
 interface NavigatorStorage {
     readonly storage: StorageManager;
 }
+
+interface NavigatorUA {
+    readonly userAgentData: NavigatorUAData;
+}
+
+interface NavigatorUAData {
+    readonly brands: ReadonlyArray<NavigatorUABrandVersion>;
+    readonly mobile: boolean;
+    readonly platform: string;
+    getHighEntropyValues(hints: string[]): Promise<UADataValues>;
+    toJSON(): UALowEntropyJSON;
+}
+
+declare var NavigatorUAData: {
+    prototype: NavigatorUAData;
+    new(): NavigatorUAData;
+};
 
 /** Node is an interface from which a number of DOM API object types inherit. It allows those types to be treated similarly; for example, inheriting the same set of methods, or being tested in the same way. */
 interface Node extends EventTarget {

--- a/baselines/dom.iterable.generated.d.ts
+++ b/baselines/dom.iterable.generated.d.ts
@@ -148,6 +148,10 @@ interface Navigator {
     requestMediaKeySystemAccess(keySystem: string, supportedConfigurations: Iterable<MediaKeySystemConfiguration>): Promise<MediaKeySystemAccess>;
 }
 
+interface NavigatorUAData {
+    getHighEntropyValues(hints: Iterable<string>): Promise<UADataValues>;
+}
+
 interface NodeList {
     [Symbol.iterator](): IterableIterator<Node>;
     /**

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -294,6 +294,11 @@ interface NavigationPreloadState {
     headerValue?: string;
 }
 
+interface NavigatorUABrandVersion {
+    brand?: string;
+    version?: string;
+}
+
 interface NotificationAction {
     action: string;
     icon?: string;
@@ -555,6 +560,23 @@ interface Transformer<I = any, O = any> {
     start?: TransformerStartCallback<O>;
     transform?: TransformerTransformCallback<I, O>;
     writableType?: undefined;
+}
+
+interface UADataValues {
+    architecture?: string;
+    bitness?: string;
+    brands?: NavigatorUABrandVersion[];
+    mobile?: boolean;
+    model?: string;
+    platform?: string;
+    platformVersion?: string;
+    uaFullVersion?: string;
+}
+
+interface UALowEntropyJSON {
+    brands?: NavigatorUABrandVersion[];
+    mobile?: boolean;
+    platform?: string;
 }
 
 interface UnderlyingSink<W = any> {
@@ -2330,6 +2352,23 @@ interface NavigatorOnLine {
 interface NavigatorStorage {
     readonly storage: StorageManager;
 }
+
+interface NavigatorUA {
+    readonly userAgentData: NavigatorUAData;
+}
+
+interface NavigatorUAData {
+    readonly brands: ReadonlyArray<NavigatorUABrandVersion>;
+    readonly mobile: boolean;
+    readonly platform: string;
+    getHighEntropyValues(hints: string[]): Promise<UADataValues>;
+    toJSON(): UALowEntropyJSON;
+}
+
+declare var NavigatorUAData: {
+    prototype: NavigatorUAData;
+    new(): NavigatorUAData;
+};
 
 interface NotificationEventMap {
     "click": Event;
@@ -5453,7 +5492,7 @@ declare var WorkerLocation: {
 };
 
 /** A subset of the Navigator interface allowed to be accessed from a Worker. Such an object is initialized for each worker and is available via the WorkerGlobalScope.navigator property obtained by calling window.self.navigator. */
-interface WorkerNavigator extends NavigatorConcurrentHardware, NavigatorID, NavigatorLanguage, NavigatorOnLine, NavigatorStorage {
+interface WorkerNavigator extends NavigatorConcurrentHardware, NavigatorID, NavigatorLanguage, NavigatorOnLine, NavigatorStorage, NavigatorUA {
     readonly permissions: Permissions;
 }
 

--- a/baselines/webworker.iterable.generated.d.ts
+++ b/baselines/webworker.iterable.generated.d.ts
@@ -66,6 +66,10 @@ interface IDBObjectStore {
     createIndex(name: string, keyPath: string | Iterable<string>, options?: IDBIndexParameters): IDBIndex;
 }
 
+interface NavigatorUAData {
+    getHighEntropyValues(hints: Iterable<string>): Promise<UADataValues>;
+}
+
 interface URLSearchParams {
     [Symbol.iterator](): IterableIterator<[string, string]>;
     /**

--- a/inputfiles/idl/User-Agent Client Hints.widl
+++ b/inputfiles/idl/User-Agent Client Hints.widl
@@ -1,0 +1,37 @@
+dictionary NavigatorUABrandVersion {
+  DOMString brand;
+  DOMString version;
+};
+
+dictionary UADataValues {
+  sequence<NavigatorUABrandVersion> brands;
+  boolean mobile;
+  DOMString platform;
+  DOMString architecture;
+  DOMString bitness;
+  DOMString model;
+  DOMString platformVersion;
+  DOMString uaFullVersion;
+};
+
+dictionary UALowEntropyJSON {
+  sequence<NavigatorUABrandVersion> brands;
+  boolean mobile;
+  DOMString platform;
+};
+
+[Exposed=(Window,Worker)]
+interface NavigatorUAData {
+  readonly attribute FrozenArray<NavigatorUABrandVersion> brands;
+  readonly attribute boolean mobile;
+  readonly attribute DOMString platform;
+  Promise<UADataValues> getHighEntropyValues(sequence<DOMString> hints);
+  UALowEntropyJSON toJSON();
+};
+
+interface mixin NavigatorUA {
+  [SecureContext] readonly attribute NavigatorUAData userAgentData;
+};
+
+Navigator includes NavigatorUA;
+WorkerNavigator includes NavigatorUA;

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -519,6 +519,10 @@
         "title": "User Timing"
     },
     {
+        "url": "https://wicg.github.io/ua-client-hints/",
+        "title": "User-Agent Client Hints"
+    },
+    {
         "url": "https://www.w3.org/TR/vibration/",
         "title": "Vibration"
     },


### PR DESCRIPTION
Provides `navigator.userAgentData` for User-Agent Client Hints values as per https://wicg.github.io/ua-client-hints/