### PR TITLE
Add discriminants to FileSystemHandle subtypes

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5123,6 +5123,7 @@ declare var FileSystemDirectoryEntry: {
 
 /** Available only in secure contexts. */
 interface FileSystemDirectoryHandle extends FileSystemHandle {
+    readonly kind: "directory";
     getDirectoryHandle(name: string, options?: FileSystemGetDirectoryOptions): Promise<FileSystemDirectoryHandle>;
     getFileHandle(name: string, options?: FileSystemGetFileOptions): Promise<FileSystemFileHandle>;
     removeEntry(name: string, options?: FileSystemRemoveOptions): Promise<void>;
@@ -5168,6 +5169,7 @@ declare var FileSystemFileEntry: {
 
 /** Available only in secure contexts. */
 interface FileSystemFileHandle extends FileSystemHandle {
+    readonly kind: "file";
     getFile(): Promise<File>;
 }
 

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -1482,6 +1482,7 @@ declare var FileReader: {
 
 /** Available only in secure contexts. */
 interface FileSystemDirectoryHandle extends FileSystemHandle {
+    readonly kind: "directory";
     getDirectoryHandle(name: string, options?: FileSystemGetDirectoryOptions): Promise<FileSystemDirectoryHandle>;
     getFileHandle(name: string, options?: FileSystemGetFileOptions): Promise<FileSystemFileHandle>;
     removeEntry(name: string, options?: FileSystemRemoveOptions): Promise<void>;
@@ -1495,6 +1496,7 @@ declare var FileSystemDirectoryHandle: {
 
 /** Available only in secure contexts. */
 interface FileSystemFileHandle extends FileSystemHandle {
+    readonly kind: "file";
     getFile(): Promise<File>;
 }
 

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -1402,6 +1402,7 @@ declare var FileReaderSync: {
 
 /** Available only in secure contexts. */
 interface FileSystemDirectoryHandle extends FileSystemHandle {
+    readonly kind: "directory";
     getDirectoryHandle(name: string, options?: FileSystemGetDirectoryOptions): Promise<FileSystemDirectoryHandle>;
     getFileHandle(name: string, options?: FileSystemGetFileOptions): Promise<FileSystemFileHandle>;
     removeEntry(name: string, options?: FileSystemRemoveOptions): Promise<void>;
@@ -1415,6 +1416,7 @@ declare var FileSystemDirectoryHandle: {
 
 /** Available only in secure contexts. */
 interface FileSystemFileHandle extends FileSystemHandle {
+    readonly kind: "file";
     getFile(): Promise<File>;
 }
 

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1534,6 +1534,7 @@ declare var FileReaderSync: {
 
 /** Available only in secure contexts. */
 interface FileSystemDirectoryHandle extends FileSystemHandle {
+    readonly kind: "directory";
     getDirectoryHandle(name: string, options?: FileSystemGetDirectoryOptions): Promise<FileSystemDirectoryHandle>;
     getFileHandle(name: string, options?: FileSystemGetFileOptions): Promise<FileSystemFileHandle>;
     removeEntry(name: string, options?: FileSystemRemoveOptions): Promise<void>;
@@ -1547,6 +1548,7 @@ declare var FileSystemDirectoryHandle: {
 
 /** Available only in secure contexts. */
 interface FileSystemFileHandle extends FileSystemHandle {
+    readonly kind: "file";
     getFile(): Promise<File>;
 }
 

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -1060,6 +1060,30 @@
                         }
                     ]
                 }
+            },
+            "FileSystemFileHandle": {
+                "name": "FileSystemFileHandle",
+                "properties": {
+                    "property": {
+                        "kind": {
+                            "name": "kind",
+                            "readonly": true,
+                            "overrideType": "\"file\""
+                        }
+                    }
+                }
+            },
+            "FileSystemDirectoryHandle": {
+                "name": "FileSystemDirectoryHandle",
+                "properties": {
+                    "property": {
+                        "kind": {
+                            "name": "kind",
+                            "readonly": true,
+                            "overrideType": "\"directory\""
+                        }
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
This makes them almost as usable as the existing shims at @types/wicg-file-system-access.

To make up the rest of the difference, I tried adding an alias

```ts
type X = FileSystemFileHandle | FileSystemDirectoryHandle
```

But
1. I couldn't come up with a good name for X
2. I couldn't easily figure out how to generate the type alias without it being used somewhere.