### PR TITLE
Add Task Scheduling API

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1555,6 +1555,18 @@ interface SVGBoundingBoxOptions {
     stroke?: boolean;
 }
 
+interface SchedulerPostTaskOptions {
+    delay?: number;
+    priority?: TaskPriority;
+    signal?: AbortSignal;
+}
+
+interface Scheduler {
+    postTask<T, P extends readonly unknown[] | []>(callback: (...params: P) => T, options?: SchedulerPostTaskOptions, ...arguments: P): Promise<T>;
+}
+
+declare var scheduler: Scheduler;
+
 interface ScrollIntoViewOptions extends ScrollOptions {
     block?: ScrollLogicalPosition;
     inline?: ScrollLogicalPosition;
@@ -1663,6 +1675,22 @@ interface StructuredSerializeOptions {
 
 interface SubmitEventInit extends EventInit {
     submitter?: HTMLElement | null;
+}
+
+interface TaskSignal extends AbortSignal {
+    readonly priority: TaskPriority;
+    onprioritychange: ((this: TaskSignal, ev: Event) => any) | null;
+    addEventListener<K extends keyof TaskSignalEventMap>(type: K, listener: (this: TaskSignal, ev: TaskSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof TaskSignalEventMap>(type: K, listener: (this: TaskSignal, ev: TaskSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+}
+
+declare var TaskSignal: {
+    prototype: TaskSignal;
+    new(): TaskSignal;
+}
+
+interface TaskSignalEventMap extends AbortSignalEventMap {
+    "prioritychange": Event;
 }
 
 interface TextDecodeOptions {
@@ -17915,6 +17943,7 @@ type ServiceWorkerUpdateViaCache = "all" | "imports" | "none";
 type ShadowRootMode = "closed" | "open";
 type SlotAssignmentMode = "manual" | "named";
 type SpeechSynthesisErrorCode = "audio-busy" | "audio-hardware" | "canceled" | "interrupted" | "invalid-argument" | "language-unavailable" | "network" | "not-allowed" | "synthesis-failed" | "synthesis-unavailable" | "text-too-long" | "voice-unavailable";
+type TaskPriority = "user-blocking" | "user-visible" | "background";
 type TextTrackKind = "captions" | "chapters" | "descriptions" | "metadata" | "subtitles";
 type TextTrackMode = "disabled" | "hidden" | "showing";
 type TouchType = "direct" | "stylus";

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1689,7 +1689,7 @@ declare var TaskSignal: {
     new(): TaskSignal;
 }
 
-interface TaskSignalEventMap extends AbortSignalEventMap {
+interface TaskSignalEventMap {
     "prioritychange": Event;
 }
 

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -543,6 +543,18 @@ interface RsaPssParams extends Algorithm {
     saltLength: number;
 }
 
+interface SchedulerPostTaskOptions {
+    delay?: number;
+    priority?: TaskPriority;
+    signal?: AbortSignal;
+}
+
+interface Scheduler {
+    postTask<T, P extends readonly unknown[] | []>(callback: (...params: P) => T, options?: SchedulerPostTaskOptions, ...arguments: P): Promise<T>;
+}
+
+declare var scheduler: Scheduler;
+
 interface SecurityPolicyViolationEventInit extends EventInit {
     blockedURI?: string;
     columnNumber?: number;
@@ -589,6 +601,22 @@ interface StreamPipeOptions {
 
 interface StructuredSerializeOptions {
     transfer?: Transferable[];
+}
+
+interface TaskSignal extends AbortSignal {
+    readonly priority: TaskPriority;
+    onprioritychange: ((this: TaskSignal, ev: Event) => any) | null;
+    addEventListener<K extends keyof TaskSignalEventMap>(type: K, listener: (this: TaskSignal, ev: TaskSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof TaskSignalEventMap>(type: K, listener: (this: TaskSignal, ev: TaskSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+}
+
+declare var TaskSignal: {
+    prototype: TaskSignal;
+    new(): TaskSignal;
+}
+
+interface TaskSignalEventMap {
+    "prioritychange": Event;
 }
 
 interface TextDecodeOptions {
@@ -5569,6 +5597,7 @@ type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | "opaquer
 type SecurityPolicyViolationEventDisposition = "enforce" | "report";
 type ServiceWorkerState = "activated" | "activating" | "installed" | "installing" | "parsed" | "redundant";
 type ServiceWorkerUpdateViaCache = "all" | "imports" | "none";
+type TaskPriority = "user-blocking" | "user-visible" | "background";
 type TransferFunction = "hlg" | "pq" | "srgb";
 type WebGLPowerPreference = "default" | "high-performance" | "low-power";
 type WorkerType = "classic" | "module";

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -509,6 +509,22 @@ interface RsaPssParams extends Algorithm {
     saltLength: number;
 }
 
+interface SchedulerPostTaskOptions {
+    delay?: number;
+    priority?: TaskPriority;
+    signal?: AbortSignal;
+}
+  
+interface Scheduler {
+    postTask<T, P extends readonly unknown[] | []>(
+      callback: (...params: P) => T,
+      options?: SchedulerPostTaskOptions,
+      ...arguments: P
+    ): Promise<T>;
+}
+  
+declare var scheduler: Scheduler;
+
 interface SecurityPolicyViolationEventInit extends EventInit {
     blockedURI?: string;
     columnNumber?: number;
@@ -555,6 +571,30 @@ interface StreamPipeOptions {
 
 interface StructuredSerializeOptions {
     transfer?: Transferable[];
+}
+
+interface TaskSignal extends AbortSignal {
+    readonly priority: TaskPriority;
+    onprioritychange: ((this: TaskSignal, ev: Event) => any) | null;
+    addEventListener<K extends keyof TaskSignalEventMap>(
+      type: K,
+      listener: (this: TaskSignal, ev: TaskSignalEventMap[K]) => any,
+      options?: boolean | AddEventListenerOptions
+    ): void;
+    removeEventListener<K extends keyof TaskSignalEventMap>(
+      type: K,
+      listener: (this: TaskSignal, ev: TaskSignalEventMap[K]) => any,
+      options?: boolean | EventListenerOptions
+    ): void;
+}
+  
+declare var TaskSignal: {
+    prototype: TaskSignal;
+    new (): TaskSignal;
+};
+  
+interface TaskSignalEventMap {
+    prioritychange: Event;
 }
 
 interface TextDecodeOptions {
@@ -5410,6 +5450,34 @@ interface QueuingStrategySize<T = any> {
     (chunk: T): number;
 }
 
+interface SchedulerPostTaskOptions {
+    delay?: number;
+    priority?: TaskPriority;
+    signal?: AbortSignal;
+}
+
+interface Scheduler {
+    postTask<T, P extends readonly unknown[] | []>(callback: (...params: P) => T, options?: SchedulerPostTaskOptions, ...arguments: P): Promise<T>;
+}
+
+declare var scheduler: Scheduler;
+
+interface TaskSignal extends AbortSignal {
+    readonly priority: TaskPriority;
+    onprioritychange: ((this: TaskSignal, ev: Event) => any) | null;
+    addEventListener<K extends keyof TaskSignalEventMap>(type: K, listener: (this: TaskSignal, ev: TaskSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof TaskSignalEventMap>(type: K, listener: (this: TaskSignal, ev: TaskSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+}
+
+declare var TaskSignal: {
+    prototype: TaskSignal;
+    new(): TaskSignal;
+}
+
+interface TaskSignalEventMap {
+    "prioritychange": Event;
+}
+
 interface TransformerFlushCallback<O> {
     (controller: TransformStreamDefaultController<O>): void | PromiseLike<void>;
 }
@@ -5583,6 +5651,7 @@ type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | "opaquer
 type SecurityPolicyViolationEventDisposition = "enforce" | "report";
 type ServiceWorkerState = "activated" | "activating" | "installed" | "installing" | "parsed" | "redundant";
 type ServiceWorkerUpdateViaCache = "all" | "imports" | "none";
+type TaskPriority = "user-blocking" | "user-visible" | "background";
 type TransferFunction = "hlg" | "pq" | "srgb";
 type WebGLPowerPreference = "default" | "high-performance" | "low-power";
 type WorkerType = "classic" | "module";

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2704,6 +2704,18 @@ declare var Response: {
     redirect(url: string | URL, status?: number): Response;
 };
 
+interface SchedulerPostTaskOptions {
+    delay?: number;
+    priority?: TaskPriority;
+    signal?: AbortSignal;
+}
+
+interface Scheduler {
+    postTask<T, P extends readonly unknown[] | []>(callback: (...params: P) => T, options?: SchedulerPostTaskOptions, ...arguments: P): Promise<T>;
+}
+
+declare var scheduler: Scheduler;
+
 /** Inherits from Event, and represents the event object of an event sent on a document or worker when its content security policy is violated. */
 interface SecurityPolicyViolationEvent extends Event {
     readonly blockedURI: string;
@@ -2907,6 +2919,22 @@ declare var SubtleCrypto: {
     prototype: SubtleCrypto;
     new(): SubtleCrypto;
 };
+
+interface TaskSignal extends AbortSignal {
+    readonly priority: TaskPriority;
+    onprioritychange: ((this: TaskSignal, ev: Event) => any) | null;
+    addEventListener<K extends keyof TaskSignalEventMap>(type: K, listener: (this: TaskSignal, ev: TaskSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof TaskSignalEventMap>(type: K, listener: (this: TaskSignal, ev: TaskSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+}
+
+declare var TaskSignal: {
+    prototype: TaskSignal;
+    new(): TaskSignal;
+}
+
+interface TaskSignalEventMap {
+    "prioritychange": Event;
+}
 
 /** A decoder for a specific method, that is a specific character encoding, like utf-8, iso-8859-2, koi8, cp1261, gbk, etc. A decoder takes a stream of bytes as input and emits a stream of code points. For a more scalable, non-native library, see StringView – a C-like representation of strings based on typed arrays. */
 interface TextDecoder extends TextDecoderCommon {
@@ -5816,6 +5844,7 @@ type ResponseType = "basic" | "cors" | "default" | "error" | "opaque" | "opaquer
 type SecurityPolicyViolationEventDisposition = "enforce" | "report";
 type ServiceWorkerState = "activated" | "activating" | "installed" | "installing" | "parsed" | "redundant";
 type ServiceWorkerUpdateViaCache = "all" | "imports" | "none";
+type TaskPriority = "user-blocking" | "user-visible" | "background";
 type TransferFunction = "hlg" | "pq" | "srgb";
 type WebGLPowerPreference = "default" | "high-performance" | "low-power";
 type WorkerType = "classic" | "module";


### PR DESCRIPTION
This pull request adds the Task Scheduling API to the DOM, Service Worker, Shared Worker, and Web Worker libraries. It includes `SchedulerPostTaskOptions`, `Scheduler`, `scheduler`, `TaskSignal`, `TaskSignalEventMap`, and `TaskPriority`.

An issue I'm currently having is that building it removes all types I added, and changing `overridingTypes.jsonc` doesn't seem to be working. If anybody could help me out with it I'd appreciate it.