### PR TITLE
Change return type of CredentialsContainer.create for WebAuthn

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5920,7 +5920,7 @@ declare var Credential: {
  */
 interface CredentialsContainer {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/create) */
-    create(options?: CredentialCreationOptions): Promise<Credential | null>;
+    create(options?: CredentialCreationOptions): Promise<PublicKeyCredential | null>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/get) */
     get(options?: CredentialRequestOptions): Promise<Credential | null>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CredentialsContainer/preventSilentAccess) */

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -3291,6 +3291,19 @@
                         }
                     }
                 }
+            },
+            "CredentialsContainer": {
+                "methods": {
+                    "method": {
+                        "create": {
+                            "signature": {
+                                "0": {
+                                    "overrideType": "Promise<PublicKeyCredential | null>"
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
Hi developers,

The return value for CredentialsContainer.create is one of `FederatedCredential`, `PasswordCredential`, and `PublicKeyCredential` 
according to https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/create#return_value

The return types are subclass of Credential. So I changed using `PublicKeyCredential` from `Credential`. Note that `FederatedCredential` and `PasswordCredential` haven't been implemented yet, therefore, I didn't use them.

Thank you for reading my PR.