### PR TITLE
Make Navigator.canShare and Navigator.share methods optional

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -16239,7 +16239,7 @@ interface Navigator extends NavigatorAutomationInformation, NavigatorBadge, Navi
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Navigator/canShare)
      */
-    canShare(data?: ShareData): boolean;
+    canShare?(data?: ShareData): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Navigator/getGamepads) */
     getGamepads(): (Gamepad | null)[];
     /**
@@ -16261,7 +16261,7 @@ interface Navigator extends NavigatorAutomationInformation, NavigatorBadge, Navi
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Navigator/share)
      */
-    share(data?: ShareData): Promise<void>;
+    share?(data?: ShareData): Promise<void>;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Navigator/vibrate) */
     vibrate(pattern: VibratePattern): boolean;
 }

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -3315,6 +3315,24 @@
                         }
                     }
                 }
+            },
+            "Navigator": {
+                "methods": {
+                    "method": {
+                        "share": {
+                            "name": "share",
+                            "overrideSignatures": [
+                                "share?(data?: ShareData): Promise<void>"
+                            ]
+                        },
+                        "canShare": {
+                            "name": "canShare",
+                            "overrideSignatures": [
+                                "canShare?(data?: ShareData): boolean"
+                            ]
+                        }
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
Hi!

I've recently worked with `navigator.share` and `navigator.canShare` and have noticed that the types report them as non-optional.

I saw #837 where it's stated that the w3c says they are non-optional, but the truth is that most desktop browsers do not implement them and are only supported on secure contexts, so they can be undefined in certain cases. 

I'm not sure if there's something else that should be changed, let me know.
