### PR TITLE
Gives @saschanaz the ability to merge PRs which affect src/baselines/inputfiles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+src/**/*.ts @saschanaz
+baselines/* @saschanaz
+inputfiles/**/* @saschanaz
+README.md @saschanaz

--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -1,0 +1,20 @@
+name: Codeowners merging
+on:
+  pull_request_target: { types: [opened] }
+  issue_comment: { types: [created] }
+  pull_request_review: { types: [submitted] }
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Run Codeowners merge check
+        uses: OSS-Docs-Tools/code-owner-self-merge@1.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          merge_method: 'squash'
+          if_no_maintainers_add_label: 'maintainers'
+          if_no_maintainers_assign: '@orta @sandersn'


### PR DESCRIPTION
By using https://github.com/OSS-Docs-Tools/code-owner-self-merge we get to give enough rights to @saschanaz while still conforming to the Microsoft security guidelines 