### PR TITLE
feat: add type parameter to EventTarget

### DIFF
--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -583,7 +583,7 @@ interface EventListenerObject {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget)
  */
-interface EventTarget {
+interface EventTarget<T = any> {
     /**
      * Appends an event listener for events whose type attribute value is type. The callback argument sets the callback that will be invoked when the event is dispatched.
      *
@@ -601,7 +601,8 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
      */
-    addEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: AddEventListenerOptions | boolean): void;
+    addEventListener<K extends keyof T>(type: K, callback: (this: EventTarget<T>, ev: T[K]) => any, options?: AddEventListenerOptions | boolean): void;
+    addEventListener(type: string, callback: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean): void;
     /**
      * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
      *
@@ -613,7 +614,8 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)
      */
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
+    removeEventListener<K extends keyof T>(type: K, callback: (this: EventTarget<T>, ev: T[K]) => any, options?: EventListenerOptions | boolean): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean): void;
 }
 
 declare var EventTarget: {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8298,7 +8298,7 @@ declare var EventSource: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget)
  */
-interface EventTarget {
+interface EventTarget<T = any> {
     /**
      * Appends an event listener for events whose type attribute value is type. The callback argument sets the callback that will be invoked when the event is dispatched.
      *
@@ -8316,7 +8316,8 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
      */
-    addEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: AddEventListenerOptions | boolean): void;
+    addEventListener<K extends keyof T>(type: K, callback: (this: EventTarget<T>, ev: T[K]) => any, options?: AddEventListenerOptions | boolean): void;
+    addEventListener(type: string, callback: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean): void;
     /**
      * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
      *
@@ -8328,7 +8329,8 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)
      */
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
+    removeEventListener<K extends keyof T>(type: K, callback: (this: EventTarget<T>, ev: T[K]) => any, options?: EventListenerOptions | boolean): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean): void;
 }
 
 declare var EventTarget: {

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -2402,7 +2402,7 @@ declare var EventSource: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget)
  */
-interface EventTarget {
+interface EventTarget<T = any> {
     /**
      * Appends an event listener for events whose type attribute value is type. The callback argument sets the callback that will be invoked when the event is dispatched.
      *
@@ -2420,7 +2420,8 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
      */
-    addEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: AddEventListenerOptions | boolean): void;
+    addEventListener<K extends keyof T>(type: K, callback: (this: EventTarget<T>, ev: T[K]) => any, options?: AddEventListenerOptions | boolean): void;
+    addEventListener(type: string, callback: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean): void;
     /**
      * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
      *
@@ -2432,7 +2433,8 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)
      */
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
+    removeEventListener<K extends keyof T>(type: K, callback: (this: EventTarget<T>, ev: T[K]) => any, options?: EventListenerOptions | boolean): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean): void;
 }
 
 declare var EventTarget: {

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -2329,7 +2329,7 @@ declare var EventSource: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget)
  */
-interface EventTarget {
+interface EventTarget<T = any> {
     /**
      * Appends an event listener for events whose type attribute value is type. The callback argument sets the callback that will be invoked when the event is dispatched.
      *
@@ -2347,7 +2347,8 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
      */
-    addEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: AddEventListenerOptions | boolean): void;
+    addEventListener<K extends keyof T>(type: K, callback: (this: EventTarget<T>, ev: T[K]) => any, options?: AddEventListenerOptions | boolean): void;
+    addEventListener(type: string, callback: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean): void;
     /**
      * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
      *
@@ -2359,7 +2360,8 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)
      */
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
+    removeEventListener<K extends keyof T>(type: K, callback: (this: EventTarget<T>, ev: T[K]) => any, options?: EventListenerOptions | boolean): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean): void;
 }
 
 declare var EventTarget: {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2612,7 +2612,7 @@ declare var EventSource: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget)
  */
