### PR TITLE
DOM: Add Support for pageswap and pagereveal event on window

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -27472,9 +27472,9 @@ interface WindowEventHandlersEventMap {
     "offline": Event;
     "online": Event;
     "pagehide": PageTransitionEvent;
-    "pagereveal": Event;
+    "pagereveal": PageRevealEvent;
     "pageshow": PageTransitionEvent;
-    "pageswap": Event;
+    "pageswap": PageSwapEvent;
     "popstate": PopStateEvent;
     "rejectionhandled": PromiseRejectionEvent;
     "storage": StorageEvent;
@@ -27508,11 +27508,11 @@ interface WindowEventHandlers {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pagehide_event) */
     onpagehide: ((this: WindowEventHandlers, ev: PageTransitionEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pagereveal_event) */
-    onpagereveal: ((this: WindowEventHandlers, ev: Event) => any) | null;
+    onpagereveal: ((this: WindowEventHandlers, ev: PageRevealEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pageshow_event) */
     onpageshow: ((this: WindowEventHandlers, ev: PageTransitionEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pageswap_event) */
-    onpageswap: ((this: WindowEventHandlers, ev: Event) => any) | null;
+    onpageswap: ((this: WindowEventHandlers, ev: PageSwapEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/popstate_event) */
     onpopstate: ((this: WindowEventHandlers, ev: PopStateEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/rejectionhandled_event) */
@@ -29558,11 +29558,11 @@ declare var ononline: ((this: Window, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pagehide_event) */
 declare var onpagehide: ((this: Window, ev: PageTransitionEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pagereveal_event) */
-declare var onpagereveal: ((this: Window, ev: Event) => any) | null;
+declare var onpagereveal: ((this: Window, ev: PageRevealEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pageshow_event) */
 declare var onpageshow: ((this: Window, ev: PageTransitionEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pageswap_event) */
-declare var onpageswap: ((this: Window, ev: Event) => any) | null;
+declare var onpageswap: ((this: Window, ev: PageSwapEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/popstate_event) */
 declare var onpopstate: ((this: Window, ev: PopStateEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/rejectionhandled_event) */

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -27450,9 +27450,9 @@ interface WindowEventHandlersEventMap {
     "offline": Event;
     "online": Event;
     "pagehide": PageTransitionEvent;
-    "pagereveal": Event;
+    "pagereveal": PageRevealEvent;
     "pageshow": PageTransitionEvent;
-    "pageswap": Event;
+    "pageswap": PageSwapEvent;
     "popstate": PopStateEvent;
     "rejectionhandled": PromiseRejectionEvent;
     "storage": StorageEvent;
@@ -27486,11 +27486,11 @@ interface WindowEventHandlers {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pagehide_event) */
     onpagehide: ((this: WindowEventHandlers, ev: PageTransitionEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pagereveal_event) */
-    onpagereveal: ((this: WindowEventHandlers, ev: Event) => any) | null;
+    onpagereveal: ((this: WindowEventHandlers, ev: PageRevealEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pageshow_event) */
     onpageshow: ((this: WindowEventHandlers, ev: PageTransitionEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pageswap_event) */
-    onpageswap: ((this: WindowEventHandlers, ev: Event) => any) | null;
+    onpageswap: ((this: WindowEventHandlers, ev: PageSwapEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/popstate_event) */
     onpopstate: ((this: WindowEventHandlers, ev: PopStateEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/rejectionhandled_event) */
@@ -29536,11 +29536,11 @@ declare var ononline: ((this: Window, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pagehide_event) */
 declare var onpagehide: ((this: Window, ev: PageTransitionEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pagereveal_event) */
-declare var onpagereveal: ((this: Window, ev: Event) => any) | null;
+declare var onpagereveal: ((this: Window, ev: PageRevealEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pageshow_event) */
 declare var onpageshow: ((this: Window, ev: PageTransitionEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/pageswap_event) */
-declare var onpageswap: ((this: Window, ev: Event) => any) | null;
+declare var onpageswap: ((this: Window, ev: PageSwapEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/popstate_event) */
 declare var onpopstate: ((this: Window, ev: PopStateEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/rejectionhandled_event) */

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -248,6 +248,14 @@
                             "type": "PageTransitionEvent"
                         },
                         {
+                            "name": "pageswap",
+                            "type": "PageSwapEvent"
+                        },
+                        {
+                            "name": "pagereveal",
+                            "type": "PageRevealEvent"
+                        },
+                        {
                             "name": "popstate",
                             "type": "PopStateEvent"
                         },


### PR DESCRIPTION
This PR is adding type of `pageswap` and `pagereveal` event callback args on window event handler property and `addEventListener`. 
Both of them are already supported by Chromium and Webkit.

> [!NOTE]
> PageSwap and PageReveal Event interfaces are added at this PR (https://github.com/microsoft/TypeScript/pull/60987), but event handler callback args is still typed as `Event`.