### PR TITLE
Override SVGSVGElement method getElementById

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -20555,7 +20555,7 @@ interface SVGSVGElement extends SVGGraphicsElement, SVGFitToViewBox, WindowEvent
     /** @deprecated */
     forceRedraw(): void;
     getCurrentTime(): number;
-    getElementById(elementId: string): Element;
+    getElementById(elementId: string): Element | null;
     getEnclosureList(rect: DOMRectReadOnly, referenceElement: SVGElement | null): NodeListOf<SVGCircleElement | SVGEllipseElement | SVGImageElement | SVGLineElement | SVGPathElement | SVGPolygonElement | SVGPolylineElement | SVGRectElement | SVGTextElement | SVGUseElement>;
     getIntersectionList(rect: DOMRectReadOnly, referenceElement: SVGElement | null): NodeListOf<SVGCircleElement | SVGEllipseElement | SVGImageElement | SVGLineElement | SVGPathElement | SVGPolygonElement | SVGPolylineElement | SVGRectElement | SVGTextElement | SVGUseElement>;
     pauseAnimations(): void;

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1238,6 +1238,12 @@
             "SVGSVGElement": {
                 "methods": {
                     "method": {
+                        "getElementById": {
+                            "name": "getElementById",
+                            "overrideSignatures": [
+                                "getElementById(elementId: string): Element | null"
+                            ]
+                        },
                         "getEnclosureList": {
                             "signature": {
                                 "0": {


### PR DESCRIPTION
This method may return null, but not according to the current type definitions.