### PR TITLE
docs: Add TypeScript 4.9 to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npm run test
 | `@types/web` [0.0.68](https://www.npmjs.com/package/@types/web/v/0.0.68)  | 4.8 beta    | 4.4            |
 | `@types/web` [0.0.69](https://www.npmjs.com/package/@types/web/v/0.0.69)  | 4.8 rc      | 4.4            |
 | `@types/web` [0.0.69](https://www.npmjs.com/package/@types/web/v/0.0.69)  | 4.8         | 4.4            |
+| `@types/web` [0.0.76](https://www.npmjs.com/package/@types/web/v/0.0.76)  | 4.9         | 4.4            |
 
 ## `@types/[lib]` Minimum Target
 


### PR DESCRIPTION
TS 4.9 released on November 17, 2022: https://github.com/microsoft/TypeScript/commit/93bd577458d55cd720b2677705feab5c91eb12ce The last change in that ref's tree to `src/lib/dom.generated.d.ts` is from https://github.com/microsoft/TypeScript/pull/51300 on October 25, 2022 which pulled in the types from @types/web 0.0.76, released on October 24, 2022.

Verified by running
```sh
curl "https://raw.githubusercontent.com/microsoft/TypeScript/93bd577458d55cd720b2677705feab5c91eb12ce/src/lib/dom.generated.d.ts" -o ts-types.txt
curl "https://raw.githubusercontent.com/microsoft/TypeScript-DOM-lib-generator/1a77ff811b6b515636c24789ac2cf8f008d4bcbb/baselines/dom.generated.d.ts" -o ts-dom-types.txt
diff ts-types.txt ts-dom-types.txt # no output meaning the files are identicial
```