### PR TITLE
Add permissions to codeowners merge workflow

### DIFF
--- a/.github/workflows/codeowners-merge.yml
+++ b/.github/workflows/codeowners-merge.yml
@@ -4,6 +4,10 @@ on:
   issue_comment: { types: [created] }
   pull_request_review: { types: [submitted] }
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should fix auto merging. The permissions block might need `issue: write`, too, but I think that all of the PR stuff can be accessed using `pull-requests: write` by my reading of https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-pull-requests