### PR TITLE
Remove some compat quirk

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -20413,7 +20413,7 @@ declare var SVGSwitchElement: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/SVGSymbolElement)
  */
-interface SVGSymbolElement extends SVGElement, SVGFitToViewBox {
+interface SVGSymbolElement extends SVGGraphicsElement, SVGFitToViewBox {
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGSymbolElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGSymbolElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5683,7 +5683,7 @@ declare var CharacterData: {
     new(): CharacterData;
 };
 
-interface ChildNode extends Node {
+interface ChildNode {
     /**
      * Inserts nodes just after node, while replacing strings in nodes with equivalent Text nodes.
      *
@@ -16502,7 +16502,7 @@ declare var PannerNode: {
     new(context: BaseAudioContext, options?: PannerOptions): PannerNode;
 };
 
-interface ParentNode extends Node {
+interface ParentNode {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/childElementCount) */
     readonly childElementCount: number;
     /**

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1262,9 +1262,6 @@
                     }
                 }
             },
-            "SVGSymbolElement": {
-                "extends": "SVGElement"
-            },
             "FormData": {
                 "methods": {
                     "method": {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1,12 +1,6 @@
 {
     "mixins": {
         "mixin": {
-            "ChildNode": {
-                "extends": "Node"
-            },
-            "ParentNode": {
-                "extends": "Node"
-            },
             "Animatable": {
                 "methods": {
                     "method": {


### PR DESCRIPTION
https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/1713#issuecomment-2248890913

> types/web also has some compat quirk that had to mismatch with the spec, e.g. ChildNode being only a mixin interface inherited by some Node variants but types/web had to make it inherit from Node, reversing the inheritance, because back in the day we thought maybe we should put the compat first before correctness.
>
> But if https://github.com/microsoft/TypeScript/pull/58222 didn't break DefinitelyTyped then maybe it's a good chance to remove one quirk.
