### PR TITLE
Add CustomEvent to EventListener

### DIFF
--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -558,11 +558,11 @@ declare var Event: {
 };
 
 interface EventListener {
-    (evt: Event): void;
+    (evt: Event | CustomEvent): void;
 }
 
 interface EventListenerObject {
-    handleEvent(object: Event): void;
+    handleEvent(object: Event | CustomEvent): void;
 }
 
 /**

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8060,11 +8060,11 @@ declare var EventCounts: {
 };
 
 interface EventListener {
-    (evt: Event): void;
+    (evt: Event | CustomEvent): void;
 }
 
 interface EventListenerObject {
-    handleEvent(object: Event): void;
+    handleEvent(object: Event | CustomEvent): void;
 }
 
 interface EventSourceEventMap {

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -2293,11 +2293,11 @@ declare var Event: {
 };
 
 interface EventListener {
-    (evt: Event): void;
+    (evt: Event | CustomEvent): void;
 }
 
 interface EventListenerObject {
-    handleEvent(object: Event): void;
+    handleEvent(object: Event | CustomEvent): void;
 }
 
 interface EventSourceEventMap {

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -2220,11 +2220,11 @@ declare var Event: {
 };
 
 interface EventListener {
-    (evt: Event): void;
+    (evt: Event | CustomEvent): void;
 }
 
 interface EventListenerObject {
-    handleEvent(object: Event): void;
+    handleEvent(object: Event | CustomEvent): void;
 }
 
 interface EventSourceEventMap {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2494,11 +2494,11 @@ declare var Event: {
 };
 
 interface EventListener {
-    (evt: Event): void;
+    (evt: Event | CustomEvent): void;
 }
 
 interface EventListenerObject {
-    handleEvent(object: Event): void;
+    handleEvent(object: Event | CustomEvent): void;
 }
 
 interface EventSourceEventMap {

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -688,7 +688,7 @@
                         // emitter for this one case.
                         "callable": {
                             "overrideSignatures": [
-                                "(evt: Event): void"
+                                "(evt: Event | CustomEvent): void"
                             ]
                         }
                     }
@@ -701,7 +701,7 @@
                     "method": {
                         "handleEvent": {
                             "overrideSignatures": [
-                                "handleEvent(object: Event): void"
+                                "handleEvent(object: Event | CustomEvent): void"
                             ]
                         }
                     }


### PR DESCRIPTION
Type definition for EventListener and EventListenerObject is overly narrow and does not allow for CustomEvent.

Submitting this PR on behalf of issue: https://github.com/microsoft/TypeScript/issues/28357

MDN and WhatWG seem to specify that this is allowed:

 - https://dom.spec.whatwg.org/#defining-event-interfaces
 - https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#the_event_listener_callback