-interface EventTarget {
+interface EventTarget<T = any> {
     /**
      * Appends an event listener for events whose type attribute value is type. The callback argument sets the callback that will be invoked when the event is dispatched.
      *
@@ -2630,7 +2630,8 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/addEventListener)
      */
-    addEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: AddEventListenerOptions | boolean): void;
+    addEventListener<K extends keyof T>(type: K, callback: (this: EventTarget<T>, ev: T[K]) => any, options?: AddEventListenerOptions | boolean): void;
+    addEventListener(type: string, callback: EventListenerOrEventListenerObject, options?: AddEventListenerOptions | boolean): void;
     /**
      * Dispatches a synthetic event event to target and returns true if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
      *
@@ -2642,7 +2643,8 @@ interface EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/removeEventListener)
      */
-    removeEventListener(type: string, callback: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
+    removeEventListener<K extends keyof T>(type: K, callback: (this: EventTarget<T>, ev: T[K]) => any, options?: EventListenerOptions | boolean): void;
+    removeEventListener(type: string, callback: EventListenerOrEventListenerObject, options?: EventListenerOptions | boolean): void;
 }
 
 declare var EventTarget: {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2998,29 +2998,95 @@
                 }
             },
             "EventTarget": {
+                "typeParameters": [
+                    {
+                        "name": "T",
+                        "default": "any"
+                    }
+                ],
                 "methods": {
                     "method": {
                         "addEventListener": {
                             "signature": {
                                 "0": {
+                                    "typeParameters": [
+                                        {
+                                            "name": "K extends keyof T",
+                                            "default": ""
+                                        }
+                                    ],
                                     "param": [
+                                        {
+                                            "name": "type",
+                                            "overrideType": "K"
+                                        },
+                                        {
+                                            "name": "callback",
+                                            "overrideType": "(this: EventTarget<T>, ev: T[K]) => any",
+                                            "nullable": false
+                                        }
+                                    ],
+                                    "overrideType": "void"
+                                },
+                                "1": {
+                                    "param": [
+                                        {
+                                            "name": "type",
+                                            "overrideType": "string"
+                                        },
                                         {
                                             "name": "callback",
                                             "overrideType": "EventListenerOrEventListenerObject"
+                                        },
+                                        {
+                                            "name": "options",
+                                            "overrideType": "AddEventListenerOptions | boolean",
+                                            "optional": true
                                         }
-                                    ]
+                                    ],
+                                    "overrideType": "void"
                                 }
                             }
                         },
                         "removeEventListener": {
                             "signature": {
                                 "0": {
+                                    "typeParameters": [
+                                        {
+                                            "name": "K extends keyof T",
+                                            "default": ""
+                                        }
+                                    ],
                                     "param": [
+                                        {
+                                            "name": "type",
+                                            "overrideType": "K"
+                                        },
+                                        {
+                                            "name": "callback",
+                                            "overrideType": "(this: EventTarget<T>, ev: T[K]) => any",
+                                            "nullable": false
+                                        }
+                                    ],
+                                    "overrideType": "void"
+                                },
+                                "1": {
+                                    "param": [
+                                        {
+                                            "name": "type",
+                                            "overrideType": "string"
+                                        },
                                         {
                                             "name": "callback",
                                             "overrideType": "EventListenerOrEventListenerObject"
+                                        },
+                                        {
+                                            "name": "options",
+                                            "overrideType": "EventListenerOptions | boolean",
+                                            "optional": true
                                         }
-                                    ]
+                                    ],
+                                    "overrideType": "void"
                                 }
                             }
                         }

--- a/unittests/files/eventtarget.ts
+++ b/unittests/files/eventtarget.ts
@@ -1,0 +1,15 @@
+declare const target: EventTarget;
+
+target.addEventListener("custom", (event) => {
+  event.target;
+});
+
+interface CustomEventMap {
+  custom: CustomEvent<{ data: number }>;
+}
+
+declare const customTarget: EventTarget<CustomEventMap>;
+
+customTarget.addEventListener("custom", (event) => {
+  event.detail.data;
+});


### PR DESCRIPTION
This introduces a type parameter to `EventTarget` such that the following is now possible:

```ts
interface CustomMap {
  'test-event': CustomEvent<{x: number; y: number}>;
}

declare const customTarget: EventTarget<CustomMap>;

customTarget.addEventListener('test-event', (event) => {
  // event is now `CustomEvent<{x: number; y: number}>`
  event.detail.x;
  event.detail.y;
});
```

Defaults to `T = any` to maintain existing behaviour otherwise.