### PR TITLE
Prevent Deploy Workflow from Running in Forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,15 +2,15 @@ name: Deploy to npm
 
 on:
   schedule:
-    # Daily run
-    - cron: "0 4 * * *"
-  workflow_dispatch: null
+    - cron: "0 4 * * *" # Daily
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
   deploy:
+    if: github.repository == 'microsoft/TypeScript-DOM-lib-generator'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,9 @@ name: Deploy to npm
 
 on:
   schedule:
-    - cron: "0 4 * * *" # Daily
-  workflow_dispatch:
+    # Daily run
+    - cron: "0 4 * * *"
+  workflow_dispatch: null
 
 permissions:
   contents: write


### PR DESCRIPTION
Hello!

I’ve added a safeguard to ensure that the NPM deploy action only runs in the **main repository**.

#### 🛠️ What was happening:
The workflow was being triggered **daily in my fork**, which obviously failed because the NPM token (`NODE_AUTH_TOKEN`) isn’t available in forks.

#### ✅ What I changed:
Added the following condition to the job:

```yaml
if: github.repository == 'your-username/your-repo-name'
```

This ensures that the deploy job only runs in the main repo, and not in forks. If someone removes that line, the job might start triggering (and failing) in forks again — so it's important to keep it!