### PR TITLE
Allow `null` candidate in `RTCPeerConnection.addIceCandidate`

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -18150,9 +18150,9 @@ interface RTCPeerConnection extends EventTarget {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/signalingState) */
     readonly signalingState: RTCSignalingState;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addIceCandidate) */
-    addIceCandidate(candidate?: RTCIceCandidateInit): Promise<void>;
+    addIceCandidate(candidate?: RTCIceCandidateInit | null): Promise<void>;
     /** @deprecated */
-    addIceCandidate(candidate: RTCIceCandidateInit, successCallback: VoidFunction, failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
+    addIceCandidate(candidate: RTCIceCandidateInit | null, successCallback: VoidFunction, failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addTrack) */
     addTrack(track: MediaStreamTrack, ...streams: MediaStream[]): RTCRtpSender;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCPeerConnection/addTransceiver) */

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2173,7 +2173,7 @@
                                     "param": [
                                         {
                                             "name": "candidate",
-                                            "overrideType": "RTCIceCandidateInit | null"
+                                            "nullable": true
                                         }
                                     ]
                                 },
@@ -2181,7 +2181,7 @@
                                     "param": [
                                         {
                                             "name": "candidate",
-                                            "overrideType": "RTCIceCandidateInit | null"
+                                            "nullable": true
                                         }
                                     ],
                                     "deprecated": true

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2169,7 +2169,21 @@
                     "method": {
                         "addIceCandidate": {
                             "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "candidate",
+                                            "overrideType": "RTCIceCandidateInit | null"
+                                        }
+                                    ]
+                                },
                                 "1": {
+                                    "param": [
+                                        {
+                                            "name": "candidate",
+                                            "overrideType": "RTCIceCandidateInit | null"
+                                        }
+                                    ],
                                     "deprecated": true
                                 }
                             }


### PR DESCRIPTION
Add an override for [`addIceCandidate`][]’s `candidate` parameter to allow it to be `null`, which is a special value indicating that ICE gathering is complete.

> If no `candidate` object is specified, **or its value is `null`**, an end-of-candidates signal is sent to the remote peer *[emphasis added]*

Fixes #1738.

[`addIceCandidate`]: https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addIceCandidate