### PR TITLE
Remove invalid documentation for pause method of HTMLMediaElement

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -11589,7 +11589,7 @@ interface HTMLMediaElement extends HTMLElement {
      */
     load(): void;
     /**
-     * Pauses the current playback and sets paused to TRUE. This can be used to test whether the media is playing or paused. You can also use the pause or play events to tell whether the media is playing or not.
+     * Pauses the current playback and sets paused to TRUE.
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/pause)
      */

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -1574,7 +1574,7 @@
                 "methods": {
                     "method": {
                         "pause": {
-                            "comment": "Pauses the current playback and sets paused to TRUE. This can be used to test whether the media is playing or paused. You can also use the pause or play events to tell whether the media is playing or not."
+                            "comment": "Pauses the current playback and sets paused to TRUE."
                         },
                         "play": {
                             "comment": "Loads and starts playback of a media resource."
@@ -1811,7 +1811,7 @@
                 "properties": {
                     "property": {
                         "parent": {
-                            "comment" : "Refers to either the parent WindowProxy, or itself.\n\nIt can rarely be null e.g. for contentWindow of an iframe that is already removed from the parent."
+                            "comment": "Refers to either the parent WindowProxy, or itself.\n\nIt can rarely be null e.g. for contentWindow of an iframe that is already removed from the parent."
                         }
                     }
                 }


### PR DESCRIPTION
Fairly simple one. Since there is no return value, the paused property should be used for testing if a media element is paused instead of the pause method.

[Looking at the spec](https://html.spec.whatwg.org/multipage/media.html#dom-media-pause-dev)
> The paused attribute represents whether the [media element](https://html.spec.whatwg.org/multipage/media.html#media-element) is paused or not.

That comment has been there 6 years, so I am not sure of the origin, but it confused me so I made the PR.

References:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/pause
https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/paused