### PR TITLE
Narrow ClipboardItem to match current Blink behaviour

### DIFF
--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2812,6 +2812,20 @@
             },
             "SourceBufferList": {
                 "exposed": "Window"
+            },
+            "ClipboardItem": {
+                "constructor": {
+                    "signature": {
+                        "0": {
+                            "param": [
+                                {
+                                    "name": "items",
+                                    "overrideType": "Record<string, ClipboardItemDataType>"
+                                }
+                            ]
+                        }
+                    }
+                }
             }
         }
     },
@@ -3104,6 +3118,10 @@
                         "name": "T"
                     }
                 ]
+            },
+            {
+                "overrideType": "Blob",
+                "name": "ClipboardItemDataType"
             }
         ]
     },


### PR DESCRIPTION
As per: https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1029#issuecomment-912975670

"The ClipboardItem constructor only accepts a blob as the item data,
but not strings or Promises that resolve to strings or blobs. See bug 1014310."

See:
 - https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem
 - https://bugs.chromium.org/p/chromium/issues/detail?id=1014310