### PR TITLE
remove unnecessary type dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@octokit/rest": "^18.12.0",
     "@types/jsdom": "^16.2.13",
     "@types/node": "^16.10.5",
-    "@types/node-fetch": "^3.0.2",
     "@types/webidl2": "^23.13.6",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",


### PR DESCRIPTION
When installing dependencies, the following warning comes from `@types/node-fetch`
```bash
npm WARN deprecated @types/node-fetch@3.0.3: This is a stub types definition. node-fetch provides its own type definitions, so you do not need this installed.
```

Included types for `node-fetch` can be seen in the node fetch repository - https://github.com/node-fetch/node-fetch/tree/main/%40types


The `node-fetch` npm package also shows that type declarations are included - https://www.npmjs.com/package/node-fetch

![Screen Shot 2021-11-30 at 6 34 10 PM](https://user-images.githubusercontent.com/44626877/144088386-559cd91b-319c-4774-9ffe-633c808810fc.png)