### PR TITLE
Make structuredClone generic

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -17776,7 +17776,7 @@ interface WindowOrWorkerGlobalScope {
     reportError(e: any): void;
     setInterval(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
     setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
-    structuredClone(value: any, options?: StructuredSerializeOptions): any;
+    structuredClone<T = any>(value: T, options?: StructuredSerializeOptions): T;
 }
 
 interface WindowSessionStorage {
@@ -19193,7 +19193,7 @@ declare function queueMicrotask(callback: VoidFunction): void;
 declare function reportError(e: any): void;
 declare function setInterval(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
 declare function setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
-declare function structuredClone(value: any, options?: StructuredSerializeOptions): any;
+declare function structuredClone<T = any>(value: T, options?: StructuredSerializeOptions): T;
 declare var sessionStorage: Storage;
 declare function addEventListener<K extends keyof WindowEventMap>(type: K, listener: (this: Window, ev: WindowEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
 declare function addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -5751,7 +5751,7 @@ interface WindowOrWorkerGlobalScope {
     reportError(e: any): void;
     setInterval(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
     setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
-    structuredClone(value: any, options?: StructuredSerializeOptions): any;
+    structuredClone<T = any>(value: T, options?: StructuredSerializeOptions): T;
 }
 
 interface WorkerGlobalScopeEventMap {
@@ -6129,7 +6129,7 @@ declare function queueMicrotask(callback: VoidFunction): void;
 declare function reportError(e: any): void;
 declare function setInterval(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
 declare function setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
-declare function structuredClone(value: any, options?: StructuredSerializeOptions): any;
+declare function structuredClone<T = any>(value: T, options?: StructuredSerializeOptions): T;
 declare function addEventListener<K extends keyof ServiceWorkerGlobalScopeEventMap>(type: K, listener: (this: ServiceWorkerGlobalScope, ev: ServiceWorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
 declare function addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
 declare function removeEventListener<K extends keyof ServiceWorkerGlobalScopeEventMap>(type: K, listener: (this: ServiceWorkerGlobalScope, ev: ServiceWorkerGlobalScopeEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -5602,7 +5602,7 @@ interface WindowOrWorkerGlobalScope {
     reportError(e: any): void;
     setInterval(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
     setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
-    structuredClone(value: any, options?: StructuredSerializeOptions): any;
+    structuredClone<T = any>(value: T, options?: StructuredSerializeOptions): T;
 }
 
 interface WorkerEventMap extends AbstractWorkerEventMap {
@@ -6140,7 +6140,7 @@ declare function queueMicrotask(callback: VoidFunction): void;
 declare function reportError(e: any): void;
 declare function setInterval(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
 declare function setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
-declare function structuredClone(value: any, options?: StructuredSerializeOptions): any;
+declare function structuredClone<T = any>(value: T, options?: StructuredSerializeOptions): T;
 declare function addEventListener<K extends keyof SharedWorkerGlobalScopeEventMap>(type: K, listener: (this: SharedWorkerGlobalScope, ev: SharedWorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
 declare function addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
 declare function removeEventListener<K extends keyof SharedWorkerGlobalScopeEventMap>(type: K, listener: (this: SharedWorkerGlobalScope, ev: SharedWorkerGlobalScopeEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -6092,7 +6092,7 @@ interface WindowOrWorkerGlobalScope {
     reportError(e: any): void;
     setInterval(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
     setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
-    structuredClone(value: any, options?: StructuredSerializeOptions): any;
+    structuredClone<T = any>(value: T, options?: StructuredSerializeOptions): T;
 }
 
 interface WorkerEventMap extends AbstractWorkerEventMap {
@@ -6650,7 +6650,7 @@ declare function queueMicrotask(callback: VoidFunction): void;
 declare function reportError(e: any): void;
 declare function setInterval(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
 declare function setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
-declare function structuredClone(value: any, options?: StructuredSerializeOptions): any;
+declare function structuredClone<T = any>(value: T, options?: StructuredSerializeOptions): T;
 declare function cancelAnimationFrame(handle: number): void;
 declare function requestAnimationFrame(callback: FrameRequestCallback): number;
 declare function addEventListener<K extends keyof DedicatedWorkerGlobalScopeEventMap>(type: K, listener: (this: DedicatedWorkerGlobalScope, ev: DedicatedWorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -252,6 +252,25 @@
                                 }
                             }
                         },
+                        "structuredClone": {
+                            "signature": {
+                                "0": {
+                                    "typeParameters": [
+                                        {
+                                            "name": "T",
+                                            "default": "any"
+                                        }
+                                    ],
+                                    "param": [
+                                        {
+                                            "name": "value",
+                                            "overrideType": "T"
+                                        }
+                                    ],
+                                    "overrideType": "T"
+                                }
+                            }
+                        },
                         "clearTimeout": {
                             "signature": {
                                 "0": {

--- a/unittests/files/structuredClone.ts
+++ b/unittests/files/structuredClone.ts
@@ -1,0 +1,17 @@
+function assertType<T>(_x: T) {}
+
+const toBeCloned = {
+  name: "abc",
+  address: "test",
+  age: 30,
+  info: {
+    url: "https://example.com",
+  },
+} as const;
+
+const nonMatchingType = { foo: "bar" } as const;
+const clone = structuredClone(toBeCloned);
+
+assertType<typeof toBeCloned>(clone);
+// @ts-expect-error non matching type
+assertType<typeof nonMatchingType>(clone);


### PR DESCRIPTION
Looks to addresse [this issue](https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1237).

Creates a generic for structuredClone.

[Playground with examples](https://www.typescriptlang.org/play?ssl=3&ssc=3&pln=1&pc=1#code/C4TwDgpgBAsgrsAhgIwDYQDwBUB8UC8UA3gFBRQC0AThIgCYD2AdqiFANoAKUAlk1AGsIIBgDMoWALoAuCV0kBuEgF8lJPsAhVRiAMbQA6n0YB3YmXKWAzsCpxdwODToBhVM0xYCURExA4ACgA3RFQ4CFksABooBjBgHmYrAH5ZAGVbe0dnNK0eUJ4ALwgAeXjEpisASkilZRISUEgoGnpmVgBRAA9EAFswdG8AJVpGFhAMUnImPoioGyo+AHMlckQluaY4XuQtOpwG3STgKAge-vRZVrHO84HoQimoGd65gHJNGzeoi3W5gGYAAwqNRHSonXTuJgPKAmYwMEwAOgWWScEFcUIgATOfXuVSUAHoCVAAALAKwUM6QByUqhUBhUZ7MKC9BAodAkSEeRF-bwAJgAnKDjiy2WgIG4PN44UxTMjMg40RiPBh4EhxRhru0QN1cegcIEudD8SRWer0JLoTyNvyhQ0iVA0gALBhwVB0U50hmnO7oKyIw4ipjMXKLRCFdkwp6iOBMXSyAJVAh4Ij1eokB1kilUiA0rT0xkAOQYJyseQKEfFnJF+YZlphMrlKMVznrAWDTFD+Ur6HxUAdRlQqE9Bdi-DsTASr3txKwVF8VlEWnRsWQACtc+SZ1AXK1ND5+ABBOmIEAAITgoiXjLhwCdPnmRWgfCgyBAn2r4Nfl+vAEZvNCZjHvO54-loAS-gAbCan42KuG4OP+jwWMgYFULIqFXlov4-Ko271lAd7QAw66blAYJIHwyyEU60CYdeMS+B6tgLtevDALBJwkQhwB8t4zbZOibbcZuOHEIR86VNesjsPR2GSFAygwQ6u60Puvg+CebCiPSvQ0dARornJVCcbwk7-HyABqPAQCYfGEIBUAAJLmXywGngEIkOHyiLGSaGgWdZtl8uwgIKYQAAsfJKGCVgMOgiLuEsAQBVZNl2aFkjKcSWaUl01LALSo50BASC6LRHruaBWEmbFJypUFJhIc8tnOa5VWeaRiG+WhfYDjwQ4jt6zITlOEBAA)

# Addressed from issue

### Typed return value
Types return value now instead of any. (Taken from test)
```typescript
function assertType<T>(_x: T) {}

const toBeCloned = {
  name: "abc",
  address: "test",
  age: 30,
  info: {
    url: "https://example.com",
  },
} as const;

const nonMatchingType = { foo: "bar" } as const;
const clone = structuredClone(toBeCloned);

assertType<typeof toBeCloned>(clone);
// @ts-expect-error non matching type
assertType<typeof nonMatchingType>(clone);
```

### Make readonly types mutable
```typescript
type Mutable<T> = {
  -readonly [P in keyof T]: T[P];
};

type readonlyExample = Readonly<{
  name: string;
  age: number;
}>

const example: readonlyExample = {
  name: 'test',
  age: 30
};

const clone = window.structuredClone(example);
// @ts-expect-error non mutable
clone.age = 29;

const mutableClone = window.structuredClone<Mutable<readonlyExample>>(clone);
mutableClone.age = 29;
```

instead of being within the generic function can pass through mutable helper.

# Not addressed from issue

### Error on non structured-cloneable types
From [mdn docs](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone#exceptions) will throw exception if not [structuredCloneable](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#javascript_types) type.  Could add a generic constraint to a `StructuredCloneable` type to prevent these errors in this pr?

Example
```typescript
const nonSeriazable = {
  func: () => {}
}

// @ts-expect-error Not serializable
const errorClone = window.structuredClone(nonSeriazable); // Will error on runtime
```

### Errors on transferring an object.
From [docs](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone#transferring_an_object)

When an object is transferred using it in the original throws an exception, which isn't captured on typing.

Example
```
// Create an ArrayBuffer with a size in bytes
const buffer1 = new ArrayBuffer(16);

const object1 = {
  buffer: buffer1,
};

// Clone the object containing the buffer, and transfer it
const object2 = structuredClone(object1, { transfer: [buffer1] });

// Create an array from the cloned buffer
const int32View2 = new Int32Array(object2.buffer);
int32View2[0] = 42;
console.log(int32View2[0]);

// @ts-expect-error detached ArrayBuffer
const int32View1 = new Int32Array(object1.buffer); // Will error on runtime
```

Not sure on handling this one `buffer1` is still an `ArrayBuffer` after being cloned, it'll just throw an error if used. Maybe doesn't need to be handled here.
