### PR TITLE
Improve loading attribute for HTMLImageElement

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -6672,7 +6672,8 @@ interface HTMLImageElement extends HTMLElement {
     hspace: number;
     /** Sets or retrieves whether the image is a server-side image map. */
     isMap: boolean;
-    loading: string;
+    /** Sets or retrieves the policy for loading image elements that are outside the viewport. */
+    loading: "eager" | "lazy";
     /**
      * Sets or retrieves a Uniform Resource Identifier (URI) to a long description of the object.
      * @deprecated

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -356,7 +356,6 @@
                             "overrideType": "\"async\" | \"sync\" | \"auto\""
                         },
                         "loading": {
-                            "name": "loading",
                             "overrideType": "\"eager\" | \"lazy\""
                         }
                     }

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -309,7 +309,7 @@
                     "hue",
                     "saturation",
                     "color",
-                    "luminosity"          
+                    "luminosity"
                 ]
             }
         }
@@ -354,6 +354,10 @@
                         "decoding": {
                             "name": "decoding",
                             "overrideType": "\"async\" | \"sync\" | \"auto\""
+                        },
+                        "loading": {
+                            "name": "loading",
+                            "overrideType": "\"eager\" | \"lazy\""
                         }
                     }
                 }

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -553,6 +553,9 @@
                         "hspace": {
                             "comment": "Sets or retrieves the width of the border to draw around the object."
                         },
+                        "loading": {
+                            "comment": "Sets or retrieves the policy for loading image elements that are outside the viewport."
+                        },
                         "longDesc": {
                             "comment": "Sets or retrieves a Uniform Resource Identifier (URI) to a long description of the object."
                         },


### PR DESCRIPTION
[`loading` attribute for `<img>` element is going to be supported also by Safari](https://webkit.org/blog/12040/release-notes-for-safari-technology-preview-135/), [HTML element: img: loading](https://caniuse.com/mdn-html_elements_img_loading).

- Add a description of [`loading` attribuets for `<img>` element](https://html.spec.whatwg.org/#the-img-element).
- Use [`'eager' | 'lazy'` instead of `string` as a type for `loading` attributes](https://html.spec.whatwg.org/#lazy-loading-attributes)