### PR TITLE
Add `generate` command for faster build and baseline acceptance

### DIFF
--- a/.github/workflows/update-core-deps.yml
+++ b/.github/workflows/update-core-deps.yml
@@ -27,7 +27,7 @@ jobs:
       # Example: https://github.com/microsoft/TypeScript-DOM-lib-generator/pull/1463
       - run: npm i
       - id: build
-        run: npm run build && npm run baseline-accept
+        run: npm run generate
         continue-on-error: true
       - if: ${{ steps.build.outcome == 'failure' }}
         run: node deploy/onUpdateFailure.js

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ In order to make the tests pass, please update the baseline as well in any pull 
 
 It's possible that the automated algorithm decided that it's not well supported by browsers and thus removed it. Say we want to add a new interface named `Foo`. Check if there is a document about that interface in [MDN](https://developer.mozilla.org/). If there is, see the browser compatibility section and check whether it's supported by two or more browser engines. (Note that Chromium-based browsers use the same browser engine and thus support from them counts as a single support.)
 
-If all the conditions are fulfilled, it could be that the type is incorrectly removed by `inputfiles/removedTypes.jsonc`. Try finding and removing the relevant item there and run `npm run build && npm run baseline-accept`.
+If all the conditions are fulfilled, it could be that the type is incorrectly removed by `inputfiles/removedTypes.jsonc`. Try finding and removing the relevant item there and run `npm run generate`.
 
 If conditions are not fulfilled but you think MDN is wrong, please file an issue at https://github.com/mdn/browser-compat-data/issues/. The type will be automatically added in a few weeks when MDN fixes their data.
 
 ### When the type exists but is wrong
 
-It's possible that the type is too specific or too general. First you need to check whether `inputfiles/overridingTypes.jsonc` or `inputfiles/addedTypes.jsonc` have a relevant item, which can be fixed if exists. If they don't, add one in `overridingTypes.jsonc`. Run `npm run build && npm run baseline-accept` to make sure the resulting changes are what you want.
+It's possible that the type is too specific or too general. First you need to check whether `inputfiles/overridingTypes.jsonc` or `inputfiles/addedTypes.jsonc` have a relevant item, which can be fixed if exists. If they don't, add one in `overridingTypes.jsonc`. Run `npm run generate` to make sure the resulting changes are what you want.
 
 If you are familiar with Web IDL, you may also want to check whether the upstream IDL itself can be made more specific. Doing so will reduce the need for manual overrides in this repository and thus can be more helpful.
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "changelog": "tsc && node ./lib/changelog.js",
     "ts-changelog": "node ./deploy/versionChangelog.js",
     "migrate": "node ./deploy/migrate.js",
-    "version": "npm i && tsc && node ./lib/version.js"
+    "version": "npm i && tsc && node ./lib/version.js",
+    "generate": "npm run generate"
   },
   "author": {
     "name": "Kagami Sascha Rosylight",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "ts-changelog": "node ./deploy/versionChangelog.js",
     "migrate": "node ./deploy/migrate.js",
     "version": "npm i && tsc && node ./lib/version.js",
-    "generate": "npm run generate"
+    "generate": "npm run build && npm run baseline-accept"
   },
   "author": {
     "name": "Kagami Sascha Rosylight",


### PR DESCRIPTION
Hello! 🙂

I’ve added a new `generate` command to the `package.json` scripts. This change will allow contributors to quickly run the build and baseline acceptance process with a single command, improving workflow efficiency.

Instead of manually running:

```bash
npm run build && npm run baseline-accept
```

Contributors can now simply execute:

```bash
npm run generate
```

Here’s how the updated `scripts` section will look:

```json
"scripts": {
  "generate": "npm run build && npm run baseline-accept"
}
```

This small change should help make the development process smoother for everyone. Let me know if you have any questions or suggestions!