### PR TITLE
docs: Add `0.0.69`, `4.8 rc`, & `4.8` to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ npm run test
 | `@types/web` [0.0.61](https://www.npmjs.com/package/@types/web/v/0.0.61)  | 4.7 rc      | 4.4            |
 | `@types/web` [0.0.61](https://www.npmjs.com/package/@types/web/v/0.0.61)  | 4.7         | 4.4            |
 | `@types/web` [0.0.68](https://www.npmjs.com/package/@types/web/v/0.0.68)  | 4.8 beta    | 4.4            |
+| `@types/web` [0.0.69](https://www.npmjs.com/package/@types/web/v/0.0.69)  | 4.8 rc      | 4.4            |
+| `@types/web` [0.0.69](https://www.npmjs.com/package/@types/web/v/0.0.69)  | 4.8         | 4.4            |
 
 ## `@types/[lib]` Minimum Target
 


### PR DESCRIPTION
See https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1383#issuecomment-1287927095.

Reasonably confident, but also wondering if there is a tight correspondence between these versions, it's possible there were changes made in third-party sources during this 18-day gap:
Jul 02, 2022: [@types/web@0.0.69](https://github.com/microsoft/TypeScript-DOM-lib-generator/releases/tag/%40types%2Fweb%400.0.69)
July 20, 2022: `v4.8-rc` https://github.com/microsoft/TypeScript/pull/49976