### PR TITLE
`mediation: "conditional"` should be available now

### DIFF
--- a/inputfiles/removedTypes.jsonc
+++ b/inputfiles/removedTypes.jsonc
@@ -16,9 +16,6 @@
             "ConnectionType": {
                 "value": ["wimax"]
             },
-            "CredentialMediationRequirement": {
-                "value": ["conditional"] // tied to Credential#isConditionalMediationAvailable
-            },
             "GamepadHapticActuatorType": {
                 "value": ["dual-rumble"] // Blink only as of 2022-12
             },


### PR DESCRIPTION
`PublicKeyCredential.isConditionalMediationAvailable()` method is already available, `mediation` field's value `"conditional"` should also be available now. https://github.com/microsoft/TypeScript-DOM-lib-generator/blob/0337998b669df62d10f3acb96cc2f7c2382bbfda/baselines/dom.generated.d.ts#L11245

There was a previous issue that proposed the same thing, but it was closed because 'isConditionalMediationAvailable' was not available.
https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/1391

However, it's now available in both MDN document and this repo's `baselines/` file.