### PR TITLE
Do not generate iterable signatures for static methods

### DIFF
--- a/baselines/audioworklet.iterable.generated.d.ts
+++ b/baselines/audioworklet.iterable.generated.d.ts
@@ -2,11 +2,6 @@
 /// AudioWorklet Iterable APIs
 /////////////////////////////
 
-interface AbortSignal {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
-    any(signals: Iterable<AbortSignal>): AbortSignal;
-}
-
 interface MessageEvent<T = any> {
     /** @deprecated */
     initMessageEvent(type: string, bubbles?: boolean, cancelable?: boolean, data?: any, origin?: string, lastEventId?: string, source?: MessageEventSource | null, ports?: Iterable<MessagePort>): void;

--- a/baselines/dom.iterable.generated.d.ts
+++ b/baselines/dom.iterable.generated.d.ts
@@ -2,11 +2,6 @@
 /// Window Iterable APIs
 /////////////////////////////
 
-interface AbortSignal {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
-    any(signals: Iterable<AbortSignal>): AbortSignal;
-}
-
 interface AudioParam {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AudioParam/setValueCurveAtTime) */
     setValueCurveAtTime(values: Iterable<number>, startTime: number, duration: number): AudioParam;

--- a/baselines/serviceworker.iterable.generated.d.ts
+++ b/baselines/serviceworker.iterable.generated.d.ts
@@ -2,11 +2,6 @@
 /// ServiceWorker Iterable APIs
 /////////////////////////////
 
-interface AbortSignal {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
-    any(signals: Iterable<AbortSignal>): AbortSignal;
-}
-
 interface CSSNumericArray {
     [Symbol.iterator](): ArrayIterator<CSSNumericValue>;
     entries(): ArrayIterator<[number, CSSNumericValue]>;

--- a/baselines/sharedworker.iterable.generated.d.ts
+++ b/baselines/sharedworker.iterable.generated.d.ts
@@ -2,11 +2,6 @@
 /// SharedWorker Iterable APIs
 /////////////////////////////
 
-interface AbortSignal {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
-    any(signals: Iterable<AbortSignal>): AbortSignal;
-}
-
 interface CSSNumericArray {
     [Symbol.iterator](): ArrayIterator<CSSNumericValue>;
     entries(): ArrayIterator<[number, CSSNumericValue]>;

--- a/baselines/ts5.5/audioworklet.iterable.generated.d.ts
+++ b/baselines/ts5.5/audioworklet.iterable.generated.d.ts
@@ -2,11 +2,6 @@
 /// AudioWorklet Iterable APIs
 /////////////////////////////
 
-interface AbortSignal {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
-    any(signals: Iterable<AbortSignal>): AbortSignal;
-}
-
 interface MessageEvent<T = any> {
     /** @deprecated */
     initMessageEvent(type: string, bubbles?: boolean, cancelable?: boolean, data?: any, origin?: string, lastEventId?: string, source?: MessageEventSource | null, ports?: Iterable<MessagePort>): void;

--- a/baselines/ts5.5/dom.iterable.generated.d.ts
+++ b/baselines/ts5.5/dom.iterable.generated.d.ts
@@ -2,11 +2,6 @@
 /// Window Iterable APIs
 /////////////////////////////
 
-interface AbortSignal {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
-    any(signals: Iterable<AbortSignal>): AbortSignal;
-}
-
 interface AudioParam {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AudioParam/setValueCurveAtTime) */
     setValueCurveAtTime(values: Iterable<number>, startTime: number, duration: number): AudioParam;

--- a/baselines/ts5.5/serviceworker.iterable.generated.d.ts
+++ b/baselines/ts5.5/serviceworker.iterable.generated.d.ts
@@ -2,11 +2,6 @@
 /// ServiceWorker Iterable APIs
 /////////////////////////////
 
-interface AbortSignal {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
-    any(signals: Iterable<AbortSignal>): AbortSignal;
-}
-
 interface CSSNumericArray {
     [Symbol.iterator](): IterableIterator<CSSNumericValue>;
     entries(): IterableIterator<[number, CSSNumericValue]>;

--- a/baselines/ts5.5/sharedworker.iterable.generated.d.ts
+++ b/baselines/ts5.5/sharedworker.iterable.generated.d.ts
@@ -2,11 +2,6 @@
 /// SharedWorker Iterable APIs
 /////////////////////////////
 
-interface AbortSignal {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
-    any(signals: Iterable<AbortSignal>): AbortSignal;
-}
-
 interface CSSNumericArray {
     [Symbol.iterator](): IterableIterator<CSSNumericValue>;
     entries(): IterableIterator<[number, CSSNumericValue]>;

--- a/baselines/ts5.5/webworker.iterable.generated.d.ts
+++ b/baselines/ts5.5/webworker.iterable.generated.d.ts
@@ -2,11 +2,6 @@
 /// Worker Iterable APIs
 /////////////////////////////
 
-interface AbortSignal {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
-    any(signals: Iterable<AbortSignal>): AbortSignal;
-}
-
 interface CSSNumericArray {
     [Symbol.iterator](): IterableIterator<CSSNumericValue>;
     entries(): IterableIterator<[number, CSSNumericValue]>;

--- a/baselines/webworker.iterable.generated.d.ts
+++ b/baselines/webworker.iterable.generated.d.ts
@@ -2,11 +2,6 @@
 /// Worker Iterable APIs
 /////////////////////////////
 
-interface AbortSignal {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/AbortSignal/any_static) */
-    any(signals: Iterable<AbortSignal>): AbortSignal;
-}
-
 interface CSSNumericArray {
     [Symbol.iterator](): ArrayIterator<CSSNumericValue>;
     entries(): ArrayIterator<[number, CSSNumericValue]>;

--- a/src/build/emitter.ts
+++ b/src/build/emitter.ts
@@ -1736,7 +1736,7 @@ export function emitWebIdl(
     const methodsWithSequence: Browser.Method[] = mapToArray(
       i.methods ? i.methods.method : {},
     )
-      .filter((m) => m.signature && !m.overrideSignatures)
+      .filter((m) => m.signature && !m.overrideSignatures && !m.static)
       .map((m) => ({
         ...m,
         signature: replaceTypedefsInSignatures(


### PR DESCRIPTION
The current logic is bugged, and the correct fix is not possible because of #222.

Closes #1803 