### PR TITLE
Generic DOM Events

### DIFF
--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -433,7 +433,7 @@ declare var ErrorEvent: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event)
  */
-interface Event {
+interface Event<T extends EventTarget = EventTarget> {
     /**
      * Returns true or false depending on how event was initialized. True if event goes through its target's ancestors in reverse tree order, and false otherwise.
      *
@@ -463,7 +463,7 @@ interface Event {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/currentTarget)
      */
-    readonly currentTarget: EventTarget | null;
+    readonly currentTarget: T | null;
     /**
      * Returns true if preventDefault() was invoked successfully to indicate cancelation, and false otherwise.
      *
@@ -499,7 +499,7 @@ interface Event {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
      */
-    readonly target: EventTarget | null;
+    readonly target: T | null;
     /**
      * Returns the event's timestamp as the number of milliseconds measured relative to the time origin.
      *
@@ -557,12 +557,12 @@ declare var Event: {
     readonly BUBBLING_PHASE: 3;
 };
 
-interface EventListener {
-    (evt: Event): void;
+interface EventListener<T extends EventTarget = EventTarget> {
+    (evt: Event<T>): void;
 }
 
-interface EventListenerObject {
-    handleEvent(object: Event): void;
+interface EventListenerObject<T extends EventTarget = EventTarget> {
+    handleEvent(object: Event<T>): void;
 }
 
 /**
@@ -588,7 +588,7 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
      */
-    addEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: AddEventListenerOptions | boolean): void;
+    addEventListener(type: string, callback: EventListenerOrEventListenerObject<this> | null, options?: AddEventListenerOptions | boolean): void;
     /**
      * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
      *
@@ -600,7 +600,7 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)
      */
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject<this> | null, options?: EventListenerOptions | boolean): void;
 }
 
 declare var EventTarget: {
@@ -1402,7 +1402,7 @@ declare function registerProcessor(name: string, processorCtor: AudioWorkletProc
 type AllowSharedBufferSource = ArrayBuffer | ArrayBufferView;
 type BufferSource = ArrayBufferView | ArrayBuffer;
 type DOMHighResTimeStamp = number;
-type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
+type EventListenerOrEventListenerObject<T extends EventTarget = EventTarget> = EventListener<T> | EventListenerObject<T>;
 type MessageEventSource = MessagePort;
 type ReadableStreamController<T> = ReadableStreamDefaultController<T> | ReadableByteStreamController;
 type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5721,7 +5721,7 @@ declare var Comment: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CompositionEvent)
  */
-interface CompositionEvent extends UIEvent {
+interface CompositionEvent<T extends EventTarget = EventTarget> extends UIEvent<T> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CompositionEvent/data) */
     readonly data: string;
     /**
@@ -7462,7 +7462,7 @@ declare var DocumentType: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/DragEvent)
  */
-interface DragEvent extends MouseEvent {
+interface DragEvent<T extends EventTarget = EventTarget> extends MouseEvent<T> {
     /**
      * Returns the DataTransfer object for the event.
      *
@@ -7982,7 +7982,7 @@ declare var ErrorEvent: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event)
  */
-interface Event {
+interface Event<T extends EventTarget = EventTarget> {
     /**
      * Returns true or false depending on how event was initialized. True if event goes through its target's ancestors in reverse tree order, and false otherwise.
      *
@@ -8012,7 +8012,7 @@ interface Event {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/currentTarget)
      */
-    readonly currentTarget: EventTarget | null;
+    readonly currentTarget: T | null;
     /**
      * Returns true if preventDefault() was invoked successfully to indicate cancelation, and false otherwise.
      *
@@ -8048,7 +8048,7 @@ interface Event {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
      */
-    readonly target: EventTarget | null;
+    readonly target: T | null;
     /**
      * Returns the event's timestamp as the number of milliseconds measured relative to the time origin.
      *
@@ -8116,12 +8116,12 @@ declare var EventCounts: {
     new(): EventCounts;
 };
 
-interface EventListener {
-    (evt: Event): void;
+interface EventListener<T extends EventTarget = EventTarget> {
+    (evt: Event<T>): void;
 }
 
-interface EventListenerObject {
-    handleEvent(object: Event): void;
+interface EventListenerObject<T extends EventTarget = EventTarget> {
+    handleEvent(object: Event<T>): void;
 }
 
 interface EventSourceEventMap {
@@ -8204,7 +8204,7 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
      */
-    addEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: AddEventListenerOptions | boolean): void;
+    addEventListener(type: string, callback: EventListenerOrEventListenerObject<this> | null, options?: AddEventListenerOptions | boolean): void;
     /**
      * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
      *
@@ -8216,7 +8216,7 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)
      */
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject<this> | null, options?: EventListenerOptions | boolean): void;
 }
 
 declare var EventTarget: {
@@ -8501,7 +8501,7 @@ declare var FileSystemWritableFileStream: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/FocusEvent)
  */
-interface FocusEvent extends UIEvent {
+interface FocusEvent<T extends EventTarget = EventTarget> extends UIEvent<T> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/FocusEvent/relatedTarget) */
     readonly relatedTarget: EventTarget | null;
 }
@@ -14303,7 +14303,7 @@ declare var InputDeviceInfo: {
 };
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/InputEvent) */
-interface InputEvent extends UIEvent {
+interface InputEvent<T extends EventTarget = EventTarget> extends UIEvent<T> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/InputEvent/data) */
     readonly data: string | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/InputEvent/dataTransfer) */
