### PR TITLE
IDB's 'blocked' event should be an IDBVersionChangeEvent

### DIFF
--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -799,6 +799,10 @@
                         {
                             "name": "upgradeneeded",
                             "type": "IDBVersionChangeEvent"
+                        },
+                        {
+                            "name": "blocked",
+                            "type": "IDBVersionChangeEvent"
                         }
                     ]
                 }


### PR DESCRIPTION
From the spec https://w3c.github.io/IndexedDB/#ref-for-fire-a-version-change-event%E2%91%A1

From MDN https://developer.mozilla.org/en-US/docs/Web/API/IDBOpenDBRequest/blocked_event#event_type

From Chromium https://chromium.googlesource.com/chromium/blink/+/refs/heads/main/Source/modules/indexeddb/IDBOpenDBRequest.cpp#78

From Firefox https://github.com/mozilla/integration-mozilla-inbound/blob/0d01aa29ce350beca861f7d3b7b4df399b246ed0/dom/indexedDB/OpenDatabaseHelper.cpp#L1524