### PR TITLE
Updating added types for `ReadableStreamReadDoneResult`

### DIFF
--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -1289,11 +1289,6 @@
             },
             "ReadableStreamReadDoneResult": {
                 "name": "ReadableStreamReadDoneResult",
-                "typeParameters": [
-                    {
-                        "name": "T"
-                    }
-                ],
                 "members": {
                     "member": {
                         "done": {
@@ -1303,7 +1298,8 @@
                         },
                         "value": {
                             "name": "value",
-                            "overrideType": "T"
+                            "overrideType": "undefined",
+                            "required": true
                         }
                     }
                 }
@@ -1535,7 +1531,7 @@
                         "type": "ReadableStreamReadDoneResult"
                     }
                 ],
-                "overrideType": "ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>"
+                "overrideType": "ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult"
             },
             {
                 "name": "EventListenerOrEventListenerObject",


### PR DESCRIPTION
This fixes #1675 by generating:

```typescript
type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult;

interface ReadableStreamReadDoneResult {
    done: true;
    value: undefined;
}

interface ReadableStreamReadValueResult<T> {
    done: false;
    value: T;
}
```