### PR TITLE
Add more specific types for globalCompositeOperation

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3245,7 +3245,7 @@ declare var CacheStorage: {
 
 interface CanvasCompositing {
     globalAlpha: number;
-    globalCompositeOperation: string;
+    globalCompositeOperation: GlobalCompositeOperation;
 }
 
 interface CanvasDrawImage {
@@ -17757,6 +17757,7 @@ type FontFaceSetLoadStatus = "loaded" | "loading";
 type FullscreenNavigationUI = "auto" | "hide" | "show";
 type GamepadHapticActuatorType = "vibration";
 type GamepadMappingType = "" | "standard" | "xr-standard";
+type GlobalCompositeOperation = "color" | "color-burn" | "color-dodge" | "copy" | "darken" | "destination-atop" | "destination-in" | "destination-out" | "destination-over" | "difference" | "exclusion" | "hard-light" | "hue" | "lighten" | "lighter" | "luminosity" | "multiply" | "overlay" | "saturation" | "screen" | "soft-light" | "source-atop" | "source-in" | "source-out" | "source-over" | "xor";
 type HdrMetadataType = "smpteSt2086" | "smpteSt2094-10" | "smpteSt2094-40";
 type IDBCursorDirection = "next" | "nextunique" | "prev" | "prevunique";
 type IDBRequestReadyState = "done" | "pending";

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -280,6 +280,37 @@
                 "value": [
                     "inprogress"
                 ]
+            },
+            "GlobalCompositeOperation": {
+                "name": "GlobalCompositeOperation",
+                "value": [
+                    "source-over",
+                    "source-in",
+                    "source-out",
+                    "source-atop",
+                    "destination-over",
+                    "destination-in",
+                    "destination-out",
+                    "destination-atop",
+                    "lighter",
+                    "copy",
+                    "xor",
+                    "multiply",
+                    "screen",
+                    "overlay",
+                    "darken",
+                    "lighten",
+                    "color-dodge",
+                    "color-burn",
+                    "hard-light",
+                    "soft-light",
+                    "difference",
+                    "exclusion",
+                    "hue",
+                    "saturation",
+                    "color",
+                    "luminosity"          
+                ]
             }
         }
     },

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -202,6 +202,15 @@
                     }
                 }
             },
+            "CanvasCompositing": {
+              "properties": {
+                "property": {
+                  "globalCompositeOperation": {
+                    "type": "GlobalCompositeOperation"
+                  }
+                }
+              }
+            },
             "Body": {
                 "properties": {
                     "property": {


### PR DESCRIPTION
Add types for `CanvasRenderingContext2D.globalCompositeOperation`, which is currently a `string` but should only accept certain values. The acceptable values come from [MDN](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/globalCompositeOperation).

Reported as a bug in TypeScript's main repo: https://github.com/microsoft/TypeScript/issues/34673