### PR TITLE
Fix: Add `transfer` type of `StructuredSerializeOptions`

### DIFF
--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -83,7 +83,7 @@ interface StreamPipeOptions {
 }
 
 interface StructuredSerializeOptions {
-    transfer?: any[];
+    transfer?: Transferable[];
 }
 
 interface Transformer<I = any, O = any> {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1628,7 +1628,7 @@ interface StreamPipeOptions {
 }
 
 interface StructuredSerializeOptions {
-    transfer?: any[];
+    transfer?: Transferable[];
 }
 
 interface SubmitEventInit extends EventInit {

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -558,7 +558,7 @@ interface StreamPipeOptions {
 }
 
 interface StructuredSerializeOptions {
-    transfer?: any[];
+    transfer?: Transferable[];
 }
 
 interface TextDecodeOptions {

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -524,7 +524,7 @@ interface StreamPipeOptions {
 }
 
 interface StructuredSerializeOptions {
-    transfer?: any[];
+    transfer?: Transferable[];
 }
 
 interface TextDecodeOptions {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -558,7 +558,7 @@ interface StreamPipeOptions {
 }
 
 interface StructuredSerializeOptions {
-    transfer?: any[];
+    transfer?: Transferable[];
 }
 
 interface TextDecodeOptions {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2830,6 +2830,15 @@
                     }
                 }
             },
+            "StructuredSerializeOptions": {
+                "members": {
+                    "member": {
+                        "transfer": {
+                            "overrideType": "Transferable[]"
+                        }
+                    }
+                }
+            },
             "MessageEventInit": {
                 "members": {
                     "member": {


### PR DESCRIPTION
Add `transfer` type of `StructuredSerializeOptions` for some `postMessage` methods.