### PR TITLE
Let Dependabot file a single PR for everything

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
       interval: "monthly"
     # Bump versions only in package-lock.json
     versioning-strategy: "lockfile-only"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Because it's now a thing: https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/