### PR TITLE
fix: `fetchPriority` type for `HTMLImageElement`, `HTMLLinkElement`, and `HTMLScriptElement`

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -11439,7 +11439,7 @@ interface HTMLImageElement extends HTMLElement {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/decoding) */
     decoding: "async" | "sync" | "auto";
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/fetchPriority) */
-    fetchPriority: string;
+    fetchPriority: "high" | "low" | "auto";
     /**
      * Sets or retrieves the height of the object.
      *
@@ -11958,7 +11958,7 @@ interface HTMLLinkElement extends HTMLElement, LinkStyle {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/disabled) */
     disabled: boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/fetchPriority) */
-    fetchPriority: string;
+    fetchPriority: "high" | "low" | "auto";
     /**
      * Sets or retrieves a destination URL or an anchor point.
      *
@@ -13004,7 +13004,7 @@ interface HTMLScriptElement extends HTMLElement {
      */
     event: string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/fetchPriority) */
-    fetchPriority: string;
+    fetchPriority: "high" | "low" | "auto";
     /**
      * Sets or retrieves the object that is bound to the event script.
      * @deprecated

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -11425,7 +11425,7 @@ interface HTMLImageElement extends HTMLElement {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/decoding) */
     decoding: "async" | "sync" | "auto";
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLImageElement/fetchPriority) */
-    fetchPriority: string;
+    fetchPriority: "high" | "low" | "auto";
     /**
      * Sets or retrieves the height of the object.
      *
@@ -11943,7 +11943,7 @@ interface HTMLLinkElement extends HTMLElement, LinkStyle {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/disabled) */
     disabled: boolean;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLLinkElement/fetchPriority) */
-    fetchPriority: string;
+    fetchPriority: "high" | "low" | "auto";
     /**
      * Sets or retrieves a destination URL or an anchor point.
      *
@@ -12985,7 +12985,7 @@ interface HTMLScriptElement extends HTMLElement {
      */
     event: string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/fetchPriority) */
-    fetchPriority: string;
+    fetchPriority: "high" | "low" | "auto";
     /**
      * Sets or retrieves the object that is bound to the event script.
      * @deprecated

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -3609,6 +3609,33 @@
                         }
                     }
                 }
+            },
+            "HTMLImageElement": {
+                "properties": {
+                    "property": {
+                        "fetchPriority": {
+                            "overrideType": "\"high\" | \"low\" | \"auto\""
+                        }
+                    }
+                }
+            },
+            "HTMLLinkElement": {
+                "properties": {
+                    "property": {
+                        "fetchPriority": {
+                            "overrideType": "\"high\" | \"low\" | \"auto\""
+                        }
+                    }
+                }
+            },
+            "HTMLScriptElement": {
+                "properties": {
+                    "property": {
+                        "fetchPriority": {
+                            "overrideType": "\"high\" | \"low\" | \"auto\""
+                        }
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
Fixes: https://github.com/microsoft/TypeScript/issues/60940