### PR TITLE
Fix "input" event type

### DIFF
--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -133,6 +133,10 @@
                             "type": "FormDataEvent"
                         },
                         {
+                            "name": "input",
+                            "type": "InputEvent"
+                        },
+                        {
                             "name": "keydown",
                             "type": "KeyboardEvent"
                         },


### PR DESCRIPTION
As per the spec, the Event interface for the "input" event is InputEvent, the same as "beforeinput"
https://www.w3.org/TR/2021/WD-uievents-20211020/#event-type-input

```ts
const input_element = document.createElement('input')

// currently OK
input_element.addEventListener('beforeinput', (ev: InputEvent) => {})
// currently fails, expects ev to be of 'Event' type
input_element.addEventListener('input', (ev: InputEvent) => {})
```
[>> playground](https://www.typescriptlang.org/play?ts=4.8.0-dev.20220514#code/MYewdgzgLgBAlmADgVygfQKYBsMFsNiwC8MAJiMMvoQHTABOGAhlBgKI7VQAUA5Aiii8AlAFgAUBIGpMnAlBpNSpNgDd5AGTjQCGenwBGGAGYhG0oQBoY3DKoBcMAJJJUa+cJhEAfDADeAL5i4hayePKKyu6EWjpgenwWvNa2Ds6uUNFQnj7+QUA)

Related MDN and W3C:
[MDN beforeinput](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/beforeinput_event) | [W3C beforeinput](https://www.w3.org/TR/2021/WD-uievents-20211020/#event-type-beforeinput)
[MDN input](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/input_event) | [W3C input](https://www.w3.org/TR/2021/WD-uievents-20211020/#event-type-input)

note that MDN page for "input" event states the interface can be ``InputEvent or Event``.

In practice, both events are instanceof InputEvent in Chrome 101 and Firefox 100.