### PR TITLE
Add the missing "disabled" property to HTMLStyleElement

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7846,6 +7846,8 @@ declare var HTMLSpanElement: {
 
 /** A <style> element. It inherits properties and methods from its parent, HTMLElement, and from LinkStyle. */
 interface HTMLStyleElement extends HTMLElement, LinkStyle {
+    /** Enables or disables the style sheet. */
+    disabled: boolean;
     /** Sets or retrieves the media type. */
     media: string;
     /**

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -1128,7 +1128,6 @@
                 }
             },
             "HTMLStyleElement": {
-                "name": "HTMLStyleElement",
                 "properties": {
                     "property": {
                         "disabled": {

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -1126,6 +1126,17 @@
                         }
                     }
                 }
+            },
+            "HTMLStyleElement": {
+                "name": "HTMLStyleElement",
+                "properties": {
+                    "property": {
+                        "disabled": {
+                            "name": "disabled",
+                            "type": "boolean"
+                        }
+                    }
+                }
             }
         }
     },

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -1281,6 +1281,9 @@
                         },
                         "type": {
                             "comment": "Retrieves the CSS language in which the style sheet is written."
+                        },
+                        "disabled": {
+                            "comment": "Enables or disables the style sheet."
                         }
                     }
                 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/42266

Look like the `HTMLStyleElement.disabled` property is defined in [the specs](https://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-16428977), also available on every browser, [according to MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLStyleElement#browser_compatibility).