### PR TITLE
Restore HTMLDocument constructor

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -6044,6 +6044,12 @@ interface HTMLDocument extends Document {
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
 }
 
+/** @deprecated */
+declare var HTMLDocument: {
+    prototype: HTMLDocument;
+    new(): HTMLDocument;
+};
+
 interface HTMLElementEventMap extends ElementEventMap, DocumentAndElementEventHandlersEventMap, GlobalEventHandlersEventMap {
 }
 
@@ -16000,7 +16006,6 @@ interface WindowEventMap extends GlobalEventHandlersEventMap, WindowEventHandler
 
 /** A window containing a DOM document; the document property points to the DOM document loaded in that window. */
 interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandlers, WindowEventHandlers, WindowLocalStorage, WindowOrWorkerGlobalScope, WindowSessionStorage {
-    HTMLDocument: Document;
     /** @deprecated This is a legacy alias of `navigator`. */
     readonly clientInformation: Navigator;
     /** Returns true if the window has been closed, false otherwise. */
@@ -17035,7 +17040,6 @@ declare var Image: {
 declare var Option: {
     new(text?: string, value?: string, defaultSelected?: boolean, selected?: boolean): HTMLOptionElement;
 };
-declare var HTMLDocument: Document;
 /** @deprecated This is a legacy alias of `navigator`. */
 declare var clientInformation: Navigator;
 /** Returns true if the window has been closed, false otherwise. */

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -330,7 +330,6 @@
             "HTMLDocument": {
                 "name": "HTMLDocument",
                 "extends": "Document",
-                "noInterfaceObject": true,
                 "deprecated": "use Document",
                 "exposed": "Window"
             },
@@ -363,14 +362,6 @@
                     "method": {
                         "captureEvents": {
                             "deprecated": true
-                        }
-                    }
-                },
-                "properties": {
-                    "property": {
-                        "HTMLDocument": {
-                            "name": "HTMLDocument",
-                            "type": "Document"
                         }
                     }
                 },

--- a/unittests/files/htmldocument.ts
+++ b/unittests/files/htmldocument.ts
@@ -1,2 +1,1 @@
-const d = new HTMLDocument()
-const result = d instanceof HTMLDocument
+document instanceof HTMLDocument

--- a/unittests/files/htmldocument.ts
+++ b/unittests/files/htmldocument.ts
@@ -1,0 +1,2 @@
+const d = new HTMLDocument()
+const result = d instanceof HTMLDocument


### PR DESCRIPTION
Detected in https://github.com/microsoft/TypeScript/issues/45540, where it breaks ant-design. `x instanceof HTMLDocument` no longer works.

This is likely worth fixing before the release of 4.4.

Fixes #1115