### PR TITLE
Make TextEncoderEncodeIntoResult members required

### DIFF
--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -124,8 +124,8 @@ interface TextDecoderOptions {
 }
 
 interface TextEncoderEncodeIntoResult {
-    read?: number;
-    written?: number;
+    read: number;
+    written: number;
 }
 
 interface Transformer<I = any, O = any> {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1854,8 +1854,8 @@ interface TextDecoderOptions {
 }
 
 interface TextEncoderEncodeIntoResult {
-    read?: number;
-    written?: number;
+    read: number;
+    written: number;
 }
 
 interface TouchEventInit extends EventModifierInit {

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -651,8 +651,8 @@ interface TextDecoderOptions {
 }
 
 interface TextEncoderEncodeIntoResult {
-    read?: number;
-    written?: number;
+    read: number;
+    written: number;
 }
 
 interface Transformer<I = any, O = any> {

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -617,8 +617,8 @@ interface TextDecoderOptions {
 }
 
 interface TextEncoderEncodeIntoResult {
-    read?: number;
-    written?: number;
+    read: number;
+    written: number;
 }
 
 interface Transformer<I = any, O = any> {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -691,8 +691,8 @@ interface TextDecoderOptions {
 }
 
 interface TextEncoderEncodeIntoResult {
-    read?: number;
-    written?: number;
+    read: number;
+    written: number;
 }
 
 interface Transformer<I = any, O = any> {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -3367,6 +3367,18 @@
                     }
                 }
             },
+            "TextEncoderEncodeIntoResult": {
+                "members": {
+                    "member": {
+                        "read": {
+                            "required": true
+                        },
+                        "written": {
+                            "required": true
+                        }
+                    }
+                }
+            },
             "UnderlyingSource": {
                 "typeParameters": [
                     {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -3367,6 +3367,7 @@
                     }
                 }
             },
+            // TextEncoderEncodeIntoResult is used only for return type, always with all fields defined
             "TextEncoderEncodeIntoResult": {
                 "members": {
                     "member": {


### PR DESCRIPTION
`TextEncoderEncodeIntoResult` is defined as a dictionary without `required` members in https://encoding.spec.whatwg.org/#interface-textencoder
```
dictionary TextEncoderEncodeIntoResult {
  unsigned long long read;
  unsigned long long written;
};
```

However, algorithm for `encodeInto()` (which is the only place the type is referenced) effectively ensures that the properties are always set, described in https://encoding.spec.whatwg.org/#dom-textencoder-encodeinto

>1\. Let read be 0.
>2\. Let written be 0.
>...
>7\. Return «[ "read" → read, "written" → written ]».
