### PR TITLE
Run CI in merge group, only on changes sent to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,14 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+    branches:
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
This repo is particularly sensitive to PR merge races breaking things, since so much is generated and modified.

This PR updates the CI job to also be able to run in a merge group, with the intention that we could enable merge queues here that precheck PRs before they hit main, preventing stale PRs and races from getting merged.