### PR TITLE
Support `HTMLElement.hidden` value `"until-found"`

### DIFF
--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -484,9 +484,7 @@
                 "properties": {
                     "property": {
                         "hidden": {
-                            // https://github.com/whatwg/html/pull/7475
-                            // Revisit when this get browser supports.
-                            "overrideType": "boolean",
+                            "overrideType": "boolean | \"until-found\"",
                             "nullable": false
                         }
                     }


### PR DESCRIPTION
`HTMLElement.hidden` can now be any of `true | false | "until-found"`. ([MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/hidden#until-found))

This has support from two major browsers (Chrome and Edge). ([caniuse](https://caniuse.com/mdn-html_global_attributes_hidden_until-found_value))

<img width="1459" alt="Screen Shot 2024-01-03 at 19 08 05" src="https://github.com/microsoft/TypeScript-DOM-lib-generator/assets/319655/b3937059-76e0-4cd9-b228-1778c4d91f90">
<img width="804" alt="Screen Shot 2024-01-03 at 19 07 00" src="https://github.com/microsoft/TypeScript-DOM-lib-generator/assets/319655/44d5bb9c-b6ae-48d0-ba30-97562bc70b97">
