### PR TITLE
better constant definitions for Websocket, EventSource, and FileReader

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5275,9 +5275,9 @@ interface EventSource extends EventTarget {
     readonly withCredentials: boolean;
     /** Aborts any instances of the fetch algorithm started for this EventSource object, and sets the readyState attribute to CLOSED. */
     close(): void;
-    readonly CLOSED: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
     addEventListener<K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: (this: EventSource, event: MessageEvent) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -5289,9 +5289,9 @@ interface EventSource extends EventTarget {
 declare var EventSource: {
     prototype: EventSource;
     new(url: string | URL, eventSourceInitDict?: EventSourceInit): EventSource;
-    readonly CLOSED: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
 };
 
 /** EventTarget is a DOM interface implemented by objects that can receive events and may have listeners for them. */
@@ -5386,9 +5386,9 @@ interface FileReader extends EventTarget {
     readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
     readAsText(blob: Blob, encoding?: string): void;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
     addEventListener<K extends keyof FileReaderEventMap>(type: K, listener: (this: FileReader, ev: FileReaderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof FileReaderEventMap>(type: K, listener: (this: FileReader, ev: FileReaderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -5398,9 +5398,9 @@ interface FileReader extends EventTarget {
 declare var FileReader: {
     prototype: FileReader;
     new(): FileReader;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
 };
 
 interface FileSystem {
@@ -16857,10 +16857,10 @@ interface WebSocket extends EventTarget {
     close(code?: number, reason?: string): void;
     /** Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView. */
     send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void;
-    readonly CLOSED: number;
-    readonly CLOSING: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 3;
+    readonly CLOSING: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
     addEventListener<K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -16870,10 +16870,10 @@ interface WebSocket extends EventTarget {
 declare var WebSocket: {
     prototype: WebSocket;
     new(url: string | URL, protocols?: string | string[]): WebSocket;
-    readonly CLOSED: number;
-    readonly CLOSING: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 3;
+    readonly CLOSING: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
 };
 
 /** Events that occur due to the user moving a mouse wheel or similar input device. */

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -1493,9 +1493,9 @@ interface EventSource extends EventTarget {
     readonly withCredentials: boolean;
     /** Aborts any instances of the fetch algorithm started for this EventSource object, and sets the readyState attribute to CLOSED. */
     close(): void;
-    readonly CLOSED: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
     addEventListener<K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: (this: EventSource, event: MessageEvent) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -1507,9 +1507,9 @@ interface EventSource extends EventTarget {
 declare var EventSource: {
     prototype: EventSource;
     new(url: string | URL, eventSourceInitDict?: EventSourceInit): EventSource;
-    readonly CLOSED: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
 };
 
 /** EventTarget is a DOM interface implemented by objects that can receive events and may have listeners for them. */
@@ -1629,9 +1629,9 @@ interface FileReader extends EventTarget {
     readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
     readAsText(blob: Blob, encoding?: string): void;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
     addEventListener<K extends keyof FileReaderEventMap>(type: K, listener: (this: FileReader, ev: FileReaderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof FileReaderEventMap>(type: K, listener: (this: FileReader, ev: FileReaderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -1641,9 +1641,9 @@ interface FileReader extends EventTarget {
 declare var FileReader: {
     prototype: FileReader;
     new(): FileReader;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
 };
 
 /** Available only in secure contexts. */
@@ -5330,10 +5330,10 @@ interface WebSocket extends EventTarget {
     close(code?: number, reason?: string): void;
     /** Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView. */
     send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void;
-    readonly CLOSED: number;
-    readonly CLOSING: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 3;
+    readonly CLOSING: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
     addEventListener<K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -5343,10 +5343,10 @@ interface WebSocket extends EventTarget {
 declare var WebSocket: {
     prototype: WebSocket;
     new(url: string | URL, protocols?: string | string[]): WebSocket;
-    readonly CLOSED: number;
-    readonly CLOSING: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 3;
+    readonly CLOSING: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
 };
 
 /** This ServiceWorker API interface represents the scope of a service worker client that is a document in a browser context, controlled by an active worker. The service worker client independently selects and uses a service worker for its own loading and sub-resources. */

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -1437,9 +1437,9 @@ interface EventSource extends EventTarget {
     readonly withCredentials: boolean;
     /** Aborts any instances of the fetch algorithm started for this EventSource object, and sets the readyState attribute to CLOSED. */
     close(): void;
-    readonly CLOSED: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
     addEventListener<K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: (this: EventSource, event: MessageEvent) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -1451,9 +1451,9 @@ interface EventSource extends EventTarget {
 declare var EventSource: {
     prototype: EventSource;
     new(url: string | URL, eventSourceInitDict?: EventSourceInit): EventSource;
-    readonly CLOSED: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
 };
 
 /** EventTarget is a DOM interface implemented by objects that can receive events and may have listeners for them. */
@@ -1534,9 +1534,9 @@ interface FileReader extends EventTarget {
     readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
     readAsText(blob: Blob, encoding?: string): void;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
     addEventListener<K extends keyof FileReaderEventMap>(type: K, listener: (this: FileReader, ev: FileReaderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof FileReaderEventMap>(type: K, listener: (this: FileReader, ev: FileReaderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -1546,9 +1546,9 @@ interface FileReader extends EventTarget {
 declare var FileReader: {
     prototype: FileReader;
     new(): FileReader;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
 };
 
 /** Allows to read File or Blob objects in a synchronous way. */
@@ -5194,10 +5194,10 @@ interface WebSocket extends EventTarget {
     close(code?: number, reason?: string): void;
     /** Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView. */
     send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void;
-    readonly CLOSED: number;
-    readonly CLOSING: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 3;
+    readonly CLOSING: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
     addEventListener<K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -5207,10 +5207,10 @@ interface WebSocket extends EventTarget {
 declare var WebSocket: {
     prototype: WebSocket;
     new(url: string | URL, protocols?: string | string[]): WebSocket;
-    readonly CLOSED: number;
-    readonly CLOSING: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 3;
+    readonly CLOSING: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
 };
 
 interface WindowOrWorkerGlobalScope {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1558,9 +1558,9 @@ interface EventSource extends EventTarget {
     readonly withCredentials: boolean;
     /** Aborts any instances of the fetch algorithm started for this EventSource object, and sets the readyState attribute to CLOSED. */
     close(): void;
-    readonly CLOSED: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
     addEventListener<K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: (this: EventSource, event: MessageEvent) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -1572,9 +1572,9 @@ interface EventSource extends EventTarget {
 declare var EventSource: {
     prototype: EventSource;
     new(url: string | URL, eventSourceInitDict?: EventSourceInit): EventSource;
-    readonly CLOSED: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
 };
 
 /** EventTarget is a DOM interface implemented by objects that can receive events and may have listeners for them. */
@@ -1694,9 +1694,9 @@ interface FileReader extends EventTarget {
     readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
     readAsText(blob: Blob, encoding?: string): void;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
     addEventListener<K extends keyof FileReaderEventMap>(type: K, listener: (this: FileReader, ev: FileReaderEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof FileReaderEventMap>(type: K, listener: (this: FileReader, ev: FileReaderEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -1706,9 +1706,9 @@ interface FileReader extends EventTarget {
 declare var FileReader: {
     prototype: FileReader;
     new(): FileReader;
-    readonly DONE: number;
-    readonly EMPTY: number;
-    readonly LOADING: number;
+    readonly DONE: 2;
+    readonly EMPTY: 0;
+    readonly LOADING: 1;
 };
 
 /** Allows to read File or Blob objects in a synchronous way. */
@@ -5484,10 +5484,10 @@ interface WebSocket extends EventTarget {
     close(code?: number, reason?: string): void;
     /** Transmits data using the WebSocket connection. data can be a string, a Blob, an ArrayBuffer, or an ArrayBufferView. */
     send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void;
-    readonly CLOSED: number;
-    readonly CLOSING: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 3;
+    readonly CLOSING: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
     addEventListener<K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof WebSocketEventMap>(type: K, listener: (this: WebSocket, ev: WebSocketEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -5497,10 +5497,10 @@ interface WebSocket extends EventTarget {
 declare var WebSocket: {
     prototype: WebSocket;
     new(url: string | URL, protocols?: string | string[]): WebSocket;
-    readonly CLOSED: number;
-    readonly CLOSING: number;
-    readonly CONNECTING: number;
-    readonly OPEN: number;
+    readonly CLOSED: 3;
+    readonly CLOSING: 2;
+    readonly CONNECTING: 0;
+    readonly OPEN: 1;
 };
 
 /** This ServiceWorker API interface represents the scope of a service worker client that is a document in a browser context, controlled by an active worker. The service worker client independently selects and uses a service worker for its own loading and sub-resources. */

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1805,23 +1805,15 @@
                 "constants": {
                     "constant": {
                         "CONNECTING": {
-                            "name": "CONNECTING",
-                            "readonly": true,
                             "overrideType": "0"
                         },
                         "OPEN": {
-                            "name": "OPEN",
-                            "readonly": true,
                             "overrideType": "1"
                         },
                         "CLOSING": {
-                            "name": "CLOSING",
-                            "readonly": true,
                             "overrideType": "2"
                         },
                         "CLOSED": {
-                            "name": "CLOSED",
-                            "readonly": true,
                             "overrideType": "3"
                         }
                     }
@@ -1831,18 +1823,12 @@
                 "constants": {
                     "constant": {
                         "CONNECTING": {
-                            "name": "CONNECTING",
-                            "readonly": true,
                             "overrideType": "0"
                         },
                         "OPEN": {
-                            "name": "OPEN",
-                            "readonly": true,
                             "overrideType": "1"
                         },
                         "CLOSED": {
-                            "name": "CLOSED",
-                            "readonly": true,
                             "overrideType": "2"
                         }
                     }
@@ -1928,18 +1914,12 @@
                 "constants": {
                     "constant": {
                         "EMPTY": {
-                            "name": "EMPTY",
-                            "readonly": true,
                             "overrideType": "0"
                         },
                         "LOADING": {
-                            "name": "LOADING",
-                            "readonly": true,
                             "overrideType": "1"
                         },
                         "DONE": {
-                            "name": "DONE",
-                            "readonly": true,
                             "overrideType": "2"
                         }
                     }

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1801,6 +1801,51 @@
                             "type": "MessageEvent"
                         }
                     ]
+                },
+                "constants": {
+                    "constant": {
+                        "CONNECTING": {
+                            "name": "CONNECTING",
+                            "readonly": true,
+                            "overrideType": "0"
+                        },
+                        "OPEN": {
+                            "name": "OPEN",
+                            "readonly": true,
+                            "overrideType": "1"
+                        },
+                        "CLOSING": {
+                            "name": "CLOSING",
+                            "readonly": true,
+                            "overrideType": "2"
+                        },
+                        "CLOSED": {
+                            "name": "CLOSED",
+                            "readonly": true,
+                            "overrideType": "3"
+                        }
+                    }
+                }
+            },
+            "EventSource": {
+                "constants": {
+                    "constant": {
+                        "CONNECTING": {
+                            "name": "CONNECTING",
+                            "readonly": true,
+                            "overrideType": "0"
+                        },
+                        "OPEN": {
+                            "name": "OPEN",
+                            "readonly": true,
+                            "overrideType": "1"
+                        },
+                        "CLOSED": {
+                            "name": "CLOSED",
+                            "readonly": true,
+                            "overrideType": "2"
+                        }
+                    }
                 }
             },
             "HTMLTableRowElement": {
@@ -1880,6 +1925,25 @@
                 }
             },
             "FileReader": {
+                "constants": {
+                    "constant": {
+                        "EMPTY": {
+                            "name": "EMPTY",
+                            "readonly": true,
+                            "overrideType": "0"
+                        },
+                        "LOADING": {
+                            "name": "LOADING",
+                            "readonly": true,
+                            "overrideType": "1"
+                        },
+                        "DONE": {
+                            "name": "DONE",
+                            "readonly": true,
+                            "overrideType": "2"
+                        }
+                    }
+                },
                 "events": {
                     "event": [
                         {


### PR DESCRIPTION
The websocket spec defines the values of constants like `WebSocket.OPEN`, so they're never going to change. Defining them as literal numbers allows us to write more type-safe code. The same as true for `EventSource` and `FileReader`.

This [same change was made to the `@types/ws` package](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/ws/index.d.ts#L55-L62), which has been very helpful in the NodeJS world. 

I think it's unlikley that this will be a breaking change (?) since `0` and `1` etc. are a subset of `number`, but I could be wrong here. 

There was a discussion at https://github.com/microsoft/TypeScript/issues/25090 where an impossible solution to this problem was proposed (const enums).