### PR TITLE
Use lelia/forker instead of gh cli

### DIFF
--- a/.github/workflows/update-core-deps.yml
+++ b/.github/workflows/update-core-deps.yml
@@ -27,13 +27,11 @@ jobs:
         run: git diff --quiet HEAD baselines
         continue-on-error: true
       # TODO: Remove the following command after the fork is created
-      - env:
-          TS_TOKEN: ${{ secrets.TS_GITHUB_BOT_AUTH }}
-        run: |
-          echo $TS_TOKEN > ts_token
-          gh auth login --with-token < ts_token
-          gh repo fork --remote false
-          rm ts_token
+      - uses: lelia/forker@v0.0.1
+        with:
+          token: ${{ secrets.TS_GITHUB_BOT_AUTH }}
+          owner: microsoft
+          repo: TypeScript-DOM-lib-generator
         continue-on-error: true
       - uses: peter-evans/create-pull-request@v3
         if: ${{ steps.git-diff.outcome == 'failure' }}


### PR DESCRIPTION
I think `read:org` is only required for other features of `gh` and shouldn't be required for forking itself.