### PR TITLE
Update Body json() method to allow generic types.

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3165,7 +3165,7 @@ interface Body {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/formData) */
     formData(): Promise<FormData>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/json) */
-    json(): Promise<any>;
+    json<T = any>(): Promise<T>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/text) */
     text(): Promise<string>;
 }

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -884,7 +884,7 @@ interface Body {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/formData) */
     formData(): Promise<FormData>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/json) */
-    json(): Promise<any>;
+    json<T = any>(): Promise<T>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/text) */
     text(): Promise<string>;
 }

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -856,7 +856,7 @@ interface Body {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/formData) */
     formData(): Promise<FormData>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/json) */
-    json(): Promise<any>;
+    json<T = any>(): Promise<T>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/text) */
     text(): Promise<string>;
 }

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1027,7 +1027,7 @@ interface Body {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/formData) */
     formData(): Promise<FormData>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/json) */
-    json(): Promise<any>;
+    json<T = any>(): Promise<T>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Request/text) */
     text(): Promise<string>;
 }

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -234,6 +234,23 @@
                             "overrideType": "ReadableStream<Uint8Array>"
                         }
                     }
+                },
+                "methods": {
+                    "method": {
+                        "json": {
+                            "signature": {
+                                "0": {
+                                    "typeParameters": [
+                                        {
+                                            "name": "T",
+                                            "default": "any"
+                                        }
+                                    ],
+                                    "overrideType": "Promise<T>"
+                                }
+                            }
+                        }
+                    }
                 }
             },
             "WindowOrWorkerGlobalScope": {


### PR DESCRIPTION
This all started when I tried to use the Body > json() API for my server using Typescript.

Unfortunately, the json() function returns a `Promise<any>` type, which is not ideal when trying to build type-safe code.
A way I got around this was by using the `as` operator, which allowed me to cast my types. This isn't a completely ideal method but it worked.

```ts
const data = (await request.json()) as SetCreatorDataRequest;
```
A much better way to use this API with type-safety would be to how axios does it:
```ts
axios.get<MyTypeHere>(...)
```

So I adjusted the Body > json() function so that it allows for a generic type (`T`), and defaults to an `any` type.
```ts
json<T = any>(): Promise<T>
```

Hopefully this pull request gets implemented and becomes a feature of the Typescript DOM API.

Thanks :)