### PR TITLE
Make FileSystem*Handle additions smaller

### DIFF
--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -1062,7 +1062,6 @@
                 }
             },
             "FileSystemFileHandle": {
-                "name": "FileSystemFileHandle",
                 "properties": {
                     "property": {
                         "kind": {
@@ -1074,7 +1073,6 @@
                 }
             },
             "FileSystemDirectoryHandle": {
-                "name": "FileSystemDirectoryHandle",
                 "properties": {
                     "property": {
                         "kind": {


### PR DESCRIPTION
`name` is not needed when the interface is already defined.