### PR TITLE
Use special type for MediaRecorder error event

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -9013,7 +9013,7 @@ declare var MediaQueryListEvent: {
 
 interface MediaRecorderEventMap {
     "dataavailable": BlobEvent;
-    "error": Event;
+    "error": MediaRecorderErrorEvent;
     "pause": Event;
     "resume": Event;
     "start": Event;
@@ -9024,7 +9024,7 @@ interface MediaRecorder extends EventTarget {
     readonly audioBitsPerSecond: number;
     readonly mimeType: string;
     ondataavailable: ((this: MediaRecorder, ev: BlobEvent) => any) | null;
-    onerror: ((this: MediaRecorder, ev: Event) => any) | null;
+    onerror: ((this: MediaRecorder, ev: MediaRecorderErrorEvent) => any) | null;
     onpause: ((this: MediaRecorder, ev: Event) => any) | null;
     onresume: ((this: MediaRecorder, ev: Event) => any) | null;
     onstart: ((this: MediaRecorder, ev: Event) => any) | null;

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -882,6 +882,10 @@
                         {
                             "name": "dataavailable",
                             "type": "BlobEvent"
+                        },
+                        {
+                            "name": "error",
+                            "type": "MediaRecorderErrorEvent"
                         }
                     ]
                 }


### PR DESCRIPTION
The spec (https://w3c.github.io/mediacapture-record/#event-summary) specifies a specific event type MediaRecorderErrorEvent for the error event.

This ensures we're using it, similar to the dataavailable event.

Fixes #1138 

(I hope this is the correct way to do this 🙂)