### PR TITLE
Strengthen type of `HTMLSelectElement.type`

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -12563,7 +12563,7 @@ interface HTMLSelectElement extends HTMLElement {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/type)
      */
-    readonly type: string;
+    readonly type: "select-one" | "select-multiple";
     /**
      * Returns the error message that would be displayed if the user submits the form, or an empty string if no error message. It also triggers the standard error message, such as "this is a required field". The result is that the user sees validation messages without actually submitting.
      *

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1281,6 +1281,10 @@
             "HTMLSelectElement": {
                 "properties": {
                     "property": {
+                        "type": {
+                            "name": "type",
+                            "overrideType": "\"select-one\" | \"select-multiple\""
+                        },
                         "autocomplete": {
                             "name": "autocomplete",
                             "overrideType": "AutoFill"


### PR DESCRIPTION
According to https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-type-dev: ‘Returns "`select-multiple`" if the element has a `multiple` attribute, and "`select-one`" otherwise.’