### PR TITLE
Adjust `.parentElement` type to include `SVGElement`

### DIFF
--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -766,7 +766,7 @@
                             "overrideType": "ParentNode"
                         },
                         "parentElement": {
-                            "overrideType": "HTMLElement"
+                            "overrideType": "HTMLElement | SVGElement"
                         },
                         "childNodes": {
                             "overrideType": "NodeListOf<ChildNode>"


### PR DESCRIPTION
In reality, this also includes `| null` but this has been removed in https://github.com/microsoft/TypeScript-DOM-lib-generator/commit/2cd8ad3974b63affd454164028960821e77a2e17 so I guess you want to omit that for pragmatic reasons.

Originally this was typed as `Element | null` (and that probably was the most "correct" type) but that was changed to `HTMLELement | null` here: https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/560 . However, `SVGElement` can appear here in a lot of scenarios. 

An HTML element can be a parent of SVG (the simplest `<div><svg/></div>`), SVG element can be a parent of another SVG element (`<svg><rect/></svg>`) but also the SVG element can be a parent of an HTML element (`<svg><foreignObject><div></div></foreignObject></svg>`)