### PR TITLE
Expands CSS custom highlights API

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14939,21 +14939,21 @@ interface HighlightRegistry {
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/clear) */
     clear: () => void;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/delete) */
-    delete: (id: string) => Promise<boolean>;
+    delete: (id: string) => boolean;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/entries) */
-    entries: () => { id: string; highlight: string }[];
+    entries: () => MapIterator<[string, Highlight]>;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/get) */
-    get: (key: string) => string | undefined;
+    get: (key: string) => Highlight | undefined;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/has) */
     has: (key: string) => boolean;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/keys) */
-    keys: () => string[];
+    keys: () => MapIterator<string>;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/set) */
-    set: (key: string, value: string) => void;
+    set: (key: string, value: Highlight) => void;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/size) */
     readonly size: number;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/values) */
-    values: () => string[];
+    values: () => MapIterator<Highlight>;
     forEach(callbackfn: (value: Highlight, key: string, parent: HighlightRegistry) => void, thisArg?: any): void;
 }
 

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14936,8 +14936,24 @@ declare var Highlight: {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HighlightRegistry)
  */
 interface HighlightRegistry {
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/clear) */
+    clear: () => void;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/delete) */
+    delete: (id: string) => Promise<boolean>;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/entries) */
+    entries: () => { id: string; highlight: string }[];
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/get) */
+    get: (key: string) => string | undefined;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/has) */
+    has: (key: string) => boolean;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/keys) */
+    keys: () => string[];
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/set) */
+    set: (key: string, value: string) => void;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/size) */
     readonly size: number;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/values) */
+    values: () => string[];
     forEach(callbackfn: (value: Highlight, key: string, parent: HighlightRegistry) => void, thisArg?: any): void;
 }
 

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14936,6 +14936,8 @@ declare var Highlight: {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HighlightRegistry)
  */
 interface HighlightRegistry {
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/size) */
+    readonly size: number;
     forEach(callbackfn: (value: Highlight, key: string, parent: HighlightRegistry) => void, thisArg?: any): void;
 }
 

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -14916,8 +14916,24 @@ declare var Highlight: {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HighlightRegistry)
  */
 interface HighlightRegistry {
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/clear) */
+    clear: () => void;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/delete) */
+    delete: (id: string) => Promise<boolean>;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/entries) */
+    entries: () => { id: string; highlight: string }[];
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/get) */
+    get: (key: string) => string | undefined;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/has) */
+    has: (key: string) => boolean;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/keys) */
+    keys: () => string[];
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/set) */
+    set: (key: string, value: string) => void;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/size) */
     readonly size: number;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/values) */
+    values: () => string[];
     forEach(callbackfn: (value: Highlight, key: string, parent: HighlightRegistry) => void, thisArg?: any): void;
 }
 

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -14919,21 +14919,21 @@ interface HighlightRegistry {
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/clear) */
     clear: () => void;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/delete) */
-    delete: (id: string) => Promise<boolean>;
+    delete: (id: string) => boolean;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/entries) */
-    entries: () => { id: string; highlight: string }[];
+    entries: () => MapIterator<[string, Highlight]>;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/get) */
-    get: (key: string) => string | undefined;
+    get: (key: string) => Highlight | undefined;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/has) */
     has: (key: string) => boolean;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/keys) */
-    keys: () => string[];
+    keys: () => MapIterator<string>;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/set) */
-    set: (key: string, value: string) => void;
+    set: (key: string, value: Highlight) => void;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/size) */
     readonly size: number;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/values) */
-    values: () => string[];
+    values: () => MapIterator<Highlight>;
     forEach(callbackfn: (value: Highlight, key: string, parent: HighlightRegistry) => void, thisArg?: any): void;
 }
 

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -14916,6 +14916,8 @@ declare var Highlight: {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HighlightRegistry)
  */
 interface HighlightRegistry {
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/size) */
+    readonly size: number;
     forEach(callbackfn: (value: Highlight, key: string, parent: HighlightRegistry) => void, thisArg?: any): void;
 }
 

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -14939,21 +14939,21 @@ interface HighlightRegistry {
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/clear) */
     clear: () => void;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/delete) */
-    delete: (id: string) => Promise<boolean>;
+    delete: (id: string) => boolean;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/entries) */
-    entries: () => { id: string; highlight: string }[];
+    entries: () => MapIterator<[string, Highlight]>;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/get) */
-    get: (key: string) => string | undefined;
+    get: (key: string) => Highlight | undefined;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/has) */
     has: (key: string) => boolean;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/keys) */
