### PR TITLE
Use printUnifiedDiff for faster diffing

### DIFF
--- a/deploy/deployChangedPackages.js
+++ b/deploy/deployChangedPackages.js
@@ -8,7 +8,7 @@
 import * as fs from "fs";
 import { spawnSync } from "child_process";
 import { Octokit } from "@octokit/rest";
-import { printInlineDiff } from "print-diff";
+import { printUnifiedDiff } from "print-diff";
 import { generateChangelogFrom } from "../lib/changelog.js";
 import { packages } from "./createTypesPackages.js";
 import { fileURLToPath } from "node:url";
@@ -65,7 +65,7 @@ for (const dirName of fs.readdirSync(generatedDir)) {
       );
       console.log(` - ${file}`);
       if (oldFile !== generatedDTSContent)
-        printInlineDiff(oldFile, generatedDTSContent);
+        printUnifiedDiff(oldFile, generatedDTSContent);
 
       const title = `## \`${file}\``;
       const notes = generateChangelogFrom(oldFile, generatedDTSContent);


### PR DESCRIPTION
This is really for debugging purpose than anything else, so whatever performs faster fits here.

Fixes #1580.