### PR TITLE
Add HTMLElement-returning getElementById to DocumentFragment

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4694,6 +4694,8 @@ interface DocumentAndElementEventHandlers {
 
 /** A minimal document object that has no parent. It is used as a lightweight version of Document that stores a segment of a document structure comprised of nodes just like a standard document. The key difference is that because the document fragment isn't part of the active document tree structure, changes made to the fragment don't affect the document, cause reflow, or incur any performance impact that can occur when changes are made. */
 interface DocumentFragment extends Node, NonElementParentNode, ParentNode {
+    readonly ownerDocument: Document;
+    getElementById(elementId: string): HTMLElement | null;
 }
 
 declare var DocumentFragment: {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -655,6 +655,27 @@
                     }
                 }
             },
+            "DocumentFragment": {
+                "methods": {
+                    "method": {
+                        "getElementById": {
+                            "name": "getElementById",
+                            "overrideSignatures": [
+                                "getElementById(elementId: string): HTMLElement | null"
+                            ]
+                        }
+                    }
+                },
+                "properties": {
+                    "property": {
+                        "ownerDocument": {
+                            "name": "ownerDocument",
+                            "readonly": 1,
+                            "type": "Document"
+                        }
+                    }
+                }
+            },
             "Node": {
                 "name": "Node",
                 "methods": {


### PR DESCRIPTION
This is copying what `document.getElementById` and `document.body.ownerDocument` currently looks like.

Regressed by b598925.

Fixes the DocumentFragment issue raised in #1067.