### PR TITLE
Allows passing iterable to `Blob` and `File`

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3073,7 +3073,7 @@ interface Blob {
 
 declare var Blob: {
     prototype: Blob;
-    new(blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
+    new(blobParts?: Iterable<BlobPart>, options?: BlobPropertyBag): Blob;
 };
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/BlobEvent) */

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8209,7 +8209,7 @@ interface File extends Blob {
 
 declare var File: {
     prototype: File;
-    new(fileBits: BlobPart[], fileName: string, options?: FilePropertyBag): File;
+    new(fileBits: Iterable<BlobPart>, fileName: string, options?: FilePropertyBag): File;
 };
 
 /**

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -2479,7 +2479,7 @@ interface File extends Blob {
 
 declare var File: {
     prototype: File;
-    new(fileBits: BlobPart[], fileName: string, options?: FilePropertyBag): File;
+    new(fileBits: Iterable<BlobPart>, fileName: string, options?: FilePropertyBag): File;
 };
 
 /**

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -841,7 +841,7 @@ interface Blob {
 
 declare var Blob: {
     prototype: Blob;
-    new(blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
+    new(blobParts?: Iterable<BlobPart>, options?: BlobPropertyBag): Blob;
 };
 
 interface Body {

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -813,7 +813,7 @@ interface Blob {
 
 declare var Blob: {
     prototype: Blob;
-    new(blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
+    new(blobParts?: Iterable<BlobPart>, options?: BlobPropertyBag): Blob;
 };
 
 interface Body {

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -2343,7 +2343,7 @@ interface File extends Blob {
 
 declare var File: {
     prototype: File;
-    new(fileBits: BlobPart[], fileName: string, options?: FilePropertyBag): File;
+    new(fileBits: Iterable<BlobPart>, fileName: string, options?: FilePropertyBag): File;
 };
 
 /**

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -978,7 +978,7 @@ interface Blob {
 
 declare var Blob: {
     prototype: Blob;
-    new(blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
+    new(blobParts?: Iterable<BlobPart>, options?: BlobPropertyBag): Blob;
 };
 
 interface Body {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2680,7 +2680,7 @@ interface File extends Blob {
 
 declare var File: {
     prototype: File;
-    new(fileBits: BlobPart[], fileName: string, options?: FilePropertyBag): File;
+    new(fileBits: Iterable<BlobPart>, fileName: string, options?: FilePropertyBag): File;
 };
 
 /**

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2422,6 +2422,18 @@
                 ]
             },
             "Blob": {
+                "constructor": {
+                    "signature": {
+                        "0": {
+                            "param": [
+                                {
+                                    "name": "blobParts",
+                                    "overrideType": "Iterable<BlobPart>"
+                                }
+                            ]
+                        }
+                    }
+                },
               "methods": {
                 "method": {
                   "stream": {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2446,6 +2446,20 @@
                 }
               }
             },
+            "File": {
+                "constructor": {
+                    "signature": {
+                        "0": {
+                            "param": [
+                                {
+                                    "name": "fileBits",
+                                    "overrideType": "Iterable<BlobPart>"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
             "ReadableStream": {
                 "typeParameters": [
                     {


### PR DESCRIPTION
- `Blob`: [mdn](https://developer.mozilla.org/en-US/docs/Web/API/Blob/Blob#array), [w3c](https://w3c.github.io/FileAPI/#dom-blob-blob)
- `File`: [mdn](https://developer.mozilla.org/en-US/docs/Web/API/File/File#bits), [w3c](https://w3c.github.io/FileAPI/#dom-file-file)