### PR TITLE
Update overridingTypes.jsonc to add `PointerEvent` to `contextmenu` and `auxclick`

### DIFF
--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -66,12 +66,20 @@
                             "type": "AnimationEvent"
                         },
                         {
+                            "name": "auxclick",
+                            "type": "PointerEvent"
+                        },
+                        {
                             "name": "cut",
                             "type": "ClipboardEvent"
                         },
                         {
                             "name": "copy",
                             "type": "ClipboardEvent"
+                        },
+                        {
+                            "name": "contextmenu",
+                            "type": "PointerEvent"
                         },
                         {
                             "name": "paste",


### PR DESCRIPTION
It has been noted in SolidJS discord that the interface for `contextmenu` and `auxclick` events is `PointerEvent` not `MouseEvent`.  MDN supports 
- https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event 
- https://developer.mozilla.org/en-US/docs/Web/API/Element/contextmenu_event

The file being updated here has other 10 sibling entries also for the same event `PointerEvent`, so I am adding 2 more.

Now, I'm not completely sure why this is still _outdated?_/needs manual overriding, may be worth to look at that. 

Thanks!