### PR TITLE
Correct optionality of `ReadableStreamReadDoneResult.value`

### DIFF
--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -79,7 +79,7 @@ interface ReadableStreamIteratorOptions {
 
 interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: T;
+    value: T | undefined;
 }
 
 interface ReadableStreamReadValueResult<T> {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1902,7 +1902,7 @@ interface ReadableStreamIteratorOptions {
 
 interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: T;
+    value: T | undefined;
 }
 
 interface ReadableStreamReadValueResult<T> {

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -524,7 +524,7 @@ interface ReadableStreamIteratorOptions {
 
 interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: T;
+    value: T | undefined;
 }
 
 interface ReadableStreamReadValueResult<T> {

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -463,7 +463,7 @@ interface ReadableStreamIteratorOptions {
 
 interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: T;
+    value: T | undefined;
 }
 
 interface ReadableStreamReadValueResult<T> {

--- a/baselines/ts5.5/audioworklet.generated.d.ts
+++ b/baselines/ts5.5/audioworklet.generated.d.ts
@@ -79,7 +79,7 @@ interface ReadableStreamIteratorOptions {
 
 interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: T;
+    value: T | undefined;
 }
 
 interface ReadableStreamReadValueResult<T> {

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -1902,7 +1902,7 @@ interface ReadableStreamIteratorOptions {
 
 interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: T;
+    value: T | undefined;
 }
 
 interface ReadableStreamReadValueResult<T> {

--- a/baselines/ts5.5/serviceworker.generated.d.ts
+++ b/baselines/ts5.5/serviceworker.generated.d.ts
@@ -524,7 +524,7 @@ interface ReadableStreamIteratorOptions {
 
 interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: T;
+    value: T | undefined;
 }
 
 interface ReadableStreamReadValueResult<T> {

--- a/baselines/ts5.5/sharedworker.generated.d.ts
+++ b/baselines/ts5.5/sharedworker.generated.d.ts
@@ -463,7 +463,7 @@ interface ReadableStreamIteratorOptions {
 
 interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: T;
+    value: T | undefined;
 }
 
 interface ReadableStreamReadValueResult<T> {

--- a/baselines/ts5.5/webworker.generated.d.ts
+++ b/baselines/ts5.5/webworker.generated.d.ts
@@ -666,7 +666,7 @@ interface ReadableStreamIteratorOptions {
 
 interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: T;
+    value: T | undefined;
 }
 
 interface ReadableStreamReadValueResult<T> {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -666,7 +666,7 @@ interface ReadableStreamIteratorOptions {
 
 interface ReadableStreamReadDoneResult<T> {
     done: true;
-    value?: T;
+    value: T | undefined;
 }
 
 interface ReadableStreamReadValueResult<T> {

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -1330,7 +1330,8 @@
                         },
                         "value": {
                             "name": "value",
-                            "overrideType": "T"
+                            "overrideType": "T | undefined",
+                            "required": true
                         }
                     }
                 }


### PR DESCRIPTION
The IDL specifies for `ReadableStreamReadResult` that the `value` property is always present. If the stream is cancelled, then this property won't be absent, but will be present with the value `undefined`. (This differs from _eg._ the iterator protocol, where a result object's `value` property may indeed be absent if the iterator is closed.)

The difference is only really manifest when `exactOptionalPropertyTypes` is enabled, but where it is, `ReadableStreamReadDoneResult` is currently divergent from the web standard.