### PR TITLE
fix: audioworklet registerProcessor should expect a constructor not a function

### DIFF
--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -890,7 +890,7 @@ declare namespace WebAssembly {
 }
 
 interface AudioWorkletProcessorConstructor {
-    (options: any): AudioWorkletProcessor;
+    new (options: any): AudioWorkletProcessor;
 }
 
 interface PerformanceObserverCallback {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -366,6 +366,11 @@
                 "overrideSignatures": [
                     "new (...params: any[]): HTMLElement"
                 ]
+            },
+            "AudioWorkletProcessorConstructor": {
+                "overrideSignatures": [
+                    "new (options: any): AudioWorkletProcessor"
+                ]
             }
         }
     },


### PR DESCRIPTION
fixes #1295

see also https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletProcessor/AudioWorkletProcessor 