### PR TITLE
Fix CredentialsContainer.store() return type

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4312,7 +4312,7 @@ interface CredentialsContainer {
     create(options?: CredentialCreationOptions): Promise<Credential | null>;
     get(options?: CredentialRequestOptions): Promise<Credential | null>;
     preventSilentAccess(): Promise<void>;
-    store(credential: Credential): Promise<Credential>;
+    store(credential: Credential): Promise<void>;
 }
 
 declare var CredentialsContainer: {


### PR DESCRIPTION
The existing return type is wrong. This function returns an empty promise.

As can be seen in the specification and the MDN documentation.

https://w3c.github.io/webappsec-credential-management/#abstract-opdef-store-a-credential

https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/store