### PR TITLE
Assign contents permission to deploy CI job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 4 * * *"
   workflow_dispatch: null
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pushing new tag has been failing since around Feb: https://github.com/microsoft/TypeScript-DOM-lib-generator/actions/runs/8243409917/job/22543947996#step:9:71

This mimics #1688. @jakebailey 