### PR TITLE
Update to bim@2.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -943,15 +943,16 @@
       "dev": true
     },
     "node_modules/bcd-idl-mapper": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/bcd-idl-mapper/-/bcd-idl-mapper-2.3.0.tgz",
-      "integrity": "sha512-hM8CS2NoLIkJzaEmEgVvxEfhEVDd3LBQXFwo+EY03J7QW71WIv+aZLXWdcVhLi2Zb9Q82evN+2NelDy7C/L1Fw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/bcd-idl-mapper/-/bcd-idl-mapper-2.3.1.tgz",
+      "integrity": "sha512-wtjhmrIOx93Gq67jjs4BqpkhRcR5c39l9QrGpGG4wxoj5YBz+16ibpP/I9yiHYsJd5dQRD3G+BUp71r/C4W8Iw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "webidl2": "^24.2.2"
+        "webidl2": "^24.4.1"
       },
       "peerDependencies": {
-        "@mdn/browser-compat-data": "^5.3.31",
+        "@mdn/browser-compat-data": "^5.4.1",
         "@webref/idl": "^3.39.2"
       }
     },


### PR DESCRIPTION
No feature change, just a syntax change so that it can be used in the latest Node.js without import assert support.