### PR TITLE
Convert `performance.measure()` to overloads

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -10275,7 +10275,9 @@ interface Performance extends EventTarget {
     getEntriesByName(name: string, type?: string): PerformanceEntryList;
     getEntriesByType(type: string): PerformanceEntryList;
     mark(markName: string, markOptions?: PerformanceMarkOptions): PerformanceMark;
-    measure(measureName: string, startOrMeasureOptions?: string | PerformanceMeasureOptions, endMark?: string): PerformanceMeasure;
+    measure(measureName: string): PerformanceMeasure;
+    measure(measureName: string, measureOptions: PerformanceMeasureOptions): PerformanceMeasure;
+    measure(measureName: string, startMark?: string, endMark?: string): PerformanceMeasure;
     now(): DOMHighResTimeStamp;
     setResourceTimingBufferSize(maxSize: number): void;
     toJSON(): any;

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -2323,7 +2323,9 @@ interface Performance extends EventTarget {
     getEntriesByName(name: string, type?: string): PerformanceEntryList;
     getEntriesByType(type: string): PerformanceEntryList;
     mark(markName: string, markOptions?: PerformanceMarkOptions): PerformanceMark;
-    measure(measureName: string, startOrMeasureOptions?: string | PerformanceMeasureOptions, endMark?: string): PerformanceMeasure;
+    measure(measureName: string): PerformanceMeasure;
+    measure(measureName: string, measureOptions: PerformanceMeasureOptions): PerformanceMeasure;
+    measure(measureName: string, startMark?: string, endMark?: string): PerformanceMeasure;
     now(): DOMHighResTimeStamp;
     setResourceTimingBufferSize(maxSize: number): void;
     toJSON(): any;

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -2232,7 +2232,9 @@ interface Performance extends EventTarget {
     getEntriesByName(name: string, type?: string): PerformanceEntryList;
     getEntriesByType(type: string): PerformanceEntryList;
     mark(markName: string, markOptions?: PerformanceMarkOptions): PerformanceMark;
-    measure(measureName: string, startOrMeasureOptions?: string | PerformanceMeasureOptions, endMark?: string): PerformanceMeasure;
+    measure(measureName: string): PerformanceMeasure;
+    measure(measureName: string, measureOptions: PerformanceMeasureOptions): PerformanceMeasure;
+    measure(measureName: string, startMark?: string, endMark?: string): PerformanceMeasure;
     now(): DOMHighResTimeStamp;
     setResourceTimingBufferSize(maxSize: number): void;
     toJSON(): any;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2375,7 +2375,9 @@ interface Performance extends EventTarget {
     getEntriesByName(name: string, type?: string): PerformanceEntryList;
     getEntriesByType(type: string): PerformanceEntryList;
     mark(markName: string, markOptions?: PerformanceMarkOptions): PerformanceMark;
-    measure(measureName: string, startOrMeasureOptions?: string | PerformanceMeasureOptions, endMark?: string): PerformanceMeasure;
+    measure(measureName: string): PerformanceMeasure;
+    measure(measureName: string, measureOptions: PerformanceMeasureOptions): PerformanceMeasure;
+    measure(measureName: string, startMark?: string, endMark?: string): PerformanceMeasure;
     now(): DOMHighResTimeStamp;
     setResourceTimingBufferSize(maxSize: number): void;
     toJSON(): any;

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2834,6 +2834,19 @@
             },
             "SourceBufferList": {
                 "exposed": "Window"
+            },
+            "Performance": {
+              "methods": {
+                "method": {
+                  "measure": {
+                    "overrideSignatures": [
+                      "measure(measureName: string): PerformanceMeasure",
+                      "measure(measureName: string, measureOptions: PerformanceMeasureOptions): PerformanceMeasure",
+                      "measure(measureName: string, startMark?: string, endMark?: string): PerformanceMeasure"
+                    ]
+                  }
+                }
+              }
             }
         }
     },

--- a/unittests/files/performance-measure.ts
+++ b/unittests/files/performance-measure.ts
@@ -1,0 +1,8 @@
+performance.measure('name');
+performance.measure('name', 'start');
+performance.measure('name', undefined);
+performance.measure('name', 'start', 'end');
+performance.measure('name', undefined, 'end');
+performance.measure('name', 'start', undefined);
+performance.measure('name', undefined, undefined);
+performance.measure('name', { start: 'start', end: 'end' });


### PR DESCRIPTION
Fixes #1239

Technically the third one includes the first one (when both arguments are omitted), but if the first one is removed I feel like it's hard to discover it.

The `measureOptions` can't be used with `endMark` is defined at https://w3c.github.io/user-timing/#dom-performance-measure:

> 1. If _startOrMeasureOptions_ is a non-[empty](https://infra.spec.whatwg.org/#map-is-empty) [`PerformanceMeasureOptions`](https://w3c.github.io/user-timing/#dom-performancemeasureoptions) object, run the following checks:
>     1. If _endMark_ is given, [throw](https://webidl.spec.whatwg.org/#dfn-throw) a [TypeError](https://webidl.spec.whatwg.org/#exceptiondef-typeerror).