### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '15'
+          node-version: "15"
+          cache: npm
 
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
 
-  workflow_dispatch:
-
+  workflow_dispatch: null
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,18 +16,18 @@ jobs:
         with:
           node-version: "15.x"
           registry-url: "https://registry.npmjs.org"
+          cache: npm
 
       - run: npm install
       - run: npm run build
       - run: npm test
-  
+
       - name: Create packages for .d.ts files
         run: node deploy/createTypesPackages.mjs
-        
+
       # Deploy anything which differs from the npm version of a tsconfig
-      - name: 'Deploy built packages to NPM'
+      - name: "Deploy built packages to NPM"
         run: node deploy/deployChangedPackages.mjs
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        

--- a/.github/workflows/test_typescript.yml
+++ b/.github/workflows/test_typescript.yml
@@ -9,7 +9,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '15'
+          node-version: "15"
+          cache: npm
 
       - name: Run TypeScript Compiler Tests with new dom.d.ts
         run: |
@@ -39,4 +40,3 @@ jobs:
         run: npx danger -- ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/update-core-deps.yml
+++ b/.github/workflows/update-core-deps.yml
@@ -1,6 +1,6 @@
 name: Update core dependencies
 on:
-  workflow_dispatch:
+  workflow_dispatch: null
   schedule:
     # https://crontab.guru/#5_8_*_*_*
     - cron: "5 8 * * *"
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: '15'
+          node-version: "15"
+          cache: npm
 
       # Use ncu to detect major version changes
       - run: npm i -g npm-check-updates
@@ -32,4 +33,3 @@ jobs:
           title: "chore(package): update core dependencies"
           branch: update-core-deps
           token: ${{ secrets.TS_GITHUB_BOT_AUTH }}
-


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
