### PR TITLE
Scope the action to only run on our repo

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run Codeowners merge check
         uses: OSS-Docs-Tools/code-owner-self-merge@1.5.4
+        if: github.repository == microsoft/TypeScript-DOM-lib-generator
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Should probably fix the pings in https://github.com/Scharkee/TypeScript-DOM-lib-generator/pull/1#issuecomment-875600459