### PR TITLE
Prevent runtime errors on FormData set and append

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8548,7 +8548,8 @@ interface FontFaceSource {
  */
 interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
-    append(name: string, value: string | Blob, fileName?: string): void;
+    append(name: string, value: string): void;
+    append(name: string, value: Blob, fileName?: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/delete) */
     delete(name: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get) */
@@ -8558,7 +8559,8 @@ interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/has) */
     has(name: string): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
-    set(name: string, value: string | Blob, fileName?: string): void;
+    set(name: string, value: string): void;
+    set(name: string, value: Blob, fileName?: string): void;
     forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
 }
 

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8548,8 +8548,9 @@ interface FontFaceSource {
  */
 interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
+    append(name: string, value: string | Blob): void;
     append(name: string, value: string): void;
-    append(name: string, value: Blob, fileName?: string): void;
+    append(name: string, blobValue: Blob, filename?: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/delete) */
     delete(name: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get) */
@@ -8559,8 +8560,9 @@ interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/has) */
     has(name: string): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
+    set(name: string, value: string | Blob): void;
     set(name: string, value: string): void;
-    set(name: string, value: Blob, fileName?: string): void;
+    set(name: string, blobValue: Blob, filename?: string): void;
     forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
 }
 

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -2732,7 +2732,8 @@ interface FontFaceSource {
  */
 interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
-    append(name: string, value: string | Blob, fileName?: string): void;
+    append(name: string, value: string): void;
+    append(name: string, value: Blob, fileName?: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/delete) */
     delete(name: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get) */
@@ -2742,7 +2743,8 @@ interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/has) */
     has(name: string): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
-    set(name: string, value: string | Blob, fileName?: string): void;
+    set(name: string, value: string): void;
+    set(name: string, value: Blob, fileName?: string): void;
     forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
 }
 

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -2732,8 +2732,9 @@ interface FontFaceSource {
  */
 interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
+    append(name: string, value: string | Blob): void;
     append(name: string, value: string): void;
-    append(name: string, value: Blob, fileName?: string): void;
+    append(name: string, blobValue: Blob, filename?: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/delete) */
     delete(name: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get) */
@@ -2743,8 +2744,9 @@ interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/has) */
     has(name: string): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
+    set(name: string, value: string | Blob): void;
     set(name: string, value: string): void;
-    set(name: string, value: Blob, fileName?: string): void;
+    set(name: string, blobValue: Blob, filename?: string): void;
     forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
 }
 

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -2621,8 +2621,9 @@ interface FontFaceSource {
  */
 interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
+    append(name: string, value: string | Blob): void;
     append(name: string, value: string): void;
-    append(name: string, value: Blob, fileName?: string): void;
+    append(name: string, blobValue: Blob, filename?: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/delete) */
     delete(name: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get) */
@@ -2632,8 +2633,9 @@ interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/has) */
     has(name: string): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
+    set(name: string, value: string | Blob): void;
     set(name: string, value: string): void;
-    set(name: string, value: Blob, fileName?: string): void;
+    set(name: string, blobValue: Blob, filename?: string): void;
     forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
 }
 

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -2621,7 +2621,8 @@ interface FontFaceSource {
  */
 interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
-    append(name: string, value: string | Blob, fileName?: string): void;
+    append(name: string, value: string): void;
+    append(name: string, value: Blob, fileName?: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/delete) */
     delete(name: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get) */
@@ -2631,7 +2632,8 @@ interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/has) */
     has(name: string): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
-    set(name: string, value: string | Blob, fileName?: string): void;
+    set(name: string, value: string): void;
+    set(name: string, value: Blob, fileName?: string): void;
     forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
 }
 

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2985,8 +2985,9 @@ interface FontFaceSource {
  */
 interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
+    append(name: string, value: string | Blob): void;
     append(name: string, value: string): void;
-    append(name: string, value: Blob, fileName?: string): void;
+    append(name: string, blobValue: Blob, filename?: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/delete) */
     delete(name: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get) */
@@ -2996,8 +2997,9 @@ interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/has) */
     has(name: string): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
+    set(name: string, value: string | Blob): void;
     set(name: string, value: string): void;
-    set(name: string, value: Blob, fileName?: string): void;
+    set(name: string, blobValue: Blob, filename?: string): void;
     forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
 }
 

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2985,7 +2985,8 @@ interface FontFaceSource {
  */
 interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/append) */
-    append(name: string, value: string | Blob, fileName?: string): void;
+    append(name: string, value: string): void;
+    append(name: string, value: Blob, fileName?: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/delete) */
     delete(name: string): void;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/get) */
@@ -2995,7 +2996,8 @@ interface FormData {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/has) */
     has(name: string): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FormData/set) */
-    set(name: string, value: string | Blob, fileName?: string): void;
+    set(name: string, value: string): void;
+    set(name: string, value: Blob, fileName?: string): void;
     forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
 }
 

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1240,17 +1240,15 @@
                         "append": {
                             "name": "append",
                             "flavor": "Web",
-                            "overrideSignatures": [
-                                "append(name: string, value: string): void",
-                                "append(name: string, value: Blob, fileName?: string): void"
+                            "additionalSignatures": [
+                                "append(name: string, value: string | Blob): void"
                             ]
                         },
                         "set": {
                             "name": "set",
                             "flavor": "Web",
-                            "overrideSignatures": [
-                                "set(name: string, value: string): void",
-                                "set(name: string, value: Blob, fileName?: string): void"
+                            "additionalSignatures": [
+                                "set(name: string, value: string | Blob): void"
                             ]
                         }
                     }

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1241,14 +1241,16 @@
                             "name": "append",
                             "flavor": "Web",
                             "overrideSignatures": [
-                                "append(name: string, value: string | Blob, fileName?: string): void"
+                                "append(name: string, value: string): void",
+                                "append(name: string, value: Blob, fileName?: string): void"
                             ]
                         },
                         "set": {
                             "name": "set",
                             "flavor": "Web",
                             "overrideSignatures": [
-                                "set(name: string, value: string | Blob, fileName?: string): void"
+                                "set(name: string, value: string): void",
+                                "set(name: string, value: Blob, fileName?: string): void"
                             ]
                         }
                     }

--- a/unittests/files/formData.ts
+++ b/unittests/files/formData.ts
@@ -23,3 +23,10 @@ formData.set("myProp", new Blob(), "myFile");
 
 // @ts-expect-error will error on runtime
 formData.set("myProp", "value", "myFile");
+
+// Should work for union type
+type stringBlobUnion = string | Blob;
+const unionValue = "value" as stringBlobUnion;
+
+formData.set("myProp", unionValue);
+formData.append("myProp", unionValue);

--- a/unittests/files/formData.ts
+++ b/unittests/files/formData.ts
@@ -1,0 +1,25 @@
+const formData = new FormData();
+
+// Should work
+formData.append("myProp", "value");
+
+// Should work
+formData.append("myProp", new Blob());
+
+// Should work
+formData.append("myProp", new Blob(), "myFile");
+
+// @ts-expect-error will error on runtime
+formData.append("myProp", "value", "myFile");
+
+// Should work
+formData.set("myProp", "value");
+
+// Should work
+formData.set("myProp", new Blob());
+
+// Should work
+formData.set("myProp", new Blob(), "myFile");
+
+// @ts-expect-error will error on runtime
+formData.set("myProp", "value", "myFile");


### PR DESCRIPTION
Addresses [this issue](https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1421)

Adds two overloads to `append` and `set` to prevent runtime errors.