### PR TITLE
Update codeowners-merge.yml

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Run Codeowners merge check
-        uses: OSS-Docs-Tools/code-owner-self-merge@1.5.4
+        uses: OSS-Docs-Tools/code-owner-self-merge@1.6.0
         if: github.repository == 'microsoft/TypeScript-DOM-lib-generator'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Bumps the version which adds https://github.com/OSS-Docs-Tools/code-owner-self-merge/releases/tag/v1.6.0