### PR TITLE
fix: Add missing "preservesPitch" field to HTMLMediaElement

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7216,6 +7216,8 @@ interface HTMLMediaElement extends HTMLElement {
     readonly played: TimeRanges;
     /** Gets or sets a value indicating what data should be preloaded, if any. */
     preload: "none" | "metadata" | "auto" | "";
+    /** Gets or sets a flag that indicate whether or not the browser should adjust the pitch of the audio to compensate for changes to the playback rate. */
+    preservesPitch: boolean;
     readonly readyState: number;
     readonly remote: RemotePlayback;
     /** Returns a TimeRanges object that represents the ranges of the current media resource that can be seeked. */

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -1542,6 +1542,9 @@
                         "playbackRate": {
                             "comment": "Gets or sets the current rate of speed for the media resource to play. This speed is expressed as a multiple of the normal speed of the media resource."
                         },
+                        "preservesPitch": {
+                            "comment": "Gets or sets a flag that indicate whether or not the browser should adjust the pitch of the audio to compensate for changes to the playback rate."
+                        },
                         "duration": {
                             "comment": "Returns the duration in seconds of the current media resource. A NaN value is returned if duration is not available, or Infinity if the media resource is streaming."
                         },

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2824,6 +2824,9 @@
                     "property": {
                         "preload": {
                             "overrideType": "\"none\" | \"metadata\" | \"auto\" | \"\""
+                        },
+                        "preservesPitch": {
+                            "exposed": "Window"
                         }
                     }
                 }


### PR DESCRIPTION
This PR adds the missing `preservesPitch` field to `HTMLMediaElement`.

Fixes the issue https://github.com/microsoft/TypeScript/issues/48444 