@@ -14385,7 +14385,7 @@ interface KHR_parallel_shader_compile {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/KeyboardEvent)
  */
-interface KeyboardEvent extends UIEvent {
+interface KeyboardEvent<T extends EventTarget = EventTarget> extends UIEvent<T> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/KeyboardEvent/altKey) */
     readonly altKey: boolean;
     /**
@@ -15592,7 +15592,7 @@ declare var MimeTypeArray: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/MouseEvent)
  */
-interface MouseEvent extends UIEvent {
+interface MouseEvent<T extends EventTarget = EventTarget> extends UIEvent<T> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/MouseEvent/altKey) */
     readonly altKey: boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/MouseEvent/button) */
@@ -17593,7 +17593,7 @@ declare var PluginArray: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/PointerEvent)
  */
-interface PointerEvent extends MouseEvent {
+interface PointerEvent<T extends EventTarget = EventTarget> extends MouseEvent<T> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/PointerEvent/height) */
     readonly height: number;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/PointerEvent/isPrimary) */
@@ -22414,7 +22414,7 @@ declare var Touch: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/TouchEvent)
  */
-interface TouchEvent extends UIEvent {
+interface TouchEvent<T extends EventTarget = EventTarget> extends UIEvent<T> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/TouchEvent/altKey) */
     readonly altKey: boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/TouchEvent/changedTouches) */
@@ -22562,7 +22562,7 @@ declare var TreeWalker: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/UIEvent)
  */
-interface UIEvent extends Event {
+interface UIEvent<T extends EventTarget = EventTarget> extends Event<T> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/UIEvent/detail) */
     readonly detail: number;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/UIEvent/view) */
@@ -25596,7 +25596,7 @@ declare var WebTransportError: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WheelEvent)
  */
-interface WheelEvent extends MouseEvent {
+interface WheelEvent<T extends EventTarget = EventTarget> extends MouseEvent<T> {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WheelEvent/deltaMode) */
     readonly deltaMode: number;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WheelEvent/deltaX) */
@@ -28041,7 +28041,7 @@ type ConstrainDouble = number | ConstrainDoubleRange;
 type ConstrainULong = number | ConstrainULongRange;
 type DOMHighResTimeStamp = number;
 type EpochTimeStamp = number;
-type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
+type EventListenerOrEventListenerObject<T extends EventTarget = EventTarget> = EventListener<T> | EventListenerObject<T>;
 type FileSystemWriteChunkType = BufferSource | Blob | string | WriteParams;
 type Float32List = Float32Array | GLfloat[];
 type FormDataEntryValue = File | string;

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -2202,7 +2202,7 @@ declare var ErrorEvent: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event)
  */
-interface Event {
+interface Event<T extends EventTarget = EventTarget> {
     /**
      * Returns true or false depending on how event was initialized. True if event goes through its target's ancestors in reverse tree order, and false otherwise.
      *
@@ -2232,7 +2232,7 @@ interface Event {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/currentTarget)
      */
-    readonly currentTarget: EventTarget | null;
+    readonly currentTarget: T | null;
     /**
      * Returns true if preventDefault() was invoked successfully to indicate cancelation, and false otherwise.
      *
@@ -2268,7 +2268,7 @@ interface Event {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
      */
-    readonly target: EventTarget | null;
+    readonly target: T | null;
     /**
      * Returns the event's timestamp as the number of milliseconds measured relative to the time origin.
      *
@@ -2326,12 +2326,12 @@ declare var Event: {
     readonly BUBBLING_PHASE: 3;
 };
 
-interface EventListener {
-    (evt: Event): void;
+interface EventListener<T extends EventTarget = EventTarget> {
+    (evt: Event<T>): void;
 }
 
-interface EventListenerObject {
-    handleEvent(object: Event): void;
+interface EventListenerObject<T extends EventTarget = EventTarget> {
+    handleEvent(object: Event<T>): void;
 }
 
 interface EventSourceEventMap {
@@ -2414,7 +2414,7 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
      */
-    addEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: AddEventListenerOptions | boolean): void;
+    addEventListener(type: string, callback: EventListenerOrEventListenerObject<this> | null, options?: AddEventListenerOptions | boolean): void;
     /**
      * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
      *
@@ -2426,7 +2426,7 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)
      */
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject<this> | null, options?: EventListenerOptions | boolean): void;
 }
 
 declare var EventTarget: {
@@ -8547,7 +8547,7 @@ type CSSUnparsedSegment = string | CSSVariableReferenceValue;
 type CanvasImageSource = ImageBitmap | OffscreenCanvas;
 type DOMHighResTimeStamp = number;
 type EpochTimeStamp = number;
-type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
+type EventListenerOrEventListenerObject<T extends EventTarget = EventTarget> = EventListener<T> | EventListenerObject<T>;
 type FileSystemWriteChunkType = BufferSource | Blob | string | WriteParams;
 type Float32List = Float32Array | GLfloat[];
 type FormDataEntryValue = File | string;

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -2129,7 +2129,7 @@ declare var ErrorEvent: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event)
  */
