### PR TITLE
fix(994) - WebAssembly errors extend Error

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -18776,7 +18776,7 @@ declare namespace CSS {
 }
 
 declare namespace WebAssembly {
-    interface CompileError {
+    interface CompileError extends Error {
     }
 
     var CompileError: {
@@ -18803,7 +18803,7 @@ declare namespace WebAssembly {
         new(module: Module, importObject?: Imports): Instance;
     };
 
-    interface LinkError {
+    interface LinkError extends Error {
     }
 
     var LinkError: {
@@ -18832,7 +18832,7 @@ declare namespace WebAssembly {
         imports(moduleObject: Module): ModuleImportDescriptor[];
     };
 
-    interface RuntimeError {
+    interface RuntimeError extends Error {
     }
 
     var RuntimeError: {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2615,6 +2615,21 @@
                         }
                     }
                 }
+            },
+            "CompileError": {
+                "name": "CompileError",
+                "extends": "Error",
+                "legacy-namespace": "WebAssembly"
+            },
+            "LinkError": {
+                "name": "LinkError",
+                "extends": "Error",
+                "legacy-namespace": "WebAssembly"
+            },
+            "RuntimeError": {
+                "name": "RuntimeError",
+                "extends": "Error",
+                "legacy-namespace": "WebAssembly"
             }
         }
     },


### PR DESCRIPTION
Fixes #994

[Errors in WebAssembly](https://webassembly.github.io/spec/js-api/#exceptiondef-compileerror) are located under the WebAssembly namespace and can't be expressed in WebIDL, according to the spec. Here, they've been overriden to extend the Error class as specified in the spec.