### PR TITLE
fix(createObjectURL): use MDN type declaration

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14911,7 +14911,7 @@ interface URL {
 declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
-    createObjectURL(object: File | Blob | MediaSource): string;
+    createObjectURL(obj: Blob | MediaSource): string;
     revokeObjectURL(url: string): void;
 };
 

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14911,7 +14911,7 @@ interface URL {
 declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
-    createObjectURL(object: any): string;
+    createObjectURL(object: File | Blob | MediaSource): string;
     revokeObjectURL(url: string): void;
 };
 

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -3105,7 +3105,7 @@ interface URL {
 declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
-    createObjectURL(object: any): string;
+    createObjectURL(object: File | Blob | MediaSource): string;
 };
 
 interface URLSearchParams {

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -3105,7 +3105,6 @@ interface URL {
 declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
-    createObjectURL(object: File | Blob | MediaSource): string;
 };
 
 interface URLSearchParams {

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -2981,7 +2981,7 @@ interface URL {
 declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
-    createObjectURL(object: File | Blob | MediaSource): string;
+    createObjectURL(obj: Blob): string;
     revokeObjectURL(url: string): void;
 };
 

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -2981,7 +2981,7 @@ interface URL {
 declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
-    createObjectURL(object: any): string;
+    createObjectURL(object: File | Blob | MediaSource): string;
     revokeObjectURL(url: string): void;
 };
 

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -3188,7 +3188,7 @@ interface URL {
 declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
-    createObjectURL(object: any): string;
+    createObjectURL(object: File | Blob | MediaSource): string;
     revokeObjectURL(url: string): void;
 };
 

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -3188,7 +3188,7 @@ interface URL {
 declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
-    createObjectURL(object: File | Blob | MediaSource): string;
+    createObjectURL(obj: Blob): string;
     revokeObjectURL(url: string): void;
 };
 

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -402,19 +402,6 @@
                     }
                 }
             },
-            "URL": {
-                "name": "URL",
-                "methods": {
-                    "method": {
-                        "createObjectURL": {
-                            "exposed": "Window Worker",
-                            "overrideSignatures": [
-                                "createObjectURL(object: File | Blob | MediaSource): string"
-                            ]
-                        }
-                    }
-                }
-            },
             "NodeListOf": {
                 "name": "NodeListOf",
                 "typeParameters": [

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -409,7 +409,7 @@
                         "createObjectURL": {
                             "exposed": "Window Worker",
                             "overrideSignatures": [
-                                "createObjectURL(object: any): string"
+                                "createObjectURL(object: File | Blob | MediaSource): string"
                             ]
                         }
                     }


### PR DESCRIPTION
Changes `createObjectURL(object: any): string` to `createObjectURL(object: File | Blob | MediaSource): string`.

Makes type declaration inline with the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL).

Fixes #916.


