### PR TITLE
Add async iterable flavors

### DIFF
--- a/baselines/audioworklet.asynciterable.generated.d.ts
+++ b/baselines/audioworklet.asynciterable.generated.d.ts
@@ -1,0 +1,8 @@
+/////////////////////////////
+/// AudioWorklet Async Iterable APIs
+/////////////////////////////
+
+interface ReadableStream<R = any> {
+    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+}

--- a/baselines/audioworklet.asynciterable.generated.d.ts
+++ b/baselines/audioworklet.asynciterable.generated.d.ts
@@ -3,6 +3,6 @@
 /////////////////////////////
 
 interface ReadableStream<R = any> {
-    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
-    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<R>;
+    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<R>;
 }

--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -49,6 +49,17 @@ interface ReadableStreamDefaultReadValueResult<T> {
     value: T;
 }
 
+interface ReadableStreamIteratorOptions {
+    /**
+     * Asynchronously iterates over the chunks in the stream's internal queue.
+     *
+     * Asynchronously iterating over the stream will lock it, preventing any other consumer from acquiring a reader. The lock will be released if the async iterator's return() method is called, e.g. by breaking out of the loop.
+     *
+     * By default, calling the async iterator's return() method will also cancel the stream. To prevent this, use the stream's values() method, passing true for the preventCancel option.
+     */
+    preventCancel?: boolean;
+}
+
 interface ReadableWritablePair<R = any, W = any> {
     readable: ReadableStream<R>;
     /**

--- a/baselines/dom.asynciterable.generated.d.ts
+++ b/baselines/dom.asynciterable.generated.d.ts
@@ -3,6 +3,6 @@
 /////////////////////////////
 
 interface ReadableStream<R = any> {
-    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
-    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<R>;
+    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<R>;
 }

--- a/baselines/dom.asynciterable.generated.d.ts
+++ b/baselines/dom.asynciterable.generated.d.ts
@@ -1,0 +1,8 @@
+/////////////////////////////
+/// Window Async Iterable APIs
+/////////////////////////////
+
+interface ReadableStream<R = any> {
+    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+}

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1421,6 +1421,17 @@ interface ReadableStreamDefaultReadValueResult<T> {
     value: T;
 }
 
+interface ReadableStreamIteratorOptions {
+    /**
+     * Asynchronously iterates over the chunks in the stream's internal queue.
+     *
+     * Asynchronously iterating over the stream will lock it, preventing any other consumer from acquiring a reader. The lock will be released if the async iterator's return() method is called, e.g. by breaking out of the loop.
+     *
+     * By default, calling the async iterator's return() method will also cancel the stream. To prevent this, use the stream's values() method, passing true for the preventCancel option.
+     */
+    preventCancel?: boolean;
+}
+
 interface ReadableWritablePair<R = any, W = any> {
     readable: ReadableStream<R>;
     /**

--- a/baselines/serviceworker.asynciterable.generated.d.ts
+++ b/baselines/serviceworker.asynciterable.generated.d.ts
@@ -3,6 +3,6 @@
 /////////////////////////////
 
 interface ReadableStream<R = any> {
-    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
-    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<R>;
+    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<R>;
 }

--- a/baselines/serviceworker.asynciterable.generated.d.ts
+++ b/baselines/serviceworker.asynciterable.generated.d.ts
@@ -1,0 +1,8 @@
+/////////////////////////////
+/// ServiceWorker Async Iterable APIs
+/////////////////////////////
+
+interface ReadableStream<R = any> {
+    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+}

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -435,6 +435,17 @@ interface ReadableStreamDefaultReadValueResult<T> {
     value: T;
 }
 
+interface ReadableStreamIteratorOptions {
+    /**
+     * Asynchronously iterates over the chunks in the stream's internal queue.
+     *
+     * Asynchronously iterating over the stream will lock it, preventing any other consumer from acquiring a reader. The lock will be released if the async iterator's return() method is called, e.g. by breaking out of the loop.
+     *
+     * By default, calling the async iterator's return() method will also cancel the stream. To prevent this, use the stream's values() method, passing true for the preventCancel option.
+     */
+    preventCancel?: boolean;
+}
+
 interface ReadableWritablePair<R = any, W = any> {
     readable: ReadableStream<R>;
     /**

--- a/baselines/sharedworker.asynciterable.generated.d.ts
+++ b/baselines/sharedworker.asynciterable.generated.d.ts
@@ -3,6 +3,6 @@
 /////////////////////////////
 
 interface ReadableStream<R = any> {
-    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
-    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<R>;
+    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<R>;
 }

--- a/baselines/sharedworker.asynciterable.generated.d.ts
+++ b/baselines/sharedworker.asynciterable.generated.d.ts
@@ -1,0 +1,8 @@
+/////////////////////////////
+/// SharedWorker Async Iterable APIs
+/////////////////////////////
+
+interface ReadableStream<R = any> {
+    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+}

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -401,6 +401,17 @@ interface ReadableStreamDefaultReadValueResult<T> {
     value: T;
 }
 
+interface ReadableStreamIteratorOptions {
+    /**
+     * Asynchronously iterates over the chunks in the stream's internal queue.
+     *
+     * Asynchronously iterating over the stream will lock it, preventing any other consumer from acquiring a reader. The lock will be released if the async iterator's return() method is called, e.g. by breaking out of the loop.
+     *
+     * By default, calling the async iterator's return() method will also cancel the stream. To prevent this, use the stream's values() method, passing true for the preventCancel option.
+     */
+    preventCancel?: boolean;
+}
+
 interface ReadableWritablePair<R = any, W = any> {
     readable: ReadableStream<R>;
     /**

--- a/baselines/webworker.asynciterable.generated.d.ts
+++ b/baselines/webworker.asynciterable.generated.d.ts
@@ -3,6 +3,6 @@
 /////////////////////////////
 
 interface ReadableStream<R = any> {
-    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
-    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<R>;
+    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<R>;
 }

--- a/baselines/webworker.asynciterable.generated.d.ts
+++ b/baselines/webworker.asynciterable.generated.d.ts
@@ -1,0 +1,8 @@
+/////////////////////////////
+/// Worker Async Iterable APIs
+/////////////////////////////
+
+interface ReadableStream<R = any> {
+    [Symbol.asyncIterator](options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+    values(options?: ReadableStreamIteratorOptions): AsyncIterableIterator<any>;
+}

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -435,6 +435,17 @@ interface ReadableStreamDefaultReadValueResult<T> {
     value: T;
 }
 
+interface ReadableStreamIteratorOptions {
+    /**
+     * Asynchronously iterates over the chunks in the stream's internal queue.
+     *
+     * Asynchronously iterating over the stream will lock it, preventing any other consumer from acquiring a reader. The lock will be released if the async iterator's return() method is called, e.g. by breaking out of the loop.
+     *
+     * By default, calling the async iterator's return() method will also cancel the stream. To prevent this, use the stream's values() method, passing true for the preventCancel option.
+     */
+    preventCancel?: boolean;
+}
+
 interface ReadableWritablePair<R = any, W = any> {
     readable: ReadableStream<R>;
     /**

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2332,6 +2332,13 @@
                             }
                         }
                     }
+                },
+                "iterator": {
+                    "type": {
+                        "0": {
+                            "overrideType": "R"
+                        }
+                    }
                 }
             },
             "ReadableStreamDefaultReader": {

--- a/src/build.ts
+++ b/src/build.ts
@@ -42,16 +42,25 @@ async function emitFlavor(
   const exposed = getExposedTypes(webidl, options.global, forceKnownTypes);
   mergeNamesakes(exposed);
 
-  const result = emitWebIdl(exposed, options.global[0], false);
+  const result = emitWebIdl(exposed, options.global[0], "");
   await fs.writeFile(
     new URL(`${options.name}.generated.d.ts`, options.outputFolder),
     result
   );
 
-  const iterators = emitWebIdl(exposed, options.global[0], true);
+  const iterators = emitWebIdl(exposed, options.global[0], "sync");
   await fs.writeFile(
     new URL(`${options.name}.iterable.generated.d.ts`, options.outputFolder),
     iterators
+  );
+
+  const asyncIterators = emitWebIdl(exposed, options.global[0], "async");
+  await fs.writeFile(
+    new URL(
+      `${options.name}.asynciterable.generated.d.ts`,
+      options.outputFolder
+    ),
+    asyncIterators
   );
 }
 

--- a/src/build/emitter.ts
+++ b/src/build/emitter.ts
@@ -135,7 +135,7 @@ function isEventHandler(p: Browser.Property) {
 export function emitWebIdl(
   webidl: Browser.WebIdl,
   global: string,
-  iterator: boolean
+  iterator: "" | "sync" | "async"
 ): string {
   // Global print target
   const printer = createTextWriter("\n");
@@ -225,7 +225,14 @@ export function emitWebIdl(
     getParentsWithConstant
   );
 
-  return iterator ? emitES6DomIterators() : emit();
+  switch (iterator) {
+    case "sync":
+      return emitES6DomIterators();
+    case "async":
+      return emitES2018DomAsyncIterators();
+    default:
+      return emit();
+  }
 
   function getTagNameToElementNameMap() {
     const htmlResult: Record<string, string> = {};
@@ -400,7 +407,7 @@ export function emitWebIdl(
   }
 
   function convertDomTypeToTsTypeSimple(objDomType: string): string {
-    if (objDomType === "sequence" && iterator) {
+    if (objDomType === "sequence" && iterator !== "") {
       return "Iterable";
     }
     if (baseTypeConversionMap.has(objDomType)) {
@@ -996,7 +1003,7 @@ export function emitWebIdl(
 
   // Emit forEach for iterators
   function emitIteratorForEach(i: Browser.Interface) {
-    if (!i.iterator) {
+    if (!i.iterator || i.iterator.async) {
       return;
     }
     const subtype = i.iterator.type.map(convertDomTypeToTsType);
@@ -1518,7 +1525,7 @@ export function emitWebIdl(
     }
 
     function getIteratorSubtypes() {
-      if (i.iterator) {
+      if (i.iterator && !i.iterator.async) {
         if (i.iterator.type.length === 1) {
           return [convertDomTypeToTsType(i.iterator.type[0])];
         }
@@ -1682,6 +1689,90 @@ export function emitWebIdl(
     }
   }
 
+  function emitAsyncIterator(i: Browser.Interface) {
+    function getAsyncIteratorSubtypes() {
+      if (i.iterator && i.iterator.kind === "iterable" && i.iterator.async) {
+        if (i.iterator.type.length === 1) {
+          return [convertDomTypeToTsType(i.iterator.type[0])];
+        }
+        return i.iterator.type.map(convertDomTypeToTsType);
+      }
+    }
+
+    function stringifySingleOrTupleTypes(types: string[]) {
+      if (types.length === 1) {
+        return types[0];
+      }
+      return `[${types.join(", ")}]`;
+    }
+
+    function emitAsyncIterableDeclarationMethods(
+      i: Browser.Interface,
+      subtypes: string[],
+      paramsString: string
+    ) {
+      let methods;
+      if (subtypes.length === 1) {
+        // https://heycam.github.io/webidl/#value-asynchronously-iterable-declaration
+        const [valueType] = subtypes;
+        methods = [
+          {
+            name: "values",
+            definition: `AsyncIterableIterator<${valueType}>`,
+          },
+        ];
+      } else {
+        // https://heycam.github.io/webidl/#pair-asynchronously-iterable-declaration
+        const [keyType, valueType] = subtypes;
+        methods = [
+          {
+            name: "entries",
+            definition: `AsyncIterableIterator<[${keyType}, ${valueType}]>`,
+          },
+          {
+            name: "keys",
+            definition: `AsyncIterableIterator<${keyType}>`,
+          },
+          {
+            name: "values",
+            definition: `AsyncIterableIterator<${valueType}>`,
+          },
+        ];
+      }
+
+      const comments = i.iterator!.comments?.comment;
+
+      methods.forEach((m) => {
+        emitComments({ comment: comments?.[m.name] }, printer.printLine);
+        printer.printLine(`${m.name}(${paramsString}): ${m.definition};`);
+      });
+    }
+
+    const subtypes = getAsyncIteratorSubtypes();
+    if (subtypes) {
+      const name = getNameWithTypeParameter(
+        i.typeParameters,
+        extendConflictsBaseTypes[i.name] ? `${i.name}Base` : i.name
+      );
+      const paramsString = i.iterator!.param
+        ? paramsToString(i.iterator!.param)
+        : "";
+      printer.printLine("");
+      printer.printLine(`interface ${name} {`);
+      printer.increaseIndent();
+
+      printer.printLine(
+        `[Symbol.asyncIterator](${paramsString}): AsyncIterableIterator<${stringifySingleOrTupleTypes(
+          subtypes
+        )}>;`
+      );
+      emitAsyncIterableDeclarationMethods(i, subtypes, paramsString);
+
+      printer.decreaseIndent();
+      printer.printLine("}");
+    }
+  }
+
   function emitES6DomIterators() {
     printer.reset();
     printer.printLine("/////////////////////////////");
@@ -1689,6 +1780,17 @@ export function emitWebIdl(
     printer.printLine("/////////////////////////////");
 
     allInterfaces.sort(compareName).forEach(emitIterator);
+
+    return printer.getResult();
+  }
+
+  function emitES2018DomAsyncIterators() {
+    printer.reset();
+    printer.printLine("/////////////////////////////");
+    printer.printLine(`/// ${global} Async Iterable APIs`);
+    printer.printLine("/////////////////////////////");
+
+    allInterfaces.sort(compareName).forEach(emitAsyncIterator);
 
     return printer.getResult();
   }

--- a/src/build/emitter.ts
+++ b/src/build/emitter.ts
@@ -1505,6 +1505,13 @@ export function emitWebIdl(
     return printer.getResult();
   }
 
+  function stringifySingleOrTupleTypes(types: string[]) {
+    if (types.length === 1) {
+      return types[0];
+    }
+    return `[${types.join(", ")}]`;
+  }
+
   function emitIterator(i: Browser.Interface) {
     // https://heycam.github.io/webidl/#dfn-indexed-property-getter
     const isIndexedPropertyGetter = (m: Browser.AnonymousMethod) =>
@@ -1541,13 +1548,6 @@ export function emitWebIdl(
           ];
         }
       }
-    }
-
-    function stringifySingleOrTupleTypes(types: string[]) {
-      if (types.length === 1) {
-        return types[0];
-      }
-      return `[${types.join(", ")}]`;
     }
 
     function emitIterableDeclarationMethods(
@@ -1697,13 +1697,6 @@ export function emitWebIdl(
         }
         return i.iterator.type.map(convertDomTypeToTsType);
       }
-    }
-
-    function stringifySingleOrTupleTypes(types: string[]) {
-      if (types.length === 1) {
-        return types[0];
-      }
-      return `[${types.join(", ")}]`;
     }
 
     function emitAsyncIterableDeclarationMethods(

--- a/src/build/types.d.ts
+++ b/src/build/types.d.ts
@@ -196,7 +196,9 @@ export interface Interface {
 export interface Iterator {
   kind: "iterable" | "setlike" | "maplike";
   readonly: boolean;
+  async: boolean;
   type: Typed[];
+  param?: Param[];
   comments?: {
     comment: Record<string, string>;
   };

--- a/src/build/widlprocess.ts
+++ b/src/build/widlprocess.ts
@@ -199,13 +199,15 @@ function convertInterfaceCommon(
         addComments(method[member.name], commentMap, i.name, member.name);
       }
     } else if (
-      (member.type === "iterable" && !member.async) ||
+      member.type === "iterable" ||
       member.type === "maplike" ||
       member.type === "setlike"
     ) {
       result.iterator = {
         kind: member.type,
         readonly: member.readonly,
+        async: member.async,
+        param: member.arguments.map(convertArgument),
         type: member.idlType.map(convertIdlType),
       };
     }

--- a/src/test.ts
+++ b/src/test.ts
@@ -62,11 +62,21 @@ function test() {
       "dom.generated.d.ts",
       "dom.iterable.generated.d.ts"
     ) &&
+    compileGeneratedFiles(
+      "es2018",
+      "dom.generated.d.ts",
+      "dom.asynciterable.generated.d.ts"
+    ) &&
     compileGeneratedFiles("es5", "webworker.generated.d.ts") &&
     compileGeneratedFiles(
       "es6",
       "webworker.generated.d.ts",
       "webworker.iterable.generated.d.ts"
+    ) &&
+    compileGeneratedFiles(
+      "es2018",
+      "webworker.generated.d.ts",
+      "webworker.asynciterable.generated.d.ts"
     ) &&
     compileGeneratedFiles("es5", "sharedworker.generated.d.ts") &&
     compileGeneratedFiles(
@@ -74,17 +84,32 @@ function test() {
       "sharedworker.generated.d.ts",
       "sharedworker.iterable.generated.d.ts"
     ) &&
+    compileGeneratedFiles(
+      "es2018",
+      "sharedworker.generated.d.ts",
+      "sharedworker.asynciterable.generated.d.ts"
+    ) &&
     compileGeneratedFiles("es5", "serviceworker.generated.d.ts") &&
     compileGeneratedFiles(
       "es6",
       "serviceworker.generated.d.ts",
       "serviceworker.iterable.generated.d.ts"
     ) &&
+    compileGeneratedFiles(
+      "es2018",
+      "serviceworker.generated.d.ts",
+      "serviceworker.asynciterable.generated.d.ts"
+    ) &&
     compileGeneratedFiles("es5", "audioworklet.generated.d.ts") &&
     compileGeneratedFiles(
       "es6",
       "audioworklet.generated.d.ts",
       "audioworklet.iterable.generated.d.ts"
+    ) &&
+    compileGeneratedFiles(
+      "es2018",
+      "audioworklet.generated.d.ts",
+      "audioworklet.asynciterable.generated.d.ts"
     )
   ) {
     console.log("All tests passed.");


### PR DESCRIPTION
Add support for `async iterable` declarations [per Web IDL](https://heycam.github.io/webidl/#idl-async-iterable), and emit them as `.asynciterable.d.ts` flavors. This is an alternative solution for #1134, and a first step towards microsoft/TypeScript#29867.

Since this is currently only used by a single interface (`ReadableStream`), I understand that there's limited use for this. That's why I'm opening this as a draft PR for now: as a proof-of-concept on what this *could* look like, and as a starting point to discuss *if* we want to proceed with this. (If we don't want this, that's fine too, no hard feelings. 🙂)