### PR TITLE
Wrap the repository name in codeowner checker

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Run Codeowners merge check
         uses: OSS-Docs-Tools/code-owner-self-merge@1.5.4
-        if: github.repository == microsoft/TypeScript-DOM-lib-generator
+        if: github.repository == 'microsoft/TypeScript-DOM-lib-generator'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
It currently is [causing syntax error](https://github.com/microsoft/TypeScript-DOM-lib-generator/actions/runs/1015022267). @orta