-interface Event {
+interface Event<T extends EventTarget = EventTarget> {
     /**
      * Returns true or false depending on how event was initialized. True if event goes through its target's ancestors in reverse tree order, and false otherwise.
      *
@@ -2159,7 +2159,7 @@ interface Event {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/currentTarget)
      */
-    readonly currentTarget: EventTarget | null;
+    readonly currentTarget: T | null;
     /**
      * Returns true if preventDefault() was invoked successfully to indicate cancelation, and false otherwise.
      *
@@ -2195,7 +2195,7 @@ interface Event {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
      */
-    readonly target: EventTarget | null;
+    readonly target: T | null;
     /**
      * Returns the event's timestamp as the number of milliseconds measured relative to the time origin.
      *
@@ -2253,12 +2253,12 @@ declare var Event: {
     readonly BUBBLING_PHASE: 3;
 };
 
-interface EventListener {
-    (evt: Event): void;
+interface EventListener<T extends EventTarget = EventTarget> {
+    (evt: Event<T>): void;
 }
 
-interface EventListenerObject {
-    handleEvent(object: Event): void;
+interface EventListenerObject<T extends EventTarget = EventTarget> {
+    handleEvent(object: Event<T>): void;
 }
 
 interface EventSourceEventMap {
@@ -2341,7 +2341,7 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
      */
-    addEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: AddEventListenerOptions | boolean): void;
+    addEventListener(type: string, callback: EventListenerOrEventListenerObject<this> | null, options?: AddEventListenerOptions | boolean): void;
     /**
      * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
      *
@@ -2353,7 +2353,7 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)
      */
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject<this> | null, options?: EventListenerOptions | boolean): void;
 }
 
 declare var EventTarget: {
@@ -8556,7 +8556,7 @@ type CSSUnparsedSegment = string | CSSVariableReferenceValue;
 type CanvasImageSource = ImageBitmap | OffscreenCanvas;
 type DOMHighResTimeStamp = number;
 type EpochTimeStamp = number;
-type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
+type EventListenerOrEventListenerObject<T extends EventTarget = EventTarget> = EventListener<T> | EventListenerObject<T>;
 type FileSystemWriteChunkType = BufferSource | Blob | string | WriteParams;
 type Float32List = Float32Array | GLfloat[];
 type FormDataEntryValue = File | string;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2405,7 +2405,7 @@ declare var ErrorEvent: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event)
  */
