### PR TITLE
 DOM lib: Add support for Trusted Types API

### DIFF
--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -241,6 +241,15 @@ declare var EventTarget: {
     new(): EventTarget;
 };
 
+interface InnerHTML {
+    innerHTML: string | TrustedHTML;
+}
+
+declare var InnerHTML: {
+    prototype: InnerHTML;
+    new(): InnerHTML;
+};
+
 /** A message received by a target object. */
 interface MessageEvent<T = any> extends Event {
     /** Returns the data of the message. */

--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -241,15 +241,6 @@ declare var EventTarget: {
     new(): EventTarget;
 };
 
-interface InnerHTML {
-    innerHTML: string | TrustedHTML;
-}
-
-declare var InnerHTML: {
-    prototype: InnerHTML;
-    new(): InnerHTML;
-};
-
 /** A message received by a target object. */
 interface MessageEvent<T = any> extends Event {
     /** Returns the data of the message. */

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8727,11 +8727,6 @@ interface InnerHTML {
     innerHTML: string | TrustedHTML;
 }
 
-declare var InnerHTML: {
-    prototype: InnerHTML;
-    new(): InnerHTML;
-};
-
 interface InputDeviceInfo extends MediaDeviceInfo {
 }
 

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3447,13 +3447,13 @@ interface ChildNode extends Node {
      *
      * Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
      */
-    after(...nodes: (Node | string)[]): void;
+    after(...nodes: (Node | string | TrustedScript)[]): void;
     /**
      * Inserts nodes just before node, while replacing strings in nodes with equivalent Text nodes.
      *
      * Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
      */
-    before(...nodes: (Node | string)[]): void;
+    before(...nodes: (Node | string | TrustedScript)[]): void;
     /** Removes node. */
     remove(): void;
     /**
@@ -3461,7 +3461,7 @@ interface ChildNode extends Node {
      *
      * Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
      */
-    replaceWith(...nodes: (Node | string)[]): void;
+    replaceWith(...nodes: (Node | string | TrustedScript)[]): void;
 }
 
 /** @deprecated */
@@ -3843,7 +3843,7 @@ interface DOMParser {
      *
      * Values other than the above for type will cause a TypeError exception to be thrown.
      */
-    parseFromString(string: string, type: DOMParserSupportedType): Document;
+    parseFromString(string: string | TrustedHTML, type: DOMParserSupportedType): Document;
 }
 
 declare var DOMParser: {
@@ -4459,7 +4459,7 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
      * @param value Value to assign.
      * @deprecated
      */
-    execCommand(commandId: string, showUI?: boolean, value?: string): boolean;
+    execCommand(commandId: string, showUI?: boolean, value?: string | TrustedHTML): boolean;
     /** Stops document's fullscreen element from being displayed fullscreen and resolves promise when done. */
     exitFullscreen(): Promise<void>;
     exitPictureInPicture(): Promise<void>;
@@ -4737,7 +4737,7 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, InnerHTML, Non
     readonly namespaceURI: string | null;
     onfullscreenchange: ((this: Element, ev: Event) => any) | null;
     onfullscreenerror: ((this: Element, ev: Event) => any) | null;
-    outerHTML: string;
+    outerHTML: string | TrustedHTML;
     readonly ownerDocument: Document;
     readonly part: DOMTokenList;
     /** Returns the namespace prefix. */
@@ -4784,7 +4784,7 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, InnerHTML, Non
     hasAttributes(): boolean;
     hasPointerCapture(pointerId: number): boolean;
     insertAdjacentElement(where: InsertPosition, element: Element): Element | null;
-    insertAdjacentHTML(position: InsertPosition, text: string): void;
+    insertAdjacentHTML(position: InsertPosition, text: string | TrustedHTML): void;
     insertAdjacentText(where: InsertPosition, data: string): void;
     /** Returns true if matching selectors against element's root yields element, and false otherwise. */
     matches(selectors: string): boolean;
@@ -6176,7 +6176,7 @@ interface HTMLElement extends Element, DocumentAndElementEventHandlers, ElementC
     dir: string;
     draggable: boolean;
     hidden: boolean;
-    innerText: string;
+    innerText: string | TrustedScript;
     lang: string;
     readonly offsetHeight: number;
     readonly offsetLeft: number;
@@ -6212,7 +6212,7 @@ interface HTMLEmbedElement extends HTMLElement {
      */
     name: string;
     /** Sets or retrieves a URL to be loaded by the object. */
-    src: string;
+    src: string | TrustedScriptURL;
     type: string;
     /** Sets or retrieves the width of the object. */
     width: string;
@@ -6637,7 +6637,7 @@ interface HTMLIFrameElement extends HTMLElement {
     /** Sets or retrieves a URL to be loaded by the object. */
     src: string;
     /** Sets or retrives the content of the page that is to contain. */
-    srcdoc: string;
+    srcdoc: string | TrustedHTML;
     /** Sets or retrieves the width of the object. */
     width: string;
     getSVGDocument(): Document | null;
@@ -7234,7 +7234,7 @@ interface HTMLObjectElement extends HTMLElement {
      * Sets or retrieves the URL of the component.
      * @deprecated
      */
-    codeBase: string;
+    codeBase: string | TrustedHTML;
     /**
      * Sets or retrieves the Internet media type for the code associated with the object.
      * @deprecated
@@ -7244,7 +7244,7 @@ interface HTMLObjectElement extends HTMLElement {
     readonly contentDocument: Document | null;
     readonly contentWindow: WindowProxy | null;
     /** Sets or retrieves the URL that references the data of the object. */
-    data: string;
+    data: string | TrustedHTML;
     /** @deprecated */
     declare: boolean;
     /** Retrieves a reference to the form that the object is embedded in. */
@@ -7550,9 +7550,9 @@ interface HTMLScriptElement extends HTMLElement {
     noModule: boolean;
     referrerPolicy: string;
     /** Retrieves the URL to an external file that contains the source code or data. */
-    src: string;
+    src: string | TrustedScriptURL;
     /** Retrieves or sets the text of the object as a string. */
-    text: string;
+    text: string | TrustedScript;
     /** Sets or retrieves the MIME type for the associated scripting engine. */
     type: string;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLScriptElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -8724,8 +8724,13 @@ declare var ImageData: {
 };
 
 interface InnerHTML {
-    innerHTML: string;
+    innerHTML: string | TrustedHTML;
 }
+
+declare var InnerHTML: {
+    prototype: InnerHTML;
+    new(): InnerHTML;
+};
 
 interface InputDeviceInfo extends MediaDeviceInfo {
 }
@@ -9723,7 +9728,7 @@ interface Node extends EventTarget {
     readonly parentNode: ParentNode | null;
     /** Returns the previous sibling. */
     readonly previousSibling: ChildNode | null;
-    textContent: string | null;
+    textContent: string | TrustedScript | null;
     appendChild<T extends Node>(node: T): T;
     /** Returns a copy of node. If deep is true, the copy also includes the node's descendants. */
     cloneNode(deep?: boolean): Node;
@@ -10076,13 +10081,13 @@ interface ParentNode extends Node {
      *
      * Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
      */
-    append(...nodes: (Node | string)[]): void;
+    append(...nodes: (Node | string | TrustedScript)[]): void;
     /**
      * Inserts nodes before the first child of node, while replacing strings in nodes with equivalent Text nodes.
      *
      * Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
      */
-    prepend(...nodes: (Node | string)[]): void;
+    prepend(...nodes: (Node | string | TrustedScript)[]): void;
     /** Returns the first element that is a descendant of node that matches selectors. */
     querySelector<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
     querySelector<K extends keyof SVGElementTagNameMap>(selectors: K): SVGElementTagNameMap[K] | null;
@@ -10096,7 +10101,7 @@ interface ParentNode extends Node {
      *
      * Throws a "HierarchyRequestError" DOMException if the constraints of the node tree are violated.
      */
-    replaceChildren(...nodes: (Node | string)[]): void;
+    replaceChildren(...nodes: (Node | string | TrustedScript)[]): void;
 }
 
 /** This Canvas 2D API interface is used to declare a path that can then be used on a CanvasRenderingContext2D object. The path methods of the CanvasRenderingContext2D interface are also present on this interface, which gives you the convenience of being able to retain and replay your path whenever desired. */
@@ -11012,7 +11017,7 @@ interface Range extends AbstractRange {
     compareBoundaryPoints(how: number, sourceRange: Range): number;
     /** Returns −1 if the point is before the range, 0 if the point is in the range, and 1 if the point is after the range. */
     comparePoint(node: Node, offset: number): number;
-    createContextualFragment(fragment: string): DocumentFragment;
+    createContextualFragment(fragment: string | TrustedHTML): DocumentFragment;
     deleteContents(): void;
     detach(): void;
     extractContents(): DocumentFragment;
@@ -11398,7 +11403,7 @@ declare var SVGAnimatedRect: {
 /** The SVGAnimatedString interface represents string attributes which can be animated from each SVG declaration. You need to create SVG attribute before doing anything else, everything should be declared inside this. */
 interface SVGAnimatedString {
     readonly animVal: string;
-    baseVal: string;
+    baseVal: string | TrustedScriptURL;
 }
 
 declare var SVGAnimatedString: {
@@ -13082,7 +13087,7 @@ interface ServiceWorkerContainer extends EventTarget {
     readonly ready: Promise<ServiceWorkerRegistration>;
     getRegistration(clientURL?: string | URL): Promise<ServiceWorkerRegistration | undefined>;
     getRegistrations(): Promise<ReadonlyArray<ServiceWorkerRegistration>>;
-    register(scriptURL: string | URL, options?: RegistrationOptions): Promise<ServiceWorkerRegistration>;
+    register(scriptURL: string | URL | TrustedScriptURL, options?: RegistrationOptions): Promise<ServiceWorkerRegistration>;
     startMessages(): void;
     addEventListener<K extends keyof ServiceWorkerContainerEventMap>(type: K, listener: (this: ServiceWorkerContainer, ev: ServiceWorkerContainerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -13158,7 +13163,7 @@ interface SharedWorker extends EventTarget, AbstractWorker {
 
 declare var SharedWorker: {
     prototype: SharedWorker;
-    new(scriptURL: string | URL, options?: string | WorkerOptions): SharedWorker;
+    new(scriptURL: string | URL | TrustedScriptURL, options?: string | WorkerOptions): SharedWorker;
 };
 
 interface Slottable {
@@ -16464,7 +16469,7 @@ interface Worker extends EventTarget, AbstractWorker {
 
 declare var Worker: {
     prototype: Worker;
-    new(scriptURL: string | URL, options?: WorkerOptions): Worker;
+    new(scriptURL: string | URL | TrustedScriptURL, options?: WorkerOptions): Worker;
 };
 
 /** Available only in secure contexts. */
@@ -17784,8 +17789,9 @@ type ReadableStreamReader<T> = ReadableStreamDefaultReader<T>;
 type RenderingContext = CanvasRenderingContext2D | ImageBitmapRenderingContext | WebGLRenderingContext | WebGL2RenderingContext;
 type RequestInfo = Request | string;
 type TexImageSource = ImageBitmap | ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement;
-type TimerHandler = string | Function;
+type TimerHandler = string | Function | TrustedScript;
 type Transferable = ArrayBuffer | MessagePort | ImageBitmap;
+type TrustedType = TrustedHTML | TrustedScript | TrustedScriptURL;
 type Uint32List = Uint32Array | GLuint[];
 type UvmEntries = UvmEntry[];
 type UvmEntry = number[];

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1703,6 +1703,12 @@ interface TransitionEventInit extends EventInit {
     pseudoElement?: string;
 }
 
+interface TrustedTypePolicyOptions {
+    createHTML?: CreateHTMLCallback | null;
+    createScript?: CreateScriptCallback | null;
+    createScriptURL?: CreateScriptURLCallback | null;
+}
+
 interface UIEventInit extends EventInit {
     detail?: number;
     view?: Window | null;
@@ -4544,11 +4550,13 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
      * Writes one or more HTML expressions to a document in the specified window.
      * @param content Specifies the text and HTML tags to write.
      */
+    write(text: TrustedHTML): void;
     write(...text: string[]): void;
     /**
      * Writes one or more HTML expressions, followed by a carriage return, to a document in the specified window.
      * @param content The text and HTML tags to write.
      */
+    writeln(text: TrustedHTML): void;
     writeln(...text: string[]): void;
     addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -13884,6 +13892,66 @@ declare var TreeWalker: {
     new(): TreeWalker;
 };
 
+interface TrustedHTML {
+    toJSON(): string;
+    toString(): string;
+}
+
+declare var TrustedHTML: {
+    prototype: TrustedHTML;
+    fromLiteral(templateStringsArray: any): TrustedHTML;
+    toString(): string;
+};
+
+interface TrustedScript {
+    toJSON(): string;
+    toString(): string;
+}
+
+declare var TrustedScript: {
+    prototype: TrustedScript;
+    fromLiteral(templateStringsArray: any): TrustedScript;
+    toString(): string;
+};
+
+interface TrustedScriptURL {
+    toJSON(): string;
+    toString(): string;
+}
+
+declare var TrustedScriptURL: {
+    prototype: TrustedScriptURL;
+    fromLiteral(templateStringsArray: any): TrustedScriptURL;
+    toString(): string;
+};
+
+interface TrustedTypePolicy {
+    readonly name: string;
+    createHTML(input: string, ...arguments: any[]): TrustedHTML;
+    createScript(input: string, ...arguments: any[]): TrustedScript;
+    createScriptURL(input: string, ...arguments: any[]): TrustedScriptURL;
+}
+
+declare var TrustedTypePolicy: {
+    prototype: TrustedTypePolicy;
+};
+
+interface TrustedTypePolicyFactory {
+    readonly defaultPolicy: TrustedTypePolicy | null;
+    readonly emptyHTML: TrustedHTML;
+    readonly emptyScript: TrustedScript;
+    createPolicy(policyName: string, policyOptions?: TrustedTypePolicyOptions): TrustedTypePolicy;
+    getAttributeType(tagName: string, attribute: string, elementNs?: string, attrNs?: string): string | null;
+    getPropertyType(tagName: string, property: string, elementNs?: string): string | null;
+    isHTML(value: any): boolean;
+    isScript(value: any): boolean;
+    isScriptURL(value: any): boolean;
+}
+
+declare var TrustedTypePolicyFactory: {
+    prototype: TrustedTypePolicyFactory;
+};
+
 /** Simple user interface events. */
 interface UIEvent extends Event {
     readonly detail: number;
@@ -16356,6 +16424,7 @@ interface WindowOrWorkerGlobalScope {
     readonly isSecureContext: boolean;
     readonly origin: string;
     readonly performance: Performance;
+    readonly trustedTypes: TrustedTypePolicyFactory;
     atob(data: string): string;
     btoa(data: string): string;
     clearInterval(id?: number): void;
@@ -16869,6 +16938,18 @@ declare namespace WebAssembly {
 
 interface BlobCallback {
     (blob: Blob | null): void;
+}
+
+interface CreateHTMLCallback {
+    (input: string, ...arguments: any[]): string;
+}
+
+interface CreateScriptCallback {
+    (input: string, ...arguments: any[]): string;
+}
+
+interface CreateScriptURLCallback {
+    (input: string, ...arguments: any[]): string;
 }
 
 interface CustomElementConstructor {
@@ -17631,6 +17712,7 @@ declare var indexedDB: IDBFactory;
 declare var isSecureContext: boolean;
 declare var origin: string;
 declare var performance: Performance;
+declare var trustedTypes: TrustedTypePolicyFactory;
 declare function atob(data: string): string;
 declare function btoa(data: string): string;
 declare function clearInterval(id?: number): void;

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -2043,15 +2043,6 @@ declare var ImageData: {
     new(data: Uint8ClampedArray, sw: number, sh?: number, settings?: ImageDataSettings): ImageData;
 };
 
-interface InnerHTML {
-    innerHTML: string | TrustedHTML;
-}
-
-declare var InnerHTML: {
-    prototype: InnerHTML;
-    new(): InnerHTML;
-};
-
 interface KHR_parallel_shader_compile {
     readonly COMPLETION_STATUS_KHR: GLenum;
 }

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -2043,6 +2043,15 @@ declare var ImageData: {
     new(data: Uint8ClampedArray, sw: number, sh?: number, settings?: ImageDataSettings): ImageData;
 };
 
+interface InnerHTML {
+    innerHTML: string | TrustedHTML;
+}
+
+declare var InnerHTML: {
+    prototype: InnerHTML;
+    new(): InnerHTML;
+};
+
 interface KHR_parallel_shader_compile {
     readonly COMPLETION_STATUS_KHR: GLenum;
 }
@@ -2681,7 +2690,7 @@ interface ServiceWorkerContainer extends EventTarget {
     readonly ready: Promise<ServiceWorkerRegistration>;
     getRegistration(clientURL?: string | URL): Promise<ServiceWorkerRegistration | undefined>;
     getRegistrations(): Promise<ReadonlyArray<ServiceWorkerRegistration>>;
-    register(scriptURL: string | URL, options?: RegistrationOptions): Promise<ServiceWorkerRegistration>;
+    register(scriptURL: string | URL | TrustedScriptURL, options?: RegistrationOptions): Promise<ServiceWorkerRegistration>;
     startMessages(): void;
     addEventListener<K extends keyof ServiceWorkerContainerEventMap>(type: K, listener: (this: ServiceWorkerContainer, ev: ServiceWorkerContainerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -5163,7 +5172,7 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
     /** Returns workerGlobal. */
     readonly self: WorkerGlobalScope & typeof globalThis;
     /** Fetches each URL in urls, executes them one-by-one in the order they are passed, and then returns (or throws if something went amiss). */
-    importScripts(...urls: (string | URL)[]): void;
+    importScripts(...urls: (string | URL | TrustedScriptURL)[]): void;
     addEventListener<K extends keyof WorkerGlobalScopeEventMap>(type: K, listener: (this: WorkerGlobalScope, ev: WorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof WorkerGlobalScopeEventMap>(type: K, listener: (this: WorkerGlobalScope, ev: WorkerGlobalScopeEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -5491,7 +5500,7 @@ declare var onunhandledrejection: ((this: ServiceWorkerGlobalScope, ev: PromiseR
 /** Returns workerGlobal. */
 declare var self: WorkerGlobalScope & typeof globalThis;
 /** Fetches each URL in urls, executes them one-by-one in the order they are passed, and then returns (or throws if something went amiss). */
-declare function importScripts(...urls: (string | URL)[]): void;
+declare function importScripts(...urls: (string | URL | TrustedScriptURL)[]): void;
 /** Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise. */
 declare function dispatchEvent(event: Event): boolean;
 declare var fonts: FontFaceSet;
@@ -5558,8 +5567,9 @@ type ReadableStreamDefaultReadResult<T> = ReadableStreamDefaultReadValueResult<T
 type ReadableStreamReader<T> = ReadableStreamDefaultReader<T>;
 type RequestInfo = Request | string;
 type TexImageSource = ImageBitmap | ImageData | OffscreenCanvas;
-type TimerHandler = string | Function;
+type TimerHandler = string | Function | TrustedScript;
 type Transferable = ArrayBuffer | MessagePort | ImageBitmap;
+type TrustedType = TrustedHTML | TrustedScript | TrustedScriptURL;
 type Uint32List = Uint32Array | GLuint[];
 type VibratePattern = number | number[];
 type XMLHttpRequestBodyInit = Blob | BufferSource | FormData | URLSearchParams | string;

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -595,6 +595,12 @@ interface Transformer<I = any, O = any> {
     writableType?: undefined;
 }
 
+interface TrustedTypePolicyOptions {
+    createHTML?: CreateHTMLCallback | null;
+    createScript?: CreateScriptCallback | null;
+    createScriptURL?: CreateScriptURLCallback | null;
+}
+
 interface UnderlyingSink<W = any> {
     abort?: UnderlyingSinkAbortCallback;
     close?: UnderlyingSinkCloseCallback;
@@ -2909,6 +2915,66 @@ declare var TransformStreamDefaultController: {
     new(): TransformStreamDefaultController;
 };
 
+interface TrustedHTML {
+    toJSON(): string;
+    toString(): string;
+}
+
+declare var TrustedHTML: {
+    prototype: TrustedHTML;
+    fromLiteral(templateStringsArray: any): TrustedHTML;
+    toString(): string;
+};
+
+interface TrustedScript {
+    toJSON(): string;
+    toString(): string;
+}
+
+declare var TrustedScript: {
+    prototype: TrustedScript;
+    fromLiteral(templateStringsArray: any): TrustedScript;
+    toString(): string;
+};
+
+interface TrustedScriptURL {
+    toJSON(): string;
+    toString(): string;
+}
+
+declare var TrustedScriptURL: {
+    prototype: TrustedScriptURL;
+    fromLiteral(templateStringsArray: any): TrustedScriptURL;
+    toString(): string;
+};
+
+interface TrustedTypePolicy {
+    readonly name: string;
+    createHTML(input: string, ...arguments: any[]): TrustedHTML;
+    createScript(input: string, ...arguments: any[]): TrustedScript;
+    createScriptURL(input: string, ...arguments: any[]): TrustedScriptURL;
+}
+
+declare var TrustedTypePolicy: {
+    prototype: TrustedTypePolicy;
+};
+
+interface TrustedTypePolicyFactory {
+    readonly defaultPolicy: TrustedTypePolicy | null;
+    readonly emptyHTML: TrustedHTML;
+    readonly emptyScript: TrustedScript;
+    createPolicy(policyName: string, policyOptions?: TrustedTypePolicyOptions): TrustedTypePolicy;
+    getAttributeType(tagName: string, attribute: string, elementNs?: string, attrNs?: string): string | null;
+    getPropertyType(tagName: string, property: string, elementNs?: string): string | null;
+    isHTML(value: any): boolean;
+    isScript(value: any): boolean;
+    isScriptURL(value: any): boolean;
+}
+
+declare var TrustedTypePolicyFactory: {
+    prototype: TrustedTypePolicyFactory;
+};
+
 /** The URL interface represents an object providing static methods used for creating object URLs. */
 interface URL {
     hash: string;
@@ -5059,6 +5125,7 @@ interface WindowOrWorkerGlobalScope {
     readonly isSecureContext: boolean;
     readonly origin: string;
     readonly performance: Performance;
+    readonly trustedTypes: TrustedTypePolicyFactory;
     atob(data: string): string;
     btoa(data: string): string;
     clearInterval(id?: number): void;
@@ -5330,6 +5397,18 @@ declare namespace WebAssembly {
     function validate(bytes: BufferSource): boolean;
 }
 
+interface CreateHTMLCallback {
+    (input: string, ...arguments: any[]): string;
+}
+
+interface CreateScriptCallback {
+    (input: string, ...arguments: any[]): string;
+}
+
+interface CreateScriptURLCallback {
+    (input: string, ...arguments: any[]): string;
+}
+
 interface OnErrorEventHandlerNonNull {
     (event: Event | string, source?: string, lineno?: number, colno?: number, error?: Error): any;
 }
@@ -5424,6 +5503,7 @@ declare var indexedDB: IDBFactory;
 declare var isSecureContext: boolean;
 declare var origin: string;
 declare var performance: Performance;
+declare var trustedTypes: TrustedTypePolicyFactory;
 declare function atob(data: string): string;
 declare function btoa(data: string): string;
 declare function clearInterval(id?: number): void;

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -561,6 +561,12 @@ interface Transformer<I = any, O = any> {
     writableType?: undefined;
 }
 
+interface TrustedTypePolicyOptions {
+    createHTML?: CreateHTMLCallback | null;
+    createScript?: CreateScriptCallback | null;
+    createScriptURL?: CreateScriptURLCallback | null;
+}
+
 interface UnderlyingSink<W = any> {
     abort?: UnderlyingSinkAbortCallback;
     close?: UnderlyingSinkCloseCallback;
@@ -2775,6 +2781,66 @@ declare var TransformStreamDefaultController: {
     new(): TransformStreamDefaultController;
 };
 
+interface TrustedHTML {
+    toJSON(): string;
+    toString(): string;
+}
+
+declare var TrustedHTML: {
+    prototype: TrustedHTML;
+    fromLiteral(templateStringsArray: any): TrustedHTML;
+    toString(): string;
+};
+
+interface TrustedScript {
+    toJSON(): string;
+    toString(): string;
+}
+
+declare var TrustedScript: {
+    prototype: TrustedScript;
+    fromLiteral(templateStringsArray: any): TrustedScript;
+    toString(): string;
+};
+
+interface TrustedScriptURL {
+    toJSON(): string;
+    toString(): string;
+}
+
+declare var TrustedScriptURL: {
+    prototype: TrustedScriptURL;
+    fromLiteral(templateStringsArray: any): TrustedScriptURL;
+    toString(): string;
+};
+
+interface TrustedTypePolicy {
+    readonly name: string;
+    createHTML(input: string, ...arguments: any[]): TrustedHTML;
+    createScript(input: string, ...arguments: any[]): TrustedScript;
+    createScriptURL(input: string, ...arguments: any[]): TrustedScriptURL;
+}
+
+declare var TrustedTypePolicy: {
+    prototype: TrustedTypePolicy;
+};
+
+interface TrustedTypePolicyFactory {
+    readonly defaultPolicy: TrustedTypePolicy | null;
+    readonly emptyHTML: TrustedHTML;
+    readonly emptyScript: TrustedScript;
+    createPolicy(policyName: string, policyOptions?: TrustedTypePolicyOptions): TrustedTypePolicy;
+    getAttributeType(tagName: string, attribute: string, elementNs?: string, attrNs?: string): string | null;
+    getPropertyType(tagName: string, property: string, elementNs?: string): string | null;
+    isHTML(value: any): boolean;
+    isScript(value: any): boolean;
+    isScriptURL(value: any): boolean;
+}
+
+declare var TrustedTypePolicyFactory: {
+    prototype: TrustedTypePolicyFactory;
+};
+
 /** The URL interface represents an object providing static methods used for creating object URLs. */
 interface URL {
     hash: string;
@@ -4914,6 +4980,7 @@ interface WindowOrWorkerGlobalScope {
     readonly isSecureContext: boolean;
     readonly origin: string;
     readonly performance: Performance;
+    readonly trustedTypes: TrustedTypePolicyFactory;
     atob(data: string): string;
     btoa(data: string): string;
     clearInterval(id?: number): void;
@@ -5353,6 +5420,18 @@ declare namespace WebAssembly {
     function validate(bytes: BufferSource): boolean;
 }
 
+interface CreateHTMLCallback {
+    (input: string, ...arguments: any[]): string;
+}
+
+interface CreateScriptCallback {
+    (input: string, ...arguments: any[]): string;
+}
+
+interface CreateScriptURLCallback {
+    (input: string, ...arguments: any[]): string;
+}
+
 interface OnErrorEventHandlerNonNull {
     (event: Event | string, source?: string, lineno?: number, colno?: number, error?: Error): any;
 }
@@ -5441,6 +5520,7 @@ declare var indexedDB: IDBFactory;
 declare var isSecureContext: boolean;
 declare var origin: string;
 declare var performance: Performance;
+declare var trustedTypes: TrustedTypePolicyFactory;
 declare function atob(data: string): string;
 declare function btoa(data: string): string;
 declare function clearInterval(id?: number): void;

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -1963,6 +1963,15 @@ declare var ImageData: {
     new(data: Uint8ClampedArray, sw: number, sh?: number, settings?: ImageDataSettings): ImageData;
 };
 
+interface InnerHTML {
+    innerHTML: string | TrustedHTML;
+}
+
+declare var InnerHTML: {
+    prototype: InnerHTML;
+    new(): InnerHTML;
+};
+
 interface KHR_parallel_shader_compile {
     readonly COMPLETION_STATUS_KHR: GLenum;
 }
@@ -2561,7 +2570,7 @@ interface ServiceWorkerContainer extends EventTarget {
     readonly ready: Promise<ServiceWorkerRegistration>;
     getRegistration(clientURL?: string | URL): Promise<ServiceWorkerRegistration | undefined>;
     getRegistrations(): Promise<ReadonlyArray<ServiceWorkerRegistration>>;
-    register(scriptURL: string | URL, options?: RegistrationOptions): Promise<ServiceWorkerRegistration>;
+    register(scriptURL: string | URL | TrustedScriptURL, options?: RegistrationOptions): Promise<ServiceWorkerRegistration>;
     startMessages(): void;
     addEventListener<K extends keyof ServiceWorkerContainerEventMap>(type: K, listener: (this: ServiceWorkerContainer, ev: ServiceWorkerContainerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -5016,7 +5025,7 @@ interface Worker extends EventTarget, AbstractWorker {
 
 declare var Worker: {
     prototype: Worker;
-    new(scriptURL: string | URL, options?: WorkerOptions): Worker;
+    new(scriptURL: string | URL | TrustedScriptURL, options?: WorkerOptions): Worker;
 };
 
 interface WorkerGlobalScopeEventMap {
@@ -5043,7 +5052,7 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
     /** Returns workerGlobal. */
     readonly self: WorkerGlobalScope & typeof globalThis;
     /** Fetches each URL in urls, executes them one-by-one in the order they are passed, and then returns (or throws if something went amiss). */
-    importScripts(...urls: (string | URL)[]): void;
+    importScripts(...urls: (string | URL | TrustedScriptURL)[]): void;
     addEventListener<K extends keyof WorkerGlobalScopeEventMap>(type: K, listener: (this: WorkerGlobalScope, ev: WorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof WorkerGlobalScopeEventMap>(type: K, listener: (this: WorkerGlobalScope, ev: WorkerGlobalScopeEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -5508,7 +5517,7 @@ declare var onunhandledrejection: ((this: SharedWorkerGlobalScope, ev: PromiseRe
 /** Returns workerGlobal. */
 declare var self: WorkerGlobalScope & typeof globalThis;
 /** Fetches each URL in urls, executes them one-by-one in the order they are passed, and then returns (or throws if something went amiss). */
-declare function importScripts(...urls: (string | URL)[]): void;
+declare function importScripts(...urls: (string | URL | TrustedScriptURL)[]): void;
 /** Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise. */
 declare function dispatchEvent(event: Event): boolean;
 declare var fonts: FontFaceSet;
@@ -5574,8 +5583,9 @@ type ReadableStreamDefaultReadResult<T> = ReadableStreamDefaultReadValueResult<T
 type ReadableStreamReader<T> = ReadableStreamDefaultReader<T>;
 type RequestInfo = Request | string;
 type TexImageSource = ImageBitmap | ImageData | OffscreenCanvas;
-type TimerHandler = string | Function;
+type TimerHandler = string | Function | TrustedScript;
 type Transferable = ArrayBuffer | MessagePort | ImageBitmap;
+type TrustedType = TrustedHTML | TrustedScript | TrustedScriptURL;
 type Uint32List = Uint32Array | GLuint[];
 type VibratePattern = number | number[];
 type XMLHttpRequestBodyInit = Blob | BufferSource | FormData | URLSearchParams | string;

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -1963,15 +1963,6 @@ declare var ImageData: {
     new(data: Uint8ClampedArray, sw: number, sh?: number, settings?: ImageDataSettings): ImageData;
 };
 
-interface InnerHTML {
-    innerHTML: string | TrustedHTML;
-}
-
-declare var InnerHTML: {
-    prototype: InnerHTML;
-    new(): InnerHTML;
-};
-
 interface KHR_parallel_shader_compile {
     readonly COMPLETION_STATUS_KHR: GLenum;
 }

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2095,6 +2095,15 @@ declare var ImageData: {
     new(data: Uint8ClampedArray, sw: number, sh?: number, settings?: ImageDataSettings): ImageData;
 };
 
+interface InnerHTML {
+    innerHTML: string | TrustedHTML;
+}
+
+declare var InnerHTML: {
+    prototype: InnerHTML;
+    new(): InnerHTML;
+};
+
 interface KHR_parallel_shader_compile {
     readonly COMPLETION_STATUS_KHR: GLenum;
 }
@@ -2733,7 +2742,7 @@ interface ServiceWorkerContainer extends EventTarget {
     readonly ready: Promise<ServiceWorkerRegistration>;
     getRegistration(clientURL?: string | URL): Promise<ServiceWorkerRegistration | undefined>;
     getRegistrations(): Promise<ReadonlyArray<ServiceWorkerRegistration>>;
-    register(scriptURL: string | URL, options?: RegistrationOptions): Promise<ServiceWorkerRegistration>;
+    register(scriptURL: string | URL | TrustedScriptURL, options?: RegistrationOptions): Promise<ServiceWorkerRegistration>;
     startMessages(): void;
     addEventListener<K extends keyof ServiceWorkerContainerEventMap>(type: K, listener: (this: ServiceWorkerContainer, ev: ServiceWorkerContainerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -5236,7 +5245,7 @@ interface Worker extends EventTarget, AbstractWorker {
 
 declare var Worker: {
     prototype: Worker;
-    new(scriptURL: string | URL, options?: WorkerOptions): Worker;
+    new(scriptURL: string | URL | TrustedScriptURL, options?: WorkerOptions): Worker;
 };
 
 interface WorkerGlobalScopeEventMap {
@@ -5263,7 +5272,7 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
     /** Returns workerGlobal. */
     readonly self: WorkerGlobalScope & typeof globalThis;
     /** Fetches each URL in urls, executes them one-by-one in the order they are passed, and then returns (or throws if something went amiss). */
-    importScripts(...urls: (string | URL)[]): void;
+    importScripts(...urls: (string | URL | TrustedScriptURL)[]): void;
     addEventListener<K extends keyof WorkerGlobalScopeEventMap>(type: K, listener: (this: WorkerGlobalScope, ev: WorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof WorkerGlobalScopeEventMap>(type: K, listener: (this: WorkerGlobalScope, ev: WorkerGlobalScopeEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -5736,7 +5745,7 @@ declare var onunhandledrejection: ((this: DedicatedWorkerGlobalScope, ev: Promis
 /** Returns workerGlobal. */
 declare var self: WorkerGlobalScope & typeof globalThis;
 /** Fetches each URL in urls, executes them one-by-one in the order they are passed, and then returns (or throws if something went amiss). */
-declare function importScripts(...urls: (string | URL)[]): void;
+declare function importScripts(...urls: (string | URL | TrustedScriptURL)[]): void;
 /** Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise. */
 declare function dispatchEvent(event: Event): boolean;
 declare var fonts: FontFaceSet;
@@ -5805,8 +5814,9 @@ type ReadableStreamDefaultReadResult<T> = ReadableStreamDefaultReadValueResult<T
 type ReadableStreamReader<T> = ReadableStreamDefaultReader<T>;
 type RequestInfo = Request | string;
 type TexImageSource = ImageBitmap | ImageData | OffscreenCanvas;
-type TimerHandler = string | Function;
+type TimerHandler = string | Function | TrustedScript;
 type Transferable = ArrayBuffer | MessagePort | ImageBitmap;
+type TrustedType = TrustedHTML | TrustedScript | TrustedScriptURL;
 type Uint32List = Uint32Array | GLuint[];
 type VibratePattern = number | number[];
 type XMLHttpRequestBodyInit = Blob | BufferSource | FormData | URLSearchParams | string;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -595,6 +595,12 @@ interface Transformer<I = any, O = any> {
     writableType?: undefined;
 }
 
+interface TrustedTypePolicyOptions {
+    createHTML?: CreateHTMLCallback | null;
+    createScript?: CreateScriptCallback | null;
+    createScriptURL?: CreateScriptURLCallback | null;
+}
+
 interface UnderlyingSink<W = any> {
     abort?: UnderlyingSinkAbortCallback;
     close?: UnderlyingSinkCloseCallback;
@@ -2982,6 +2988,66 @@ declare var TransformStreamDefaultController: {
     new(): TransformStreamDefaultController;
 };
 
+interface TrustedHTML {
+    toJSON(): string;
+    toString(): string;
+}
+
+declare var TrustedHTML: {
+    prototype: TrustedHTML;
+    fromLiteral(templateStringsArray: any): TrustedHTML;
+    toString(): string;
+};
+
+interface TrustedScript {
+    toJSON(): string;
+    toString(): string;
+}
+
+declare var TrustedScript: {
+    prototype: TrustedScript;
+    fromLiteral(templateStringsArray: any): TrustedScript;
+    toString(): string;
+};
+
+interface TrustedScriptURL {
+    toJSON(): string;
+    toString(): string;
+}
+
+declare var TrustedScriptURL: {
+    prototype: TrustedScriptURL;
+    fromLiteral(templateStringsArray: any): TrustedScriptURL;
+    toString(): string;
+};
+
+interface TrustedTypePolicy {
+    readonly name: string;
+    createHTML(input: string, ...arguments: any[]): TrustedHTML;
+    createScript(input: string, ...arguments: any[]): TrustedScript;
+    createScriptURL(input: string, ...arguments: any[]): TrustedScriptURL;
+}
+
+declare var TrustedTypePolicy: {
+    prototype: TrustedTypePolicy;
+};
+
+interface TrustedTypePolicyFactory {
+    readonly defaultPolicy: TrustedTypePolicy | null;
+    readonly emptyHTML: TrustedHTML;
+    readonly emptyScript: TrustedScript;
+    createPolicy(policyName: string, policyOptions?: TrustedTypePolicyOptions): TrustedTypePolicy;
+    getAttributeType(tagName: string, attribute: string, elementNs?: string, attrNs?: string): string | null;
+    getPropertyType(tagName: string, property: string, elementNs?: string): string | null;
+    isHTML(value: any): boolean;
+    isScript(value: any): boolean;
+    isScriptURL(value: any): boolean;
+}
+
+declare var TrustedTypePolicyFactory: {
+    prototype: TrustedTypePolicyFactory;
+};
+
 /** The URL interface represents an object providing static methods used for creating object URLs. */
 interface URL {
     hash: string;
@@ -5134,6 +5200,7 @@ interface WindowOrWorkerGlobalScope {
     readonly isSecureContext: boolean;
     readonly origin: string;
     readonly performance: Performance;
+    readonly trustedTypes: TrustedTypePolicyFactory;
     atob(data: string): string;
     btoa(data: string): string;
     clearInterval(id?: number): void;
@@ -5573,6 +5640,18 @@ declare namespace WebAssembly {
     function validate(bytes: BufferSource): boolean;
 }
 
+interface CreateHTMLCallback {
+    (input: string, ...arguments: any[]): string;
+}
+
+interface CreateScriptCallback {
+    (input: string, ...arguments: any[]): string;
+}
+
+interface CreateScriptURLCallback {
+    (input: string, ...arguments: any[]): string;
+}
+
 interface FrameRequestCallback {
     (time: DOMHighResTimeStamp): void;
 }
@@ -5669,6 +5748,7 @@ declare var indexedDB: IDBFactory;
 declare var isSecureContext: boolean;
 declare var origin: string;
 declare var performance: Performance;
+declare var trustedTypes: TrustedTypePolicyFactory;
 declare function atob(data: string): string;
 declare function btoa(data: string): string;
 declare function clearInterval(id?: number): void;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2095,15 +2095,6 @@ declare var ImageData: {
     new(data: Uint8ClampedArray, sw: number, sh?: number, settings?: ImageDataSettings): ImageData;
 };
 
-interface InnerHTML {
-    innerHTML: string | TrustedHTML;
-}
-
-declare var InnerHTML: {
-    prototype: InnerHTML;
-    new(): InnerHTML;
-};
-
 interface KHR_parallel_shader_compile {
     readonly COMPLETION_STATUS_KHR: GLenum;
 }

--- a/inputfiles/knownTypes.json
+++ b/inputfiles/knownTypes.json
@@ -50,6 +50,7 @@
         "RTCStatsType",
         "RTCTransportStats",
         "Transferable",
+        "TrustedType",
         "VideoFacingModeEnum"
     ],
     "Worker": [
@@ -80,7 +81,8 @@
         "RsaKeyGenParams",
         "RsaOaepParams",
         "RsaPssParams",
-        "Transferable"
+        "Transferable",
+        "TrustedType"
     ],
     "Worklet": [
         "EventListenerOrEventListenerObject",

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -305,6 +305,17 @@
                         }
                     }
                 }
+            },
+            "InnerHTML": {
+                "name": "InnerHTML",
+                "properties": {
+                    "property": {
+                        "innerHTML": {
+                            "name": "innerHTML",
+                            "overrideType": "string | TrustedHTML"
+                        }
+                    }
+                }
             }
         }
     },
@@ -3070,17 +3081,6 @@
                         },
                         "text": {
                             "overrideType": "string | TrustedScript"
-                        }
-                    }
-                }
-            },
-            "InnerHTML": {
-                "name": "InnerHTML",
-                "properties": {
-                    "property": {
-                        "innerHTML": {
-                            "name": "innerHTML",
-                            "overrideType": "string | TrustedHTML"
                         }
                     }
                 }

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -612,6 +612,18 @@
                                     "overrideType": "NodeListOf<HTMLElement>"
                                 }
                             }
+                        },
+                        "write": {
+                            "name": "write",
+                            "additionalSignatures": [
+                                "write(text: TrustedHTML): void"
+                            ]
+                        },
+                        "writeln": {
+                            "name": "writeln",
+                            "additionalSignatures": [
+                                "writeln(text: TrustedHTML): void"
+                            ]
                         }
                     }
                 },
@@ -2821,6 +2833,36 @@
             },
             "SourceBufferList": {
                 "exposed": "Window"
+            },
+            "TrustedHTML": {
+                "name": "TrustedHTML",
+                "constructor": {
+                    "signature": []
+                }
+            },
+            "TrustedScript": {
+                "name": "TrustedScript",
+                "constructor": {
+                    "signature": []
+                }
+            },
+            "TrustedScriptURL": {
+                "name": "TrustedScriptURL",
+                "constructor": {
+                    "signature": []
+                }
+            },
+            "TrustedTypePolicy": {
+                "name": "TrustedTypePolicy",
+                "constructor": {
+                    "signature": []
+                }
+            },
+            "TrustedTypePolicyFactory": {
+                "name": "TrustedTypePolicyFactory",
+                "constructor": {
+                    "signature": []
+                }
             }
         }
     },

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2,10 +2,96 @@
     "mixins": {
         "mixin": {
             "ChildNode": {
-                "extends": "Node"
+                "extends": "Node",
+                "methods": {
+                    "method": {
+                        "after": {
+                            "name": "after",
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "nodes",
+                                            "overrideType": "Node | string | TrustedScript"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "before": {
+                            "name": "before",
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "nodes",
+                                            "overrideType": "Node | string | TrustedScript"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "replaceWith": {
+                            "name": "replaceWith",
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "nodes",
+                                            "overrideType": "Node | string | TrustedScript"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
             },
             "ParentNode": {
-                "extends": "Node"
+                "extends": "Node",
+                "methods": {
+                    "method": {
+                        "append": {
+                            "name": "append",
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "nodes",
+                                            "overrideType": "Node | string | TrustedScript"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "prepend": {
+                            "name": "prepend",
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "nodes",
+                                            "overrideType": "Node | string | TrustedScript"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "replaceChildren": {
+                            "name": "replaceChildren",
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "nodes",
+                                            "overrideType": "Node | string | TrustedScript"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
             },
             "Animatable": {
                 "methods": {
@@ -613,6 +699,19 @@
                                 }
                             }
                         },
+                        "execCommand": {
+                            "name": "execCommand",
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "value",
+                                            "overrideType": "string | TrustedHTML"
+                                        }
+                                    ]
+                                }
+                            }
+                        },
                         "write": {
                             "name": "write",
                             "additionalSignatures": [
@@ -803,6 +902,9 @@
                         },
                         "previousSibling": {
                             "overrideType": "ChildNode"
+                        },
+                        "textContent": {
+                            "overrideType": "string | TrustedScript"
                         }
                     }
                 }
@@ -1252,6 +1354,27 @@
                                     "overrideType": "HTMLCollectionOf<Element>"
                                 }
                             }
+                        },
+                        "insertAdjacentHTML": {
+                            "name": "insertAdjacentHTML",
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "text",
+                                            "overrideType": "string | TrustedHTML"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                },
+                "properties": {
+                    "property": {
+                        "outerHTML": {
+                            "name": "outerHTML",
+                            "overrideType": "string | TrustedHTML"
                         }
                     }
                 }
@@ -1712,6 +1835,18 @@
                                     "overrideType": "Promise<ServiceWorkerRegistration | undefined>"
                                 }
                             }
+                        },
+                        "register": {
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "scriptURL",
+                                            "overrideType": "string | URL | TrustedScriptURL"
+                                        }
+                                    ]
+                                }
+                            }
                         }
                     }
                 },
@@ -2123,6 +2258,18 @@
                             "type": "MessageEvent"
                         }
                     ]
+                },
+                "constructor": {
+                    "signature": {
+                        "0": {
+                            "param": [
+                                {
+                                    "name": "scriptURL",
+                                    "overrideType": "string | URL | TrustedScriptURL"
+                                }
+                            ]
+                        }
+                    }
                 }
             },
             "Crypto": {
@@ -2716,6 +2863,23 @@
                             "type": "ErrorEvent"
                         }
                     ]
+                },
+                "methods": {
+                    "method": {
+                        "importScripts": {
+                            "name": "importScripts",
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "urls",
+                                            "overrideType": "string | URL | TrustedScriptURL"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
                 }
             },
             "Instance": {
@@ -2833,6 +2997,136 @@
             },
             "SourceBufferList": {
                 "exposed": "Window"
+            },
+            "DOMParser": {
+                "name": "DOMParser",
+                "methods": {
+                    "method": {
+                        "parseFromString": {
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "string",
+                                            "overrideType": "string | TrustedHTML"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "HTMLElement": {
+                "name": "HTMLElement",
+                "properties": {
+                    "property": {
+                        "innerText": {
+                            "overrideType": "string | TrustedScript"
+                        }
+                    }
+                }
+            },
+            "HTMLEmbedElement": {
+                "name": "HTMLEmbedElement",
+                "properties": {
+                    "property": {
+                        "src": {
+                            "overrideType": "string | TrustedScriptURL"
+                        }
+                    }
+                }
+
+            },
+            "HTMLIFrameElement": {
+                "name": "HTMLIFrameElement",
+                "properties": {
+                    "property": {
+                        "srcdoc": {
+                            "overrideType": "string | TrustedHTML"
+                        }
+                    }
+                }
+            },
+            "HTMLObjectElement": {
+                "name": "HTMLObjectElement",
+                "properties": {
+                    "property": {
+                        "codeBase": {
+                            "overrideType": "string | TrustedHTML"
+                        },
+                        "data": {
+                            "overrideType": "string | TrustedHTML"
+                        }
+                    }
+                }
+            },
+            "HTMLScriptElement": {
+                "name": "HTMLScriptElement",
+                "properties": {
+                    "property": {
+                        "src": {
+                            "overrideType": "string | TrustedScriptURL"
+                        },
+                        "text": {
+                            "overrideType": "string | TrustedScript"
+                        }
+                    }
+                }
+            },
+            "InnerHTML": {
+                "name": "InnerHTML",
+                "properties": {
+                    "property": {
+                        "innerHTML": {
+                            "name": "innerHTML",
+                            "overrideType": "string | TrustedHTML"
+                        }
+                    }
+                }
+            },
+            "Range": {
+                "name": "Range",
+                "methods": {
+                    "method": {
+                        "createContextualFragment": {
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "fragment",
+                                            "overrideType": "string | TrustedHTML"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "SharedWorker": {
+                "constructor": {
+                    "signature": {
+                        "0": {
+                            "param": [
+                                {
+                                    "name": "scriptURL",
+                                    "overrideType": "string | URL | TrustedScriptURL"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "SVGAnimatedString": {
+                "properties": {
+                    "property": {
+                        "baseVal": {
+                            "name": "baseVal",
+                            "overrideType": "string | TrustedScriptURL"
+                        }
+                    }
+                }
             },
             "TrustedHTML": {
                 "name": "TrustedHTML",
@@ -3186,6 +3480,10 @@
                         "name": "T"
                     }
                 ]
+            },
+            {
+                "name": "TimerHandler",
+                "overrideType": "string | Function | TrustedScript"
             }
         ]
     },

--- a/src/build/bcd/keep-alive.ts
+++ b/src/build/bcd/keep-alive.ts
@@ -44,6 +44,22 @@ export const forceKeepAlive: Record<string, string[]> = {
   MediaCapabilities: ["encodingInfo"],
   RTCDtlsTransport: ["onstatechange", "state"],
   RTCPeerConnection: ["canTrickleIceCandidates"],
+  TrustedHTML: ["fromLiteral", "toJSON"],
+  TrustedScript: ["fromLiteral", "toJSON"],
+  TrustedScriptURL: ["fromLiteral", "toJSON"],
+  TrustedTypePolicy: ["createHTML", "createScript", "createScriptURL", "name"],
+  TrustedTypePolicyFactory: [
+    "createPolicy",
+    "defaultPolicy",
+    "emptyHTML",
+    "emptyScript",
+    "getAttributeType",
+    "getPropertyType",
+    "getTypeMapping",
+    "isHTML",
+    "isScript",
+    "isScriptURL",
+  ],
   WebGLRenderingContextBase: ["lineWidth"],
   WebGL2RenderingContextOverloads: [
     // These are implemented in WebGLRenderingContext and WebGL2RenderingContext separately
@@ -64,5 +80,6 @@ export const forceKeepAlive: Record<string, string[]> = {
     "uniform4iv",
   ],
   WindowEventHandlers: ["onpagehide", "onpageshow"],
+  WindowOrWorkerGlobalScope: ["trustedTypes"],
   WorkerGlobalScope: ["onrejectionhandled", "onunhandledrejection"],
 };


### PR DESCRIPTION
This PR adds support for Trusted Types APIs and Sinks in dom and worker libraries. These APIs are so far only supported by Blink. In https://github.com/microsoft/TypeScript/issues/30024 we seem to be getting an agreement to include this change anyway. 