### PR TITLE
Add DOMContentLoaded event to Window and Document

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4196,6 +4196,7 @@ declare var DeviceOrientationEvent: {
 };
 
 interface DocumentEventMap extends DocumentAndElementEventHandlersEventMap, GlobalEventHandlersEventMap {
+    "DOMContentLoaded": Event;
     "fullscreenchange": Event;
     "fullscreenerror": Event;
     "pointerlockchange": Event;
@@ -4413,6 +4414,8 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
     createEvent(eventInterface: "DeviceOrientationEvent"): DeviceOrientationEvent;
     createEvent(eventInterface: "DragEvent"): DragEvent;
     createEvent(eventInterface: "ErrorEvent"): ErrorEvent;
+    createEvent(eventInterface: "Event"): Event;
+    createEvent(eventInterface: "Events"): Event;
     createEvent(eventInterface: "FocusEvent"): FocusEvent;
     createEvent(eventInterface: "FontFaceSetLoadEvent"): FontFaceSetLoadEvent;
     createEvent(eventInterface: "FormDataEvent"): FormDataEvent;
@@ -16254,6 +16257,7 @@ declare var WheelEvent: {
 };
 
 interface WindowEventMap extends GlobalEventHandlersEventMap, WindowEventHandlersEventMap {
+    "DOMContentLoaded": Event;
     "devicemotion": DeviceMotionEvent;
     "deviceorientation": DeviceOrientationEvent;
     "gamepadconnected": GamepadEvent;

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -439,6 +439,10 @@
                         {
                             "name": "gamepaddisconnected",
                             "type": "GamepadEvent"
+                        },
+                        {
+                            "name": "DOMContentLoaded",
+                            "type": "Event"
                         }
                     ]
                 }
@@ -679,6 +683,14 @@
                             "overrideType": "null"
                         }
                     }
+                },
+                "events": {
+                    "event": [
+                        {
+                            "name": "DOMContentLoaded",
+                            "type": "Event"
+                        }
+                    ]
                 }
             },
             // This is used in the React d.ts files, and not including


### PR DESCRIPTION
The DOMContentLoaded event was missing from both the Document and Window interfaces.

https://developer.mozilla.org/en-US/docs/Web/API/Window/DOMContentLoaded_event
https://developer.mozilla.org/en-US/docs/Web/API/Document/DOMContentLoaded_event