-interface Event {
+interface Event<T extends EventTarget = EventTarget> {
     /**
      * Returns true or false depending on how event was initialized. True if event goes through its target's ancestors in reverse tree order, and false otherwise.
      *
@@ -2435,7 +2435,7 @@ interface Event {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/currentTarget)
      */
-    readonly currentTarget: EventTarget | null;
+    readonly currentTarget: T | null;
     /**
      * Returns true if preventDefault() was invoked successfully to indicate cancelation, and false otherwise.
      *
@@ -2471,7 +2471,7 @@ interface Event {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Event/target)
      */
-    readonly target: EventTarget | null;
+    readonly target: T | null;
     /**
      * Returns the event's timestamp as the number of milliseconds measured relative to the time origin.
      *
@@ -2529,12 +2529,12 @@ declare var Event: {
     readonly BUBBLING_PHASE: 3;
 };
 
-interface EventListener {
-    (evt: Event): void;
+interface EventListener<T extends EventTarget = EventTarget> {
+    (evt: Event<T>): void;
 }
 
-interface EventListenerObject {
-    handleEvent(object: Event): void;
+interface EventListenerObject<T extends EventTarget = EventTarget> {
+    handleEvent(object: Event<T>): void;
 }
 
 interface EventSourceEventMap {
@@ -2617,7 +2617,7 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
      */
-    addEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: AddEventListenerOptions | boolean): void;
+    addEventListener(type: string, callback: EventListenerOrEventListenerObject<this> | null, options?: AddEventListenerOptions | boolean): void;
     /**
      * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
      *
@@ -2629,7 +2629,7 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)
      */
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject<this> | null, options?: EventListenerOptions | boolean): void;
 }
 
 declare var EventTarget: {
@@ -9272,7 +9272,7 @@ type CSSUnparsedSegment = string | CSSVariableReferenceValue;
 type CanvasImageSource = ImageBitmap | OffscreenCanvas | VideoFrame;
 type DOMHighResTimeStamp = number;
 type EpochTimeStamp = number;
-type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
+type EventListenerOrEventListenerObject<T extends EventTarget = EventTarget> = EventListener<T> | EventListenerObject<T>;
 type FileSystemWriteChunkType = BufferSource | Blob | string | WriteParams;
 type Float32List = Float32Array | GLfloat[];
 type FormDataEntryValue = File | string;

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -772,6 +772,13 @@
             "EventListener": {
                 "name": "EventListener",
                 "noInterfaceObject": true,
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
                 "methods": {
                     "method": {
                         // This is a hack to add a call signature, but I think it's reasonable
@@ -779,7 +786,7 @@
                         // emitter for this one case.
                         "callable": {
                             "overrideSignatures": [
-                                "(evt: Event): void"
+                                "(evt: Event<T>): void"
                             ]
                         }
                     }
@@ -788,11 +795,18 @@
             "EventListenerObject": {
                 "name": "EventListenerObject",
                 "noInterfaceObject": true,
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
                 "methods": {
                     "method": {
                         "handleEvent": {
                             "overrideSignatures": [
-                                "handleEvent(object: Event): void"
+                                "handleEvent(object: Event<T>): void"
                             ]
                         }
                     }
@@ -916,6 +930,15 @@
                 }
             },
             "UIEvent": {
+                "extends": "Event<T>",
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
+                //!!!!!!!!!!!!!
                 "properties": {
                     "property": {
                         "which": {
@@ -1513,7 +1536,14 @@
             },
             {
                 "name": "EventListenerOrEventListenerObject",
-                "overrideType": "EventListener | EventListenerObject"
+                "overrideType": "EventListener<T> | EventListenerObject<T>",
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ]
             },
             {
                 "name": "OptionalPrefixToken",

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1729,7 +1729,79 @@
                     }
                 }
             },
+            "Event": {
+                // !!!!!!!!!
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
+                "properties": {
+                    "property": {
+                        "target": {
+                            "name": "target",
+                            "readonly": true,
+                            "overrideType": "T"
+                        },
+                        "currentTarget": {
+                            "name": "currentTarget",
+                            "readonly": true,
+                            "overrideType": "T"
+                        }
+                    }
+                }
+            },
+            "CompositionEvent": {
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
+                "extends": "UIEvent<T>"
+            },
+            "FocusEvent": {
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
+                "extends": "UIEvent<T>"                
+            },
+            "InputEvent": {
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
+                "extends": "UIEvent<T>"                
+            },
+            "KeyboardEvent": {
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
+                "extends": "UIEvent<T>"                
+            },
             "MouseEvent": {
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
+                "extends": "UIEvent<T>" ,
                 "methods": {
                     "method": {
                         "initMouseEvent": {
@@ -1740,6 +1812,46 @@
                         }
                     }
                 }
+            },
+            "TouchEvent": {
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
+                "extends": "UIEvent<T>"                
+            },
+            "DragEvent": {
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
+                "extends": "MouseEvent<T>"                
+            },
+            "PointerEvent": {
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
+                "extends": "MouseEvent<T>"                
+            },
+            "WheelEvent": {
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "EventTarget",
+                        "extends": "EventTarget"
+                    }
+                ],
+                "extends": "MouseEvent<T>"                
             },
             "DOMException": {
                 "extends": "Error"
@@ -2989,7 +3101,7 @@
                                     "param": [
                                         {
                                             "name": "callback",
-                                            "overrideType": "EventListenerOrEventListenerObject"
+                                            "overrideType": "EventListenerOrEventListenerObject<this>"
                                         }
                                     ]
                                 }
@@ -3001,7 +3113,7 @@
                                     "param": [
                                         {
                                             "name": "callback",
-                                            "overrideType": "EventListenerOrEventListenerObject"
+                                            "overrideType": "EventListenerOrEventListenerObject<this>"
                                         }
                                     ]
                                 }


### PR DESCRIPTION
Hopefully fixes #299

Added generics to Events so that `target` and `currentTarget`'s types can be parameterized and event listeners can take a callback that expects an event targeting the receiver's type.

All new generics have default values, so the change should be backward compatible and all tests seem to be passing.

This is my first PR to the project and I hope I'm following the community norms, but please let me know if the implementation is up to standards or something is amiss.