### PR TITLE
Revert "fix: update alert method signature to accept string type"

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -28394,7 +28394,7 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/window) */
     readonly window: Window & typeof globalThis;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/alert) */
-    alert(message?: string): void;
+    alert(message?: any): void;
     /**
      * @deprecated
      *
@@ -30047,7 +30047,7 @@ declare var visualViewport: VisualViewport | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/window) */
 declare var window: Window & typeof globalThis;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/alert) */
-declare function alert(message?: string): void;
+declare function alert(message?: any): void;
 /**
  * @deprecated
  *

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -28372,7 +28372,7 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/window) */
     readonly window: Window & typeof globalThis;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/alert) */
-    alert(message?: string): void;
+    alert(message?: any): void;
     /**
      * @deprecated
      *
@@ -30025,7 +30025,7 @@ declare var visualViewport: VisualViewport | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/window) */
 declare var window: Window & typeof globalThis;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/alert) */
-declare function alert(message?: string): void;
+declare function alert(message?: any): void;
 /**
  * @deprecated
  *

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -28394,7 +28394,7 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/window) */
     readonly window: Window & typeof globalThis;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/alert) */
-    alert(message?: string): void;
+    alert(message?: any): void;
     /**
      * @deprecated
      *
@@ -30047,7 +30047,7 @@ declare var visualViewport: VisualViewport | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/window) */
 declare var window: Window & typeof globalThis;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/alert) */
-declare function alert(message?: string): void;
+declare function alert(message?: any): void;
 /**
  * @deprecated
  *

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -718,7 +718,7 @@
                     "method": {
                         "alert": {
                             "overrideSignatures": [
-                                "alert(message?: string): void"
+                                "alert(message?: any): void"
                             ]
                         },
                         "postMessage": {


### PR DESCRIPTION
This reverts commit 3263db83c494706b220fc8d9ed5fcaac422d65f0, to make https://github.com/microsoft/TypeScript/pull/61647 less painful. See https://github.com/microsoft/TypeScript/pull/61647#issuecomment-2852450040.

cc @rbuckton