### PR TITLE
Swap link to lib replacement to libReplacement flag

### DIFF
--- a/deploy/readmes/web.md
+++ b/deploy/readmes/web.md
@@ -8,7 +8,7 @@ The APIs inside `@types/web` are [generated from](https://github.com/microsoft/T
 
 ## Installation 
 
-With TypeScript 4.5+ using [lib replacement](https://github.com/microsoft/TypeScript/pull/45771), you can swap the DOM lib with this dependency:
+With TypeScript 4.5+ using [lib replacement](https://www.typescriptlang.org/tsconfig/#libReplacement), you can swap the DOM lib with this dependency:
 
 ```sh
 pnpm add @typescript/lib-dom@npm:@types/web --save-dev

--- a/deploy/readmes/webworker.md
+++ b/deploy/readmes/webworker.md
@@ -8,7 +8,7 @@ This package contains type definitions which will set up the global environment 
 
 ## Installation 
 
-With TypeScript 4.5+ using [lib replacement](https://github.com/microsoft/TypeScript/pull/45771), you can swap the WebWorker lib with this dependency:
+With TypeScript 4.5+ using [lib replacement](https://www.typescriptlang.org/tsconfig/#libReplacement), you can swap the WebWorker lib with this dependency:
 
 ```sh
 pnpm add @typescript/lib-webworker@npm:@types/webworker --save-dev


### PR DESCRIPTION
https://www.typescriptlang.org/tsconfig/#libReplacement is a better documentation page for that flag, especially given we're planning on turning this feature off by default.