### PR TITLE
Make package name scoped to @typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typescript-dom-lib-generator",
+  "name": "@microsoft/typescript-dom-lib-generator",
   "version": "0.0.1",
   "private": true,
   "description": "Provides TypeScript types for the latest web APIs.",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@microsoft/typescript-dom-lib-generator",
+  "name": "@typescript/dom-lib-generator",
   "version": "0.0.1",
   "private": true,
   "description": "Provides TypeScript types for the latest web APIs.",


### PR DESCRIPTION
Apparently this package name was name squatted on npm by a malicious actor: https://github.com/advisories/GHSA-5h3m-q8pm-rw64.

The issue is that anyone importing this package gets a "**critical** severity vulnerability" because of the package name.  Making the package name scoped to @microsoft avoids any confusion today, and guards against any [potential future npm substitution attacks](https://github.blog/security/supply-chain-security/avoiding-npm-substitution-attacks/).