### PR TITLE
fix(IDBObjectStore): Allow keyPath to be null

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14862,7 +14862,7 @@ interface IDBObjectStore {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/keyPath)
      */
-    readonly keyPath: string | string[];
+    readonly keyPath: string | string[] | null;
     /**
      * Returns the name of the store.
      *

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -3333,7 +3333,7 @@ interface IDBObjectStore {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/keyPath)
      */
-    readonly keyPath: string | string[];
+    readonly keyPath: string | string[] | null;
     /**
      * Returns the name of the store.
      *

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -3152,7 +3152,7 @@ interface IDBObjectStore {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/keyPath)
      */
-    readonly keyPath: string | string[];
+    readonly keyPath: string | string[] | null;
     /**
      * Returns the name of the store.
      *

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -14842,7 +14842,7 @@ interface IDBObjectStore {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/keyPath)
      */
-    readonly keyPath: string | string[];
+    readonly keyPath: string | string[] | null;
     /**
      * Returns the name of the store.
      *

--- a/baselines/ts5.5/serviceworker.generated.d.ts
+++ b/baselines/ts5.5/serviceworker.generated.d.ts
@@ -3333,7 +3333,7 @@ interface IDBObjectStore {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/keyPath)
      */
-    readonly keyPath: string | string[];
+    readonly keyPath: string | string[] | null;
     /**
      * Returns the name of the store.
      *

--- a/baselines/ts5.5/sharedworker.generated.d.ts
+++ b/baselines/ts5.5/sharedworker.generated.d.ts
@@ -3152,7 +3152,7 @@ interface IDBObjectStore {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/keyPath)
      */
-    readonly keyPath: string | string[];
+    readonly keyPath: string | string[] | null;
     /**
      * Returns the name of the store.
      *

--- a/baselines/ts5.5/webworker.generated.d.ts
+++ b/baselines/ts5.5/webworker.generated.d.ts
@@ -3823,7 +3823,7 @@ interface IDBObjectStore {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/keyPath)
      */
-    readonly keyPath: string | string[];
+    readonly keyPath: string | string[] | null;
     /**
      * Returns the name of the store.
      *

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -3823,7 +3823,7 @@ interface IDBObjectStore {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/IDBObjectStore/keyPath)
      */
-    readonly keyPath: string | string[];
+    readonly keyPath: string | string[] | null;
     /**
      * Returns the name of the store.
      *

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1218,7 +1218,7 @@
                     "property": {
                         "keyPath": {
                             "name": "keyPath",
-                            "overrideType": "string | string[]"
+                            "overrideType": "string | string[] | null"
                         }
                     }
                 }


### PR DESCRIPTION
Hello :)
I have allowed `IDBObjectStore` to be null as requested in https://github.com/microsoft/TypeScript/issues/61209