### PR TITLE
fix(1017) - SVGPathElement extends geometry

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2874,6 +2874,7 @@ interface CSSStyleDeclaration {
     cssFloat: string;
     cssText: string;
     cursor: string;
+    d: string;
     direction: string;
     display: string;
     dominantBaseline: string;
@@ -13771,11 +13772,7 @@ declare var SVGNumberList: {
 };
 
 /** Corresponds to the <path> element. */
-interface SVGPathElement extends SVGGraphicsElement {
-    /** @deprecated */
-    readonly pathSegList: SVGPathSegList;
-    getPointAtLength(distance: number): SVGPoint;
-    getTotalLength(): number;
+interface SVGPathElement extends SVGGeometryElement {
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGPathElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGPathElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -19207,7 +19204,6 @@ interface SVGElementTagNameMap {
     "marker": SVGMarkerElement;
     "mask": SVGMaskElement;
     "metadata": SVGMetadataElement;
-    "path": SVGPathElement;
     "pattern": SVGPatternElement;
     "polygon": SVGPolygonElement;
     "polyline": SVGPolylineElement;

--- a/inputfiles/idl/SVG - Paths.widl
+++ b/inputfiles/idl/SVG - Paths.widl
@@ -1,0 +1,7 @@
+[Exposed=Window]
+interface SVGPathElement : SVGGeometryElement {
+};
+
+partial interface CSSStyleDeclaration {
+  [CEReactions] attribute [LegacyNullToEmptyString] CSSOMString d;
+};

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -491,6 +491,10 @@
         "title": "SVG - Painting"
     },
     {
+        "url": "https://www.w3.org/TR/SVG2/paths.html",
+        "title": "SVG - Paths"
+    },
+    {
         "url": "https://www.w3.org/TR/SVG2/pservers.html",
         "title": "SVG - Paint Servers"
     },


### PR DESCRIPTION
Fixes #1017

Added the paths page found on MDN, which just includes this one interface. That change removes the deprecated property (it doesn't show up anywhere, removed in Chrome 48) and removes the duplicate methods (they are present on SVGGeometryElement).

For some reason `"path"` was removed from the `SVGElementTagNameMap`. I'm not sure how to fix that and any support would be appreciated!