### PR TITLE
Fix(OverconstrainedError): the interface should inherit DOMException

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -16731,7 +16731,7 @@ declare var OscillatorNode: {
 };
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/OverconstrainedError) */
-interface OverconstrainedError extends Error {
+interface OverconstrainedError extends DOMException {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/OverconstrainedError/constraint) */
     readonly constraint: string;
 }


### PR DESCRIPTION
see https://developer.mozilla.org/en-US/docs/Web/API/OverconstrainedError
also reference to https://w3c.github.io/mediacapture-main/#dom-overconstrainederror