### PR TITLE
FileReader.readyState: use FileReader state constants as possible values

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5389,7 +5389,7 @@ interface FileReader extends EventTarget {
     onloadend: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
     onloadstart: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
     onprogress: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
-    readonly readyState: number;
+    readonly readyState: typeof FileReader.EMPTY | typeof FileReader.LOADING | typeof FileReader.DONE;
     readonly result: string | ArrayBuffer | null;
     abort(): void;
     readAsArrayBuffer(blob: Blob): void;

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -1627,7 +1627,7 @@ interface FileReader extends EventTarget {
     onloadend: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
     onloadstart: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
     onprogress: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
-    readonly readyState: number;
+    readonly readyState: typeof FileReader.EMPTY | typeof FileReader.LOADING | typeof FileReader.DONE;
     readonly result: string | ArrayBuffer | null;
     abort(): void;
     readAsArrayBuffer(blob: Blob): void;

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -1532,7 +1532,7 @@ interface FileReader extends EventTarget {
     onloadend: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
     onloadstart: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
     onprogress: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
-    readonly readyState: number;
+    readonly readyState: typeof FileReader.EMPTY | typeof FileReader.LOADING | typeof FileReader.DONE;
     readonly result: string | ArrayBuffer | null;
     abort(): void;
     readAsArrayBuffer(blob: Blob): void;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1692,7 +1692,7 @@ interface FileReader extends EventTarget {
     onloadend: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
     onloadstart: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
     onprogress: ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null;
-    readonly readyState: number;
+    readonly readyState: typeof FileReader.EMPTY | typeof FileReader.LOADING | typeof FileReader.DONE;
     readonly result: string | ArrayBuffer | null;
     abort(): void;
     readAsArrayBuffer(blob: Blob): void;

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1923,6 +1923,14 @@
                             "type": "ProgressEvent"
                         }
                     ]
+                },
+                "properties": {
+                    "property": {
+                        "readyState": {
+                            "name": "readyState",
+                            "overrideType": "typeof FileReader.EMPTY | typeof FileReader.LOADING | typeof FileReader.DONE"
+                        }
+                    }
                 }
             },
             "FileSystemDirectoryHandle": {


### PR DESCRIPTION
The spec doesn't allow any other values besides these constants for readyState.

See https://w3c.github.io/FileAPI/#dom-filereader-readystate

Not sure if this is the preferred way to narrow the type, I couldn't find any other examples using this pattern. Since this declaration uses constants instead of enums, it shouldn't break any consuming code. The following still compiles:
```ts
fileReader.readyState === 2;
declare const someNumber: number;
fileReader.readyState === someNumber;
```

While using an invalid value here no longer does:
```ts
fileReader.readyState === 5 // TS2367: This comparison appears to be unintentional because the types '0 | 1 | 2' and '5' have no overlap.
```