-    keys: () => string[];
+    keys: () => MapIterator<string>;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/set) */
-    set: (key: string, value: string) => void;
+    set: (key: string, value: Highlight) => void;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/size) */
     readonly size: number;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/values) */
-    values: () => string[];
+    values: () => MapIterator<Highlight>;
     forEach(callbackfn: (value: Highlight, key: string, parent: HighlightRegistry) => void, thisArg?: any): void;
 }
 

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -14936,8 +14936,24 @@ declare var Highlight: {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HighlightRegistry)
  */
 interface HighlightRegistry {
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/clear) */
+    clear: () => void;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/delete) */
+    delete: (id: string) => Promise<boolean>;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/entries) */
+    entries: () => { id: string; highlight: string }[];
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/get) */
+    get: (key: string) => string | undefined;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/has) */
+    has: (key: string) => boolean;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/keys) */
+    keys: () => string[];
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/set) */
+    set: (key: string, value: string) => void;
     /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/size) */
     readonly size: number;
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/values) */
+    values: () => string[];
     forEach(callbackfn: (value: Highlight, key: string, parent: HighlightRegistry) => void, thisArg?: any): void;
 }
 

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -14936,6 +14936,8 @@ declare var Highlight: {
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HighlightRegistry)
  */
 interface HighlightRegistry {
+    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/size) */
+    readonly size: number;
     forEach(callbackfn: (value: Highlight, key: string, parent: HighlightRegistry) => void, thisArg?: any): void;
 }
 

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -568,17 +568,17 @@
                         },
                         "delete": {
                             "name": "delete",
-                            "overrideType": "(id: string) => Promise<boolean>",
+                            "overrideType": "(id: string) => boolean",
                             "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/delete"
                         },
                         "entries": {
                             "name": "entries",
-                            "overrideType": "() => { id: string; highlight: string }[]",
+                            "overrideType": "() => MapIterator<[string, Highlight]>",
                             "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/entries"
                         },
                         "get": {
                             "name": "get",
-                            "overrideType": "(key: string) => string | undefined",
+                            "overrideType": "(key: string) => Highlight | undefined",
                             "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/get"
                         },
                         "has": {
@@ -588,17 +588,17 @@
                         },
                         "keys": {
                             "name": "keys",
-                            "overrideType": "() => string[]",
+                            "overrideType": "() => MapIterator<string>",
                             "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/keys"
                         },
                         "values": {
                             "name": "values",
-                            "overrideType": "() => string[]",
+                            "overrideType": "() => MapIterator<Highlight>",
                             "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/values"
                         },
                         "set": {
                             "name": "set",
-                            "overrideType": "(key: string, value: string) => void",
+                            "overrideType": "(key: string, value: Highlight) => void",
                             "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/set"
                         }
                       }

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -551,6 +551,19 @@
             "DeviceMotionEventRotationRate": {
                 "noInterfaceObject": true
             },
+            "HighlightRegistry":{
+                "name": "HighlightRegistry",
+                "properties": {
+                    "property": {
+                        "size": {
+                            "name": "size",
+                            "overrideType": "number",
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/size",
+                            "readonly": true
+                        }
+                    }
+                }
+            },
             "HTMLImageElement": {
                 "name": "HTMLImageElement",
                 "properties": {

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -560,9 +560,50 @@
                             "overrideType": "number",
                             "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/size",
                             "readonly": true
+                        },
+                        "clear": {
+                            "name": "clear",
+                            "overrideType": "() => void",
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/clear"
+                        },
+                        "delete": {
+                            "name": "delete",
+                            "overrideType": "(id: string) => Promise<boolean>",
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/delete"
+                        },
+                        "entries": {
+                            "name": "entries",
+                            "overrideType": "() => { id: string; highlight: string }[]",
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/entries"
+                        },
+                        "get": {
+                            "name": "get",
+                            "overrideType": "(key: string) => string | undefined",
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/get"
+                        },
+                        "has": {
+                            "name": "has",
+                            "overrideType": "(key: string) => boolean",
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/has"
+                        },
+                        "keys": {
+                            "name": "keys",
+                            "overrideType": "() => string[]",
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/keys"
+                        },
+                        "values": {
+                            "name": "values",
+                            "overrideType": "() => string[]",
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/values"
+                        },
+                        "set": {
+                            "name": "set",
+                            "overrideType": "(key: string, value: string) => void",
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HighlightRegistry/set"
                         }
+                      }
                     }
-                }
+                                
             },
             "HTMLImageElement": {
                 "name": "HTMLImageElement",


### PR DESCRIPTION
I have added more methods to the `HighlightRegistry` interface according to the MDN docs.
fixes #1698 