### PR TITLE
fix: update index signature for NamedNodeMap to support both number and string keys

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -16879,7 +16879,7 @@ interface NamedNodeMap {
     setNamedItem(attr: Attr): Attr | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/setNamedItemNS) */
     setNamedItemNS(attr: Attr): Attr | null;
-    [index: number]: Attr;
+    [index: number | string]: Attr;
 }
 
 declare var NamedNodeMap: {

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -16859,7 +16859,7 @@ interface NamedNodeMap {
     setNamedItem(attr: Attr): Attr | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/NamedNodeMap/setNamedItemNS) */
     setNamedItemNS(attr: Attr): Attr | null;
-    [index: number]: Attr;
+    [index: number | string]: Attr;
 }
 
 declare var NamedNodeMap: {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2722,6 +2722,11 @@
                     }
                 }
             },
+            "NamedNodeMap": {
+                "overrideIndexSignatures": [
+                    "[index: number | string]: Attr"
+                ]
+            },
             "Blob": {
               "methods": {
                 "method": {

--- a/unittests/files/NameNodeMap.ts
+++ b/unittests/files/NameNodeMap.ts
@@ -1,0 +1,7 @@
+const pre = document.querySelector("pre");
+if (pre) {
+  const attrMap = pre.attributes;
+  const value = attrMap["test"].value;
+  pre.textContent = `The 'test' attribute contains ${value}.
+And 'foo' has ${attrMap["foo"] ? "been" : "not been"} found.`;
+};


### PR DESCRIPTION
fixes #344 
MDN: https://developer.mozilla.org/en-US/docs/Web/API/NamedNodeMap/getNamedItem