### PR TITLE
#1261: NodeListOf#item

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -9932,7 +9932,7 @@ declare var NodeList: {
 };
 
 interface NodeListOf<TNode extends Node> extends NodeList {
-    item(index: number): TNode;
+    item(index: number): TNode | null;
     /**
      * Performs the specified action for each node in an list.
      * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.


### PR DESCRIPTION
fixes #1261
NodeListOf#item() misses `null` in return type