### PR TITLE
improve fetch body

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2427,7 +2427,7 @@ interface Body {
     arrayBuffer(): Promise<ArrayBuffer>;
     blob(): Promise<Blob>;
     formData(): Promise<FormData>;
-    json(): Promise<any>;
+    json<T = any>(): Promise<T>;
     text(): Promise<string>;
 }
 


### PR DESCRIPTION
the not is a break changes, but can improve developer experience

```typescript
const response = fetch(...)
// old method
const result = response.body() as Promise<Result>
// new method
const result = response.body<Result>()
```