### PR TITLE
Add readable byte streams

### DIFF
--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -154,6 +154,21 @@ interface Transformer<I = any, O = any> {
     writableType?: undefined;
 }
 
+interface UnderlyingByteSource {
+    autoAllocateChunkSize?: number;
+    cancel?: UnderlyingSourceCancelCallback;
+    pull?: (controller: ReadableByteStreamController) => void | PromiseLike<void>;
+    start?: (controller: ReadableByteStreamController) => any;
+    type: "bytes";
+}
+
+interface UnderlyingDefaultSource<R = any> {
+    cancel?: UnderlyingSourceCancelCallback;
+    pull?: (controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>;
+    start?: (controller: ReadableStreamDefaultController<R>) => any;
+    type?: undefined;
+}
+
 interface UnderlyingSink<W = any> {
     abort?: UnderlyingSinkAbortCallback;
     close?: UnderlyingSinkCloseCallback;
@@ -549,6 +564,8 @@ interface ReadableStream<R = any> {
 
 declare var ReadableStream: {
     prototype: ReadableStream;
+    new(underlyingSource: UnderlyingByteSource, strategy?: { highWaterMark?: number }): ReadableStream<Uint8Array>;
+    new<R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
 };
 

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1485,9 +1485,18 @@ interface RTCTransportStats extends RTCStats {
     tlsVersion?: string;
 }
 
-interface ReadableStreamReadDoneResult {
+interface ReadableStreamGetReaderOptions {
+    /**
+     * Creates a ReadableStreamBYOBReader and locks the stream to the new reader.
+     *
+     * This call behaves the same way as the no-argument variant, except that it only works on readable byte streams, i.e. streams which were constructed specifically with the ability to handle "bring your own buffer" reading. The returned BYOB reader provides the ability to directly read individual chunks from the stream via its read() method, into developer-supplied buffers, allowing more precise control over allocation.
+     */
+    mode?: ReadableStreamReaderMode;
+}
+
+interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: undefined;
+    value?: T;
 }
 
 interface ReadableStreamReadValueResult<T> {
@@ -1780,10 +1789,11 @@ interface UnderlyingSink<W = any> {
 }
 
 interface UnderlyingSource<R = any> {
+    autoAllocateChunkSize?: number;
     cancel?: UnderlyingSourceCancelCallback;
     pull?: UnderlyingSourcePullCallback<R>;
     start?: UnderlyingSourceStartCallback<R>;
-    type?: undefined;
+    type?: ReadableStreamType;
 }
 
 interface ValidityStateFlags {
@@ -11365,7 +11375,9 @@ declare var ReadableByteStreamController: {
 interface ReadableStream<R = any> {
     readonly locked: boolean;
     cancel(reason?: any): Promise<void>;
+    getReader(options: { mode: "byob" }): ReadableStreamBYOBReader;
     getReader(): ReadableStreamDefaultReader<R>;
+    getReader(options?: ReadableStreamGetReaderOptions): ReadableStreamReader<R>;
     pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
     pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
     tee(): [ReadableStream<R>, ReadableStream<R>];
@@ -11377,7 +11389,7 @@ declare var ReadableStream: {
 };
 
 interface ReadableStreamBYOBReader extends ReadableStreamGenericReader {
-    read(view: ArrayBufferView): Promise<ReadableStreamReadResult<ArrayBufferView>>;
+    read<T extends ArrayBufferView>(view: T): Promise<ReadableStreamReadResult<T>>;
     releaseLock(): void;
 }
 
@@ -18080,9 +18092,9 @@ type NamedCurve = string;
 type OnBeforeUnloadEventHandler = OnBeforeUnloadEventHandlerNonNull | null;
 type OnErrorEventHandler = OnErrorEventHandlerNonNull | null;
 type PerformanceEntryList = PerformanceEntry[];
-type ReadableStreamController<T> = ReadableStreamDefaultController<T>;
-type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult;
-type ReadableStreamReader<T> = ReadableStreamDefaultReader<T>;
+type ReadableStreamController<T> = ReadableStreamDefaultController<T> | ReadableByteStreamController;
+type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
+type ReadableStreamReader<T> = ReadableStreamDefaultReader<T> | ReadableStreamBYOBReader;
 type RenderingContext = CanvasRenderingContext2D | ImageBitmapRenderingContext | WebGLRenderingContext | WebGL2RenderingContext;
 type RequestInfo = Request | string;
 type TexImageSource = ImageBitmap | ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement;
@@ -18209,6 +18221,8 @@ type RTCSdpType = "answer" | "offer" | "pranswer" | "rollback";
 type RTCSignalingState = "closed" | "have-local-offer" | "have-local-pranswer" | "have-remote-offer" | "have-remote-pranswer" | "stable";
 type RTCStatsIceCandidatePairState = "failed" | "frozen" | "in-progress" | "inprogress" | "succeeded" | "waiting";
 type RTCStatsType = "candidate-pair" | "certificate" | "codec" | "csrc" | "data-channel" | "inbound-rtp" | "local-candidate" | "media-source" | "outbound-rtp" | "peer-connection" | "remote-candidate" | "remote-inbound-rtp" | "remote-outbound-rtp" | "track" | "transport";
+type ReadableStreamReaderMode = "byob";
+type ReadableStreamType = "bytes";
 type ReadyState = "closed" | "ended" | "open";
 type RecordingState = "inactive" | "paused" | "recording";
 type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "same-origin" | "strict-origin" | "strict-origin-when-cross-origin" | "unsafe-url";

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1780,6 +1780,21 @@ interface ULongRange {
     min?: number;
 }
 
+interface UnderlyingByteSource {
+    autoAllocateChunkSize?: number;
+    cancel?: UnderlyingSourceCancelCallback;
+    pull?: (controller: ReadableByteStreamController) => void | PromiseLike<void>;
+    start?: (controller: ReadableByteStreamController) => any;
+    type: "bytes";
+}
+
+interface UnderlyingDefaultSource<R = any> {
+    cancel?: UnderlyingSourceCancelCallback;
+    pull?: (controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>;
+    start?: (controller: ReadableStreamDefaultController<R>) => any;
+    type?: undefined;
+}
+
 interface UnderlyingSink<W = any> {
     abort?: UnderlyingSinkAbortCallback;
     close?: UnderlyingSinkCloseCallback;
@@ -11385,6 +11400,8 @@ interface ReadableStream<R = any> {
 
 declare var ReadableStream: {
     prototype: ReadableStream;
+    new(underlyingSource: UnderlyingByteSource, strategy?: { highWaterMark?: number }): ReadableStream<Uint8Array>;
+    new<R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
 };
 

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -464,9 +464,18 @@ interface QueuingStrategyInit {
     highWaterMark: number;
 }
 
-interface ReadableStreamReadDoneResult {
+interface ReadableStreamGetReaderOptions {
+    /**
+     * Creates a ReadableStreamBYOBReader and locks the stream to the new reader.
+     *
+     * This call behaves the same way as the no-argument variant, except that it only works on readable byte streams, i.e. streams which were constructed specifically with the ability to handle "bring your own buffer" reading. The returned BYOB reader provides the ability to directly read individual chunks from the stream via its read() method, into developer-supplied buffers, allowing more precise control over allocation.
+     */
+    mode?: ReadableStreamReaderMode;
+}
+
+interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: undefined;
+    value?: T;
 }
 
 interface ReadableStreamReadValueResult<T> {
@@ -631,10 +640,11 @@ interface UnderlyingSink<W = any> {
 }
 
 interface UnderlyingSource<R = any> {
+    autoAllocateChunkSize?: number;
     cancel?: UnderlyingSourceCancelCallback;
     pull?: UnderlyingSourcePullCallback<R>;
     start?: UnderlyingSourceStartCallback<R>;
-    type?: undefined;
+    type?: ReadableStreamType;
 }
 
 interface VideoConfiguration {
@@ -2593,7 +2603,9 @@ declare var ReadableByteStreamController: {
 interface ReadableStream<R = any> {
     readonly locked: boolean;
     cancel(reason?: any): Promise<void>;
+    getReader(options: { mode: "byob" }): ReadableStreamBYOBReader;
     getReader(): ReadableStreamDefaultReader<R>;
+    getReader(options?: ReadableStreamGetReaderOptions): ReadableStreamReader<R>;
     pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
     pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
     tee(): [ReadableStream<R>, ReadableStream<R>];
@@ -2605,7 +2617,7 @@ declare var ReadableStream: {
 };
 
 interface ReadableStreamBYOBReader extends ReadableStreamGenericReader {
-    read(view: ArrayBufferView): Promise<ReadableStreamReadResult<ArrayBufferView>>;
+    read<T extends ArrayBufferView>(view: T): Promise<ReadableStreamReadResult<T>>;
     releaseLock(): void;
 }
 
@@ -5571,9 +5583,9 @@ type NamedCurve = string;
 type OnErrorEventHandler = OnErrorEventHandlerNonNull | null;
 type PerformanceEntryList = PerformanceEntry[];
 type PushMessageDataInit = BufferSource | string;
-type ReadableStreamController<T> = ReadableStreamDefaultController<T>;
-type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult;
-type ReadableStreamReader<T> = ReadableStreamDefaultReader<T>;
+type ReadableStreamController<T> = ReadableStreamDefaultController<T> | ReadableByteStreamController;
+type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
+type ReadableStreamReader<T> = ReadableStreamDefaultReader<T> | ReadableStreamBYOBReader;
 type RequestInfo = Request | string;
 type TexImageSource = ImageBitmap | ImageData | OffscreenCanvas;
 type TimerHandler = string | Function;
@@ -5610,6 +5622,8 @@ type PermissionState = "denied" | "granted" | "prompt";
 type PredefinedColorSpace = "display-p3" | "srgb";
 type PremultiplyAlpha = "default" | "none" | "premultiply";
 type PushEncryptionKeyName = "auth" | "p256dh";
+type ReadableStreamReaderMode = "byob";
+type ReadableStreamType = "bytes";
 type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "same-origin" | "strict-origin" | "strict-origin-when-cross-origin" | "unsafe-url";
 type RequestCache = "default" | "force-cache" | "no-cache" | "no-store" | "only-if-cached" | "reload";
 type RequestCredentials = "include" | "omit" | "same-origin";

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -631,6 +631,21 @@ interface Transformer<I = any, O = any> {
     writableType?: undefined;
 }
 
+interface UnderlyingByteSource {
+    autoAllocateChunkSize?: number;
+    cancel?: UnderlyingSourceCancelCallback;
+    pull?: (controller: ReadableByteStreamController) => void | PromiseLike<void>;
+    start?: (controller: ReadableByteStreamController) => any;
+    type: "bytes";
+}
+
+interface UnderlyingDefaultSource<R = any> {
+    cancel?: UnderlyingSourceCancelCallback;
+    pull?: (controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>;
+    start?: (controller: ReadableStreamDefaultController<R>) => any;
+    type?: undefined;
+}
+
 interface UnderlyingSink<W = any> {
     abort?: UnderlyingSinkAbortCallback;
     close?: UnderlyingSinkCloseCallback;
@@ -2613,6 +2628,8 @@ interface ReadableStream<R = any> {
 
 declare var ReadableStream: {
     prototype: ReadableStream;
+    new(underlyingSource: UnderlyingByteSource, strategy?: { highWaterMark?: number }): ReadableStream<Uint8Array>;
+    new<R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
 };
 

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -597,6 +597,21 @@ interface Transformer<I = any, O = any> {
     writableType?: undefined;
 }
 
+interface UnderlyingByteSource {
+    autoAllocateChunkSize?: number;
+    cancel?: UnderlyingSourceCancelCallback;
+    pull?: (controller: ReadableByteStreamController) => void | PromiseLike<void>;
+    start?: (controller: ReadableByteStreamController) => any;
+    type: "bytes";
+}
+
+interface UnderlyingDefaultSource<R = any> {
+    cancel?: UnderlyingSourceCancelCallback;
+    pull?: (controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>;
+    start?: (controller: ReadableStreamDefaultController<R>) => any;
+    type?: undefined;
+}
+
 interface UnderlyingSink<W = any> {
     abort?: UnderlyingSinkAbortCallback;
     close?: UnderlyingSinkCloseCallback;
@@ -2492,6 +2507,8 @@ interface ReadableStream<R = any> {
 
 declare var ReadableStream: {
     prototype: ReadableStream;
+    new(underlyingSource: UnderlyingByteSource, strategy?: { highWaterMark?: number }): ReadableStream<Uint8Array>;
+    new<R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
 };
 

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -430,9 +430,18 @@ interface QueuingStrategyInit {
     highWaterMark: number;
 }
 
-interface ReadableStreamReadDoneResult {
+interface ReadableStreamGetReaderOptions {
+    /**
+     * Creates a ReadableStreamBYOBReader and locks the stream to the new reader.
+     *
+     * This call behaves the same way as the no-argument variant, except that it only works on readable byte streams, i.e. streams which were constructed specifically with the ability to handle "bring your own buffer" reading. The returned BYOB reader provides the ability to directly read individual chunks from the stream via its read() method, into developer-supplied buffers, allowing more precise control over allocation.
+     */
+    mode?: ReadableStreamReaderMode;
+}
+
+interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: undefined;
+    value?: T;
 }
 
 interface ReadableStreamReadValueResult<T> {
@@ -597,10 +606,11 @@ interface UnderlyingSink<W = any> {
 }
 
 interface UnderlyingSource<R = any> {
+    autoAllocateChunkSize?: number;
     cancel?: UnderlyingSourceCancelCallback;
     pull?: UnderlyingSourcePullCallback<R>;
     start?: UnderlyingSourceStartCallback<R>;
-    type?: undefined;
+    type?: ReadableStreamType;
 }
 
 interface VideoConfiguration {
@@ -2472,7 +2482,9 @@ declare var ReadableByteStreamController: {
 interface ReadableStream<R = any> {
     readonly locked: boolean;
     cancel(reason?: any): Promise<void>;
+    getReader(options: { mode: "byob" }): ReadableStreamBYOBReader;
     getReader(): ReadableStreamDefaultReader<R>;
+    getReader(options?: ReadableStreamGetReaderOptions): ReadableStreamReader<R>;
     pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
     pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
     tee(): [ReadableStream<R>, ReadableStream<R>];
@@ -2484,7 +2496,7 @@ declare var ReadableStream: {
 };
 
 interface ReadableStreamBYOBReader extends ReadableStreamGenericReader {
-    read(view: ArrayBufferView): Promise<ReadableStreamReadResult<ArrayBufferView>>;
+    read<T extends ArrayBufferView>(view: T): Promise<ReadableStreamReadResult<T>>;
     releaseLock(): void;
 }
 
@@ -5584,9 +5596,9 @@ type MessageEventSource = MessagePort | ServiceWorker;
 type NamedCurve = string;
 type OnErrorEventHandler = OnErrorEventHandlerNonNull | null;
 type PerformanceEntryList = PerformanceEntry[];
-type ReadableStreamController<T> = ReadableStreamDefaultController<T>;
-type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult;
-type ReadableStreamReader<T> = ReadableStreamDefaultReader<T>;
+type ReadableStreamController<T> = ReadableStreamDefaultController<T> | ReadableByteStreamController;
+type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
+type ReadableStreamReader<T> = ReadableStreamDefaultReader<T> | ReadableStreamBYOBReader;
 type RequestInfo = Request | string;
 type TexImageSource = ImageBitmap | ImageData | OffscreenCanvas;
 type TimerHandler = string | Function;
@@ -5621,6 +5633,8 @@ type PermissionState = "denied" | "granted" | "prompt";
 type PredefinedColorSpace = "display-p3" | "srgb";
 type PremultiplyAlpha = "default" | "none" | "premultiply";
 type PushEncryptionKeyName = "auth" | "p256dh";
+type ReadableStreamReaderMode = "byob";
+type ReadableStreamType = "bytes";
 type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "same-origin" | "strict-origin" | "strict-origin-when-cross-origin" | "unsafe-url";
 type RequestCache = "default" | "force-cache" | "no-cache" | "no-store" | "only-if-cached" | "reload";
 type RequestCredentials = "include" | "omit" | "same-origin";

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -480,9 +480,18 @@ interface RTCEncodedVideoFrameMetadata {
     width?: number;
 }
 
-interface ReadableStreamReadDoneResult {
+interface ReadableStreamGetReaderOptions {
+    /**
+     * Creates a ReadableStreamBYOBReader and locks the stream to the new reader.
+     *
+     * This call behaves the same way as the no-argument variant, except that it only works on readable byte streams, i.e. streams which were constructed specifically with the ability to handle "bring your own buffer" reading. The returned BYOB reader provides the ability to directly read individual chunks from the stream via its read() method, into developer-supplied buffers, allowing more precise control over allocation.
+     */
+    mode?: ReadableStreamReaderMode;
+}
+
+interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: undefined;
+    value?: T;
 }
 
 interface ReadableStreamReadValueResult<T> {
@@ -647,10 +656,11 @@ interface UnderlyingSink<W = any> {
 }
 
 interface UnderlyingSource<R = any> {
+    autoAllocateChunkSize?: number;
     cancel?: UnderlyingSourceCancelCallback;
     pull?: UnderlyingSourcePullCallback<R>;
     start?: UnderlyingSourceStartCallback<R>;
-    type?: undefined;
+    type?: ReadableStreamType;
 }
 
 interface VideoColorSpaceInit {
@@ -2691,7 +2701,9 @@ declare var ReadableByteStreamController: {
 interface ReadableStream<R = any> {
     readonly locked: boolean;
     cancel(reason?: any): Promise<void>;
+    getReader(options: { mode: "byob" }): ReadableStreamBYOBReader;
     getReader(): ReadableStreamDefaultReader<R>;
+    getReader(options?: ReadableStreamGetReaderOptions): ReadableStreamReader<R>;
     pipeThrough<T>(transform: ReadableWritablePair<T, R>, options?: StreamPipeOptions): ReadableStream<T>;
     pipeTo(destination: WritableStream<R>, options?: StreamPipeOptions): Promise<void>;
     tee(): [ReadableStream<R>, ReadableStream<R>];
@@ -2703,7 +2715,7 @@ declare var ReadableStream: {
 };
 
 interface ReadableStreamBYOBReader extends ReadableStreamGenericReader {
-    read(view: ArrayBufferView): Promise<ReadableStreamReadResult<ArrayBufferView>>;
+    read<T extends ArrayBufferView>(view: T): Promise<ReadableStreamReadResult<T>>;
     releaseLock(): void;
 }
 
@@ -5876,9 +5888,9 @@ type NamedCurve = string;
 type OnErrorEventHandler = OnErrorEventHandlerNonNull | null;
 type PerformanceEntryList = PerformanceEntry[];
 type PushMessageDataInit = BufferSource | string;
-type ReadableStreamController<T> = ReadableStreamDefaultController<T>;
-type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult;
-type ReadableStreamReader<T> = ReadableStreamDefaultReader<T>;
+type ReadableStreamController<T> = ReadableStreamDefaultController<T> | ReadableByteStreamController;
+type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
+type ReadableStreamReader<T> = ReadableStreamDefaultReader<T> | ReadableStreamBYOBReader;
 type RequestInfo = Request | string;
 type TexImageSource = ImageBitmap | ImageData | OffscreenCanvas;
 type TimerHandler = string | Function;
@@ -5916,6 +5928,8 @@ type PredefinedColorSpace = "display-p3" | "srgb";
 type PremultiplyAlpha = "default" | "none" | "premultiply";
 type PushEncryptionKeyName = "auth" | "p256dh";
 type RTCEncodedVideoFrameType = "delta" | "empty" | "key";
+type ReadableStreamReaderMode = "byob";
+type ReadableStreamType = "bytes";
 type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "same-origin" | "strict-origin" | "strict-origin-when-cross-origin" | "unsafe-url";
 type RequestCache = "default" | "force-cache" | "no-cache" | "no-store" | "only-if-cached" | "reload";
 type RequestCredentials = "include" | "omit" | "same-origin";

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -647,6 +647,21 @@ interface Transformer<I = any, O = any> {
     writableType?: undefined;
 }
 
+interface UnderlyingByteSource {
+    autoAllocateChunkSize?: number;
+    cancel?: UnderlyingSourceCancelCallback;
+    pull?: (controller: ReadableByteStreamController) => void | PromiseLike<void>;
+    start?: (controller: ReadableByteStreamController) => any;
+    type: "bytes";
+}
+
+interface UnderlyingDefaultSource<R = any> {
+    cancel?: UnderlyingSourceCancelCallback;
+    pull?: (controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>;
+    start?: (controller: ReadableStreamDefaultController<R>) => any;
+    type?: undefined;
+}
+
 interface UnderlyingSink<W = any> {
     abort?: UnderlyingSinkAbortCallback;
     close?: UnderlyingSinkCloseCallback;
@@ -2711,6 +2726,8 @@ interface ReadableStream<R = any> {
 
 declare var ReadableStream: {
     prototype: ReadableStream;
+    new(underlyingSource: UnderlyingByteSource, strategy?: { highWaterMark?: number }): ReadableStream<Uint8Array>;
+    new<R = any>(underlyingSource: UnderlyingDefaultSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
 };
 

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -1155,6 +1155,11 @@
             },
             "ReadableStreamReadDoneResult": {
                 "name": "ReadableStreamReadDoneResult",
+                "typeParameters": [
+                    {
+                        "name": "T"
+                    }
+                ],
                 "members": {
                     "member": {
                         "done": {
@@ -1164,7 +1169,7 @@
                         },
                         "value": {
                             "name": "value",
-                            "overrideType": "undefined"
+                            "overrideType": "T"
                         }
                     }
                 }
@@ -1302,7 +1307,7 @@
                         "type": "ReadableStreamReadDoneResult"
                     }
                 ],
-                "overrideType": "ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult"
+                "overrideType": "ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>"
             },
             {
                 "name": "ReadableStreamReader",
@@ -1314,9 +1319,12 @@
                 "type": [
                     {
                         "type": "ReadableStreamDefaultReader"
+                    },
+                    {
+                        "type": "ReadableStreamBYOBReader"
                     }
                 ],
-                "overrideType": "ReadableStreamDefaultReader<T>"
+                "overrideType": "ReadableStreamDefaultReader<T> | ReadableStreamBYOBReader"
             },
             {
                 "name": "EventListenerOrEventListenerObject",

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -1207,7 +1207,7 @@
                         },
                         "autoAllocateChunkSize": {
                             "name": "autoAllocateChunkSize",
-                            "overrideType": "number"
+                            "type": "unsigned long long"
                         },
                         "start": {
                             "name": "start",

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -1310,23 +1310,6 @@
                 "overrideType": "ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>"
             },
             {
-                "name": "ReadableStreamReader",
-                "typeParameters": [
-                    {
-                        "name": "T"
-                    }
-                ],
-                "type": [
-                    {
-                        "type": "ReadableStreamDefaultReader"
-                    },
-                    {
-                        "type": "ReadableStreamBYOBReader"
-                    }
-                ],
-                "overrideType": "ReadableStreamDefaultReader<T> | ReadableStreamBYOBReader"
-            },
-            {
                 "name": "EventListenerOrEventListenerObject",
                 "overrideType": "EventListener | EventListenerObject"
             }

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -1195,6 +1195,63 @@
                         }
                     }
                 }
+            },
+            "UnderlyingByteSource": {
+                "name": "UnderlyingByteSource",
+                "members": {
+                    "member": {
+                        "type": {
+                            "name": "type",
+                            "required": true,
+                            "overrideType": "\"bytes\""
+                        },
+                        "autoAllocateChunkSize": {
+                            "name": "autoAllocateChunkSize",
+                            "overrideType": "number"
+                        },
+                        "start": {
+                            "name": "start",
+                            "overrideType": "(controller: ReadableByteStreamController) => any"
+                        },
+                        "pull": {
+                            "name": "pull",
+                            "overrideType": "(controller: ReadableByteStreamController) => void | PromiseLike<void>"
+                        },
+                        "cancel": {
+                            "name": "cancel",
+                            "type": "UnderlyingSourceCancelCallback"
+                        }
+                    }
+                }
+            },
+            "UnderlyingDefaultSource": {
+                "name": "UnderlyingDefaultSource",
+                "typeParameters": [
+                    {
+                        "name": "R",
+                        "default": "any"
+                    }
+                ],
+                "members": {
+                    "member": {
+                        "type": {
+                            "name": "type",
+                            "type": "undefined"
+                        },
+                        "start": {
+                            "name": "start",
+                            "overrideType": "(controller: ReadableStreamDefaultController<R>) => any"
+                        },
+                        "pull": {
+                            "name": "pull",
+                            "overrideType": "(controller: ReadableStreamDefaultController<R>) => void | PromiseLike<void>"
+                        },
+                        "cancel": {
+                            "name": "cancel",
+                            "type": "UnderlyingSourceCancelCallback"
+                        }
+                    }
+                }
             }
         }
     },

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2349,6 +2349,20 @@
                 "constructor": {
                     "signature": {
                         "0": {
+                            "param": [
+                                {
+                                    "name": "underlyingSource",
+                                    "optional": false,
+                                    "overrideType": "UnderlyingByteSource"
+                                },
+                                {
+                                    "name": "strategy",
+                                    "overrideType": "{ highWaterMark?: number }"
+                                }
+                            ],
+                            "overrideType": "ReadableStream<Uint8Array>"
+                        },
+                        "1": {
                             "typeParameters": [
                                 {
                                     "name": "R",
@@ -2358,10 +2372,33 @@
                             "param": [
                                 {
                                     "name": "underlyingSource",
+                                    "optional": false,
+                                    "overrideType": "UnderlyingDefaultSource<R>"
+                                },
+                                {
+                                    "name": "strategy",
+                                    "optional": true,
+                                    "overrideType": "QueuingStrategy<R>"
+                                }
+                            ],
+                            "overrideType": "ReadableStream<R>"
+                        },
+                        "2": {
+                            "typeParameters": [
+                                {
+                                    "name": "R",
+                                    "default": "any"
+                                }
+                            ],
+                            "param": [
+                                {
+                                    "name": "underlyingSource",
+                                    "optional": true,
                                     "overrideType": "UnderlyingSource<R>"
                                 },
                                 {
                                     "name": "strategy",
+                                    "optional": true,
                                     "overrideType": "QueuingStrategy<R>"
                                 }
                             ],
@@ -2371,6 +2408,12 @@
                     "force-references": [
                         {
                             "type": "UnderlyingSource"
+                        },
+                        {
+                            "type": "UnderlyingByteSource"
+                        },
+                        {
+                            "type": "UnderlyingDefaultSource"
                         },
                         {
                             "type": "QueuingStrategy"

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2431,15 +2431,7 @@
                                 "0": {
                                     "overrideType": "ReadableStreamReader<R>"
                                 }
-                            },
-                            "force-references": [
-                                {
-                                    "type": "ReadableStreamDefaultReader"
-                                },
-                                {
-                                    "type": "ReadableStreamBYOBReader"
-                                }
-                            ]
+                            }
                         },
                         "pipeThrough": {
                             "signature": {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2353,7 +2353,7 @@
                                 {
                                     "name": "underlyingSource",
                                     "optional": false,
-                                    "overrideType": "UnderlyingByteSource"
+                                    "type": "UnderlyingByteSource"
                                 },
                                 {
                                     "name": "strategy",

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2380,11 +2380,23 @@
                 "methods": {
                     "method": {
                         "getReader": {
+                            "additionalSignatures": [
+                                "getReader(options: { mode: \"byob\" }): ReadableStreamBYOBReader",
+                                "getReader(): ReadableStreamDefaultReader<R>"
+                            ],
                             "signature": {
                                 "0": {
-                                    "overrideType": "ReadableStreamDefaultReader<R>"
+                                    "overrideType": "ReadableStreamReader<R>"
                                 }
-                            }
+                            },
+                            "force-references": [
+                                {
+                                    "type": "ReadableStreamDefaultReader"
+                                },
+                                {
+                                    "type": "ReadableStreamBYOBReader"
+                                }
+                            ]
                         },
                         "pipeThrough": {
                             "signature": {
@@ -2432,11 +2444,19 @@
                         "read": {
                             "signature": {
                                 "0": {
-                                    "subtype": {
-                                        "subtype": {
-                                            "type": "ArrayBufferView"
+                                    "typeParameters": [
+                                        {
+                                            "name": "T",
+                                            "extends": "ArrayBufferView"
                                         }
-                                    }
+                                    ],
+                                    "param": [
+                                        {
+                                            "name": "view",
+                                            "overrideType": "T"
+                                        }
+                                    ],
+                                    "overrideType": "Promise<ReadableStreamReadResult<T>>"
                                 }
                             }
                         }
@@ -3167,9 +3187,6 @@
                         },
                         "pull": {
                             "overrideType": "UnderlyingSourcePullCallback<R>"
-                        },
-                        "type": {
-                            "overrideType": "undefined"
                         }
                     }
                 }
@@ -3264,7 +3281,7 @@
     "typedefs": {
         "typedef": [
             {
-                "overrideType": "ReadableStreamDefaultController<T>",
+                "overrideType": "ReadableStreamDefaultController<T> | ReadableByteStreamController",
                 "name": "ReadableStreamController",
                 "typeParameters": [
                     {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -3288,6 +3288,23 @@
                         "name": "T"
                     }
                 ]
+            },
+            {
+                "name": "ReadableStreamReader",
+                "typeParameters": [
+                    {
+                        "name": "T"
+                    }
+                ],
+                "type": [
+                    {
+                        "type": "ReadableStreamDefaultReader"
+                    },
+                    {
+                        "type": "ReadableStreamBYOBReader"
+                    }
+                ],
+                "overrideType": "ReadableStreamDefaultReader<T> | ReadableStreamBYOBReader"
             }
         ]
     },

--- a/inputfiles/removedTypes.jsonc
+++ b/inputfiles/removedTypes.jsonc
@@ -19,8 +19,6 @@
             "CredentialMediationRequirement": {
                 "value": ["conditional"] // tied to Credential#isConditionalMediationAvailable
             },
-            "ReadableStreamReaderMode": null,
-            "ReadableStreamType": null,
             "RTCStatsType": {
                 "value": [
                     "stream",
@@ -72,19 +70,6 @@
             },
             "NetworkInformation": {
                 "implements": ["NetworkInformationSaveData"]
-            },
-            "ReadableStream": {
-                "methods": {
-                    "method": {
-                        "getReader": {
-                            "signature": {
-                                "0": {
-                                    "param": ["options"]
-                                }
-                            }
-                        }
-                    }
-                }
             },
             "Response": {
                 "methods": {
@@ -377,7 +362,6 @@
                 }
             },
             "ReadableStreamReadResult": null,
-            "ReadableStreamGetReaderOptions": null,
             "RequestInit": {
                 "members": {
                     "member": {
@@ -572,13 +556,6 @@
                 "members": {
                     "member": {
                         "sourceCapabilities": null
-                    }
-                }
-            },
-            "UnderlyingSource": {
-                "members": {
-                    "member": {
-                        "autoAllocateChunkSize": null
                     }
                 }
             },

--- a/unittests/files/streams.ts
+++ b/unittests/files/streams.ts
@@ -7,3 +7,8 @@ defaultReader.read();
 
 const byobReader = readable.getReader({ mode: "byob" });
 byobReader.read(new Uint8Array(1));
+byobReader.read(new DataView(new ArrayBuffer(1))).then((result) => {
+  if (!result.done) {
+    result.value.getUint8(0);
+  }
+});

--- a/unittests/files/streams.ts
+++ b/unittests/files/streams.ts
@@ -1,6 +1,25 @@
+const readableStream = new ReadableStream<string>({
+  start(controller) {
+    controller.desiredSize;
+    controller.enqueue("a");
+  },
+  pull(controller) {
+    controller.enqueue("b");
+    controller.close();
+  },
+});
+
+const defaultReader1 = readableStream.getReader();
+defaultReader1.read().then((result) => {
+  if (!result.done) {
+    result.value.charAt(0);
+  }
+});
+
 const readableByteStream = new ReadableStream({
   type: "bytes",
   start(controller) {
+    controller.desiredSize;
     controller.byobRequest;
   },
   pull(controller) {
@@ -15,8 +34,8 @@ const readableByteStream = new ReadableStream({
   },
 });
 
-const defaultReader = readableByteStream.getReader();
-defaultReader.read().then((result) => {
+const defaultReader2 = readableByteStream.getReader();
+defaultReader2.read().then((result) => {
   if (!result.done) {
     result.value.buffer;
     result.value[0];

--- a/unittests/files/streams.ts
+++ b/unittests/files/streams.ts
@@ -1,11 +1,29 @@
-const readable = new ReadableStream({
+const readableByteStream = new ReadableStream({
   type: "bytes",
+  start(controller) {
+    controller.byobRequest;
+  },
+  pull(controller) {
+    if (controller.byobRequest) {
+      controller.byobRequest.view;
+      controller.byobRequest.respond(1);
+      controller.byobRequest.respondWithNewView(new Uint32Array(1));
+    } else {
+      controller.enqueue(new Uint8Array(1));
+    }
+    controller.close();
+  },
 });
 
-const defaultReader = readable.getReader();
-defaultReader.read();
+const defaultReader = readableByteStream.getReader();
+defaultReader.read().then((result) => {
+  if (!result.done) {
+    result.value.buffer;
+    result.value[0];
+  }
+});
 
-const byobReader = readable.getReader({ mode: "byob" });
+const byobReader = readableByteStream.getReader({ mode: "byob" });
 byobReader.read(new Uint8Array(1));
 byobReader.read(new DataView(new ArrayBuffer(1))).then((result) => {
   if (!result.done) {

--- a/unittests/files/streams.ts
+++ b/unittests/files/streams.ts
@@ -11,6 +11,9 @@ const readableStream = new ReadableStream<string>({
     controller.enqueue("b");
     controller.close();
   },
+  cancel(reason) {
+    assertType<any>(reason);
+  },
 });
 
 const defaultReader1 = readableStream.getReader();
@@ -41,6 +44,9 @@ const readableByteStream = new ReadableStream({
     }
     controller.close();
   },
+  cancel(reason) {
+    assertType<any>(reason);
+  },
 });
 
 const defaultReader2 = readableByteStream.getReader();
@@ -62,3 +68,43 @@ byobReader.read(new DataView(new ArrayBuffer(1))).then((result) => {
     result.value.getUint8(0);
   }
 });
+
+const writableStream = new WritableStream<number>({
+  start(controller) {
+    assertType<WritableStreamDefaultController>(controller);
+  },
+  write(chunk, controller) {
+    assertType<number>(chunk);
+    assertType<WritableStreamDefaultController>(controller);
+    chunk.toFixed(3);
+    controller.error("boom!");
+  },
+  close() {},
+  abort(reason) {
+    assertType<any>(reason);
+  },
+});
+
+const defaultWriter = writableStream.getWriter();
+assertType<WritableStreamDefaultWriter<number>>(defaultWriter);
+defaultWriter.write(42);
+defaultWriter.close();
+defaultWriter.abort("boom!");
+
+const transformStream = new TransformStream<string, number>({
+  start(controller) {
+    assertType<TransformStreamDefaultController<number>>(controller);
+  },
+  transform(chunk, controller) {
+    assertType<string>(chunk);
+    assertType<TransformStreamDefaultController<number>>(controller);
+    controller.enqueue(chunk.length);
+    controller.error("boom!");
+  },
+  flush(controller) {
+    assertType<TransformStreamDefaultController<number>>(controller);
+    controller.terminate();
+  },
+});
+assertType<ReadableStream<number>>(transformStream.readable);
+assertType<WritableStream<string>>(transformStream.writable);

--- a/unittests/files/streams.ts
+++ b/unittests/files/streams.ts
@@ -1,16 +1,22 @@
+function assertType<T>(_x: T) {}
+
 const readableStream = new ReadableStream<string>({
   start(controller) {
+    assertType<ReadableStreamDefaultController<string>>(controller);
     controller.desiredSize;
     controller.enqueue("a");
   },
   pull(controller) {
+    assertType<ReadableStreamDefaultController<string>>(controller);
     controller.enqueue("b");
     controller.close();
   },
 });
 
 const defaultReader1 = readableStream.getReader();
+assertType<ReadableStreamDefaultReader<string>>(defaultReader1);
 defaultReader1.read().then((result) => {
+  assertType<ReadableStreamReadResult<string>>(result);
   if (!result.done) {
     result.value.charAt(0);
   }
@@ -19,11 +25,14 @@ defaultReader1.read().then((result) => {
 const readableByteStream = new ReadableStream({
   type: "bytes",
   start(controller) {
+    assertType<ReadableByteStreamController>(controller);
     controller.desiredSize;
     controller.byobRequest;
   },
   pull(controller) {
+    assertType<ReadableByteStreamController>(controller);
     if (controller.byobRequest) {
+      assertType<ReadableStreamBYOBRequest>(controller.byobRequest);
       controller.byobRequest.view;
       controller.byobRequest.respond(1);
       controller.byobRequest.respondWithNewView(new Uint32Array(1));
@@ -35,7 +44,9 @@ const readableByteStream = new ReadableStream({
 });
 
 const defaultReader2 = readableByteStream.getReader();
+assertType<ReadableStreamDefaultReader<Uint8Array>>(defaultReader2);
 defaultReader2.read().then((result) => {
+  assertType<ReadableStreamReadResult<Uint8Array>>(result);
   if (!result.done) {
     result.value.buffer;
     result.value[0];
@@ -43,8 +54,10 @@ defaultReader2.read().then((result) => {
 });
 
 const byobReader = readableByteStream.getReader({ mode: "byob" });
+assertType<ReadableStreamBYOBReader>(byobReader);
 byobReader.read(new Uint8Array(1));
 byobReader.read(new DataView(new ArrayBuffer(1))).then((result) => {
+  assertType<ReadableStreamReadResult<DataView>>(result);
   if (!result.done) {
     result.value.getUint8(0);
   }

--- a/unittests/files/streams.ts
+++ b/unittests/files/streams.ts
@@ -1,0 +1,9 @@
+const readable = new ReadableStream({
+  type: "bytes",
+});
+
+const defaultReader = readable.getReader();
+defaultReader.read();
+
+const byobReader = readable.getReader({ mode: "byob" });
+byobReader.read(new Uint8Array(1));


### PR DESCRIPTION
[With Firefox 102 adding support for readable byte streams](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/102), we now have two browser engines (Chromium and Gecko) shipping this feature. This means we can finally add official type definitions! 😁

Most of work was already done in #890 but then those types had to be removed. This PR brings them back, and hopefully they'll stay this time around. 😅