### PR TITLE
cloneNode Return Type Must Be Active Class, Not Base Class (Node)

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -16450,7 +16450,7 @@ interface Node extends EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/cloneNode)
      */
-    cloneNode(deep?: boolean): Node;
+    cloneNode(deep?: boolean): this;
     /**
      * Returns a bitmask indicating the position of other relative to node.
      *

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -846,6 +846,19 @@
                                 }
                             }
                         },
+                        "cloneNode": {
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "deep",
+                                            "overrideType": "boolean"
+                                        }
+                                    ],
+                                    "overrideType": "this"
+                                }
+                            }
+                        },
                         "removeChild": {
                             "signature": {
                                 "0": {


### PR DESCRIPTION
The `cloneNode` return type is incorrect as per #283, #302, https://github.com/microsoft/TypeScript/issues/17818 and #1578. The type before this PR indicated that `cloneNode` returned a `Node`, which then broke any class that extended `Node`. In reality, `cloneNode` will return an instance of whatever the current class type is, a.k.a. `this` (`DocumentFragment#cloneNode` returns a `DocumentFragment`, not a `Node`).

This PR solves this issue by changing the return type of `Node#cloneNode` to `this`.