### PR TITLE
feat: AudioParamMap extends ReadonlyMap<string, AudioParam>

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2276,7 +2276,7 @@ declare var AudioParam: {
     new(): AudioParam;
 };
 
-interface AudioParamMap {
+interface AudioParamMap extends ReadonlyMap<string, AudioParam> {
     forEach(callbackfn: (value: AudioParam, key: string, parent: AudioParamMap) => void, thisArg?: any): void;
 }
 

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -428,6 +428,9 @@
     },
     "interfaces": {
         "interface": {
+            "AudioParamMap": {
+                "extends": "ReadonlyMap<string, AudioParam>"
+            },
             "CryptoKey": {
                 "properties": {
                     "property": {


### PR DESCRIPTION
fixes #1358

Note that the forEach method could be removed as it exists on the ReadonlyMap Interface. I tried to remove it by adding it to removedTypes.json but failed.