### PR TITLE
Fix running "test" in a clean repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "baseline-accept": "cpx \"generated\\**\" baselines\\",
     "lint": "eslint --max-warnings 0 src deploy/*.js && tsc -p deploy/jsconfig.json",
     "lint-fix": "eslint --max-warnings 0 src deploy/*.js --fix",
-    "test": "npm run lint && npm run build && node ./lib/test.js && node ./unittests/index.js",
+    "test": "npm run build && npm run lint && node ./lib/test.js && node ./unittests/index.js",
     "changelog": "tsc && node ./lib/changelog.js",
     "ts-changelog": "node ./deploy/versionChangelog.js",
     "migrate": "node ./deploy/migrate.js",


### PR DESCRIPTION
I did a checkout of the repo, ran `npm install` and `npm test` and got:

```
deploy/deployChangedPackages.js:12:39 - error TS2307: Cannot find module '../lib/changelog.js' or its corresponding type declarations.

12 import { generateChangelogFrom } from "../lib/changelog.js";
                                         ~~~~~~~~~~~~~~~~~~~~~

deploy/versionChangelog.js:5:52 - error TS2307: Cannot find module '../lib/changelog.js' or its corresponding type declarations.

5 import { gitShowFile, generateChangelogFrom } from "../lib/changelog.js";
                                                     ~~~~~~~~~~~~~~~~~~~~~
```

This is because eslint runs on files that import from files which has not been built initially, turning these two around (building before linting) seems like a harmless fix.