### PR TITLE
Implement `ResponseConstructor` to allow overrides from other runtimes

### DIFF
--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -454,6 +454,262 @@
     },
     "interfaces": {
         "interface": {
+            "Response": {
+                "name": "Response",
+                "noInterfaceObject": true,
+
+                "properties": {
+                    "property": {
+                        "type": {
+                            "name": "type",
+                            "type": "ResponseType",
+                            "nullable": false,
+                            "static": false,
+                            "stringifier": false,
+                            "readonly": true,
+                            "exposed": "Window Worker",
+                            "secureContext": false,
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/type"
+                        },
+                        "url": {
+                            "name": "url",
+                            "type": "USVString",
+                            "nullable": false,
+                            "static": false,
+                            "stringifier": false,
+                            "readonly": true,
+                            "exposed": "Window Worker",
+                            "secureContext": false,
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/url"
+                        },
+                        "redirected": {
+                            "name": "redirected",
+                            "type": "boolean",
+                            "nullable": false,
+                            "static": false,
+                            "stringifier": false,
+                            "readonly": true,
+                            "exposed": "Window Worker",
+                            "secureContext": false,
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/redirected"
+                        },
+                        "status": {
+                            "name": "status",
+                            "type": "unsigned short",
+                            "nullable": false,
+                            "static": false,
+                            "stringifier": false,
+                            "readonly": true,
+                            "exposed": "Window Worker",
+                            "secureContext": false,
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/status"
+                        },
+                        "ok": {
+                            "name": "ok",
+                            "type": "boolean",
+                            "nullable": false,
+                            "static": false,
+                            "stringifier": false,
+                            "readonly": true,
+                            "exposed": "Window Worker",
+                            "secureContext": false,
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/ok"
+                        },
+                        "statusText": {
+                            "name": "statusText",
+                            "type": "ByteString",
+                            "nullable": false,
+                            "static": false,
+                            "stringifier": false,
+                            "readonly": true,
+                            "exposed": "Window Worker",
+                            "secureContext": false,
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/statusText"
+                        },
+                        "headers": {
+                            "name": "headers",
+                            "type": "Headers",
+                            "nullable": false,
+                            "static": false,
+                            "stringifier": false,
+                            "readonly": true,
+                            "exposed": "Window Worker",
+                            "secureContext": false,
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/headers"
+                        }
+                    },
+                    "namesakes": {}
+                },
+                "constructor": {
+                    "signature": [
+                        {
+                            "type": "Response",
+                            "param": [
+                                {
+                                    "name": "body",
+                                    "type": "BodyInit",
+                                    "nullable": true,
+                                    "optional": true,
+                                    "variadic": false
+                                },
+                                {
+                                    "name": "init",
+                                    "type": "ResponseInit",
+                                    "nullable": false,
+                                    "optional": true,
+                                    "variadic": false
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "exposed": "Window Worker",
+                "legacyWindowAlias": [],
+                "secureContext": false,
+                "transferable": false,
+                "implements": ["Body"],
+                "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response",
+                "comment": "This Fetch API interface represents the response to a request."
+            },
+            "ResponseConstructor": {
+                "name": "ResponseConstructor",
+                "noInterfaceObject": true,
+
+                "properties": {
+                    "property": {
+                        "prototype": {
+                            "name": "prototype",
+                            "type": "Response",
+                            "nullable": false,
+                            "static": false,
+                            "stringifier": false,
+                            "exposed": "Window Worker"
+                        }
+                    }
+                },
+
+                "methods": {
+                    "method": {
+                        "new": {
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/Response",
+                            "name": "new",
+                            "exposed": "Window Worker",
+                            "signature": [
+                                {
+                                    "type": "Response",
+                                    "param": [
+                                        {
+                                            "name": "body",
+                                            "type": "BodyInit",
+                                            "nullable": true,
+                                            "optional": true,
+                                            "variadic": false
+                                        },
+                                        {
+                                            "name": "init",
+                                            "type": "ResponseInit",
+                                            "nullable": false,
+                                            "optional": true,
+                                            "variadic": false
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        "error": {
+                            "name": "error",
+                            "signature": [
+                                {
+                                    "type": "Response",
+                                    "nullable": false,
+                                    "param": []
+                                }
+                            ],
+                            "getter": false,
+                            "stringifier": false,
+                            "exposed": "Window Worker",
+                            "secureContext": false,
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/error_static"
+                        },
+                        "redirect": {
+                            "name": "redirect",
+                            "signature": [
+                                {
+                                    "type": "Response",
+                                    "nullable": false,
+                                    "param": [
+                                        {
+                                            "name": "url",
+                                            "type": "USVString",
+                                            "nullable": false,
+                                            "optional": false,
+                                            "variadic": false
+                                        },
+                                        {
+                                            "name": "status",
+                                            "type": "unsigned short",
+                                            "nullable": false,
+                                            "optional": true,
+                                            "variadic": false
+                                        }
+                                    ]
+                                }
+                            ],
+                            "getter": false,
+                            "stringifier": false,
+                            "exposed": "Window Worker",
+                            "secureContext": false,
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/redirect_static"
+                        },
+                        "json": {
+                            "name": "json",
+                            "signature": [
+                                {
+                                    "type": "Response",
+                                    "nullable": false,
+                                    "param": [
+                                        {
+                                            "name": "data",
+                                            "type": "any",
+                                            "nullable": false,
+                                            "optional": false,
+                                            "variadic": false
+                                        },
+                                        {
+                                            "name": "init",
+                                            "type": "ResponseInit",
+                                            "nullable": false,
+                                            "optional": true,
+                                            "variadic": false
+                                        }
+                                    ]
+                                }
+                            ],
+                            "getter": false,
+                            "stringifier": false,
+                            "exposed": "Window Worker",
+                            "secureContext": false,
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/json_static"
+                        },
+                        "clone": {
+                            "name": "clone",
+                            "signature": [
+                                {
+                                    "type": "Response",
+                                    "nullable": false,
+                                    "param": []
+                                }
+                            ],
+                            "getter": false,
+                            "static": false,
+                            "stringifier": false,
+                            "exposed": "Window Worker",
+                            "secureContext": false,
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/clone"
+                        }
+                    }
+                }
+            },
             // ImportMeta is not a true DOM interface, but we are forced to declare it as one in order to emit method definitions.
             // We cannot define methods as dictionary properties with function types,
             // as this would cause conflicts with ImportMeta method overrides in places like @types/node.
@@ -604,6 +860,19 @@
                 "overrideIndexSignatures": [
                     "[index: number]: Window"
                 ],
+                "properties": {
+                    "property": {
+                        "Response": {
+                            "name": "Response",
+                            "type": "ResponseConstructor",
+                            "nullable": false,
+                            "readonly": true,
+                            "exposed": "Window",
+                            "secureContext": false,
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Response/Response"
+                        }
+                    }
+                },
                 "events": {
                     "event": [
                         {

--- a/inputfiles/removedTypes.jsonc
+++ b/inputfiles/removedTypes.jsonc
@@ -109,6 +109,7 @@
     },
     "interfaces": {
         "interface": {
+            "Response": null,
             "Clipboard": {
                 "methods": {
                     "method": {


### PR DESCRIPTION
This PR converts `Response` to be declared as the interface `ResponseConstructor`

This allows for types from some runtimes to implement extra overloads for the Response class and static methods

```ts
interface ResponseConstructor {
  prototype: Response;
  new(body?: BodyInit | null, init?: ResponseInit): Response;
  redirect(url: string | URL, status?: number): Response;
  // ... more properties
}

var Response: ResponseConstructor
```

For example, Bun supports `Response.redirect(location, statusOrRequestInit)`. Bun's types cannot declare `var Response` because if a user needs lib.dom loaded then the declarations clash, and typechecking fails

`Response` is currently declared as `var Response`, which means we cannot use interface merging to append these extra properties

I'm not sure if this is the best approach for modifying/overriding the types. This was implemented by dumping the webidl JSON and then copying in the overrides for making a ResponseConstructor exist

There was also an existing issue (#1518) that asked for this