### PR TITLE
make location.reload() return never

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14475,7 +14475,7 @@ interface Location {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Location/reload)
      */
-    reload(): void;
+    reload(): never;
     /**
      * Removes the current page from the session history and navigates to the given URL.
      *

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -584,6 +584,17 @@
                     }
                 }
             },
+            "Location": {
+                "methods": {
+                    "method": {
+                        "reload": {
+                            "overrideSignatures": [
+                                "reload(): never"
+                            ]
+                        }
+                    }
+                }
+            },
             "Window": {
                 "properties": {
                     "property": {


### PR DESCRIPTION
writing code after `location.reload()` is very likely a mistake, since the code will probably never run. 

So this PR changes `location.reload()` to return `never`, akin to `process.exit()` in node