### PR TITLE
Update the `URL.canParse` and `URL.parse` types

### DIFF
--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -1016,9 +1016,9 @@ declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
-    canParse(url: string | URL, base?: string): boolean;
+    canParse(url: string | URL, base?: string | URL): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
-    parse(url: string | URL, base?: string): URL | null;
+    parse(url: string | URL, base?: string | URL): URL | null;
 };
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams) */

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -22356,11 +22356,11 @@ declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
-    canParse(url: string | URL, base?: string): boolean;
+    canParse(url: string | URL, base?: string | URL): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
     createObjectURL(obj: Blob | MediaSource): string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
-    parse(url: string | URL, base?: string): URL | null;
+    parse(url: string | URL, base?: string | URL): URL | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL_static) */
     revokeObjectURL(url: string): void;
 };

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -5265,9 +5265,9 @@ declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
-    canParse(url: string | URL, base?: string): boolean;
+    canParse(url: string | URL, base?: string | URL): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
-    parse(url: string | URL, base?: string): URL | null;
+    parse(url: string | URL, base?: string | URL): URL | null;
 };
 
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URLSearchParams) */

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -5074,11 +5074,11 @@ declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
-    canParse(url: string | URL, base?: string): boolean;
+    canParse(url: string | URL, base?: string | URL): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
     createObjectURL(obj: Blob): string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
-    parse(url: string | URL, base?: string): URL | null;
+    parse(url: string | URL, base?: string | URL): URL | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL_static) */
     revokeObjectURL(url: string): void;
 };

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -5644,11 +5644,11 @@ declare var URL: {
     prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/canParse_static) */
-    canParse(url: string | URL, base?: string): boolean;
+    canParse(url: string | URL, base?: string | URL): boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/createObjectURL_static) */
     createObjectURL(obj: Blob): string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/parse_static) */
-    parse(url: string | URL, base?: string): URL | null;
+    parse(url: string | URL, base?: string | URL): URL | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/URL/revokeObjectURL_static) */
     revokeObjectURL(url: string): void;
 };

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2061,6 +2061,34 @@
                             ]
                         }
                     }
+                },
+                "methods": {
+                    "method": {
+                        "canParse": {
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "base",
+                                            "additionalTypes": ["URL"]
+                                        }
+                                    ]
+                                }
+                            }
+                        },
+                        "parse": {
+                            "signature": {
+                                "0": {
+                                    "param": [
+                                        {
+                                            "name": "base",
+                                            "additionalTypes": ["URL"]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
                 }
             },
             "Client": {


### PR DESCRIPTION
Modified the `URL.canParse` and `URL.parse` types to match the URL constructor type.