### PR TITLE
fix: change event types from MouseEvent to PointerEvent

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -10099,7 +10099,7 @@ interface GlobalEventHandlersEventMap {
     "canplay": Event;
     "canplaythrough": Event;
     "change": Event;
-    "click": MouseEvent;
+    "click": PointerEvent;
     "close": Event;
     "compositionend": CompositionEvent;
     "compositionstart": CompositionEvent;
@@ -10244,7 +10244,7 @@ interface GlobalEventHandlers {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/click_event)
      */
-    onclick: ((this: GlobalEventHandlers, ev: MouseEvent) => any) | null;
+    onclick: ((this: GlobalEventHandlers, ev: PointerEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/close_event) */
     onclose: ((this: GlobalEventHandlers, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/contextlost_event) */
@@ -30196,7 +30196,7 @@ declare var onchange: ((this: Window, ev: Event) => any) | null;
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/click_event)
  */
-declare var onclick: ((this: Window, ev: MouseEvent) => any) | null;
+declare var onclick: ((this: Window, ev: PointerEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/close_event) */
 declare var onclose: ((this: Window, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/contextlost_event) */

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -10089,7 +10089,7 @@ interface GlobalEventHandlersEventMap {
     "canplay": Event;
     "canplaythrough": Event;
     "change": Event;
-    "click": MouseEvent;
+    "click": PointerEvent;
     "close": Event;
     "compositionend": CompositionEvent;
     "compositionstart": CompositionEvent;
@@ -10234,7 +10234,7 @@ interface GlobalEventHandlers {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/click_event)
      */
-    onclick: ((this: GlobalEventHandlers, ev: MouseEvent) => any) | null;
+    onclick: ((this: GlobalEventHandlers, ev: PointerEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/close_event) */
     onclose: ((this: GlobalEventHandlers, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/contextlost_event) */
@@ -30174,7 +30174,7 @@ declare var onchange: ((this: Window, ev: Event) => any) | null;
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/click_event)
  */
-declare var onclick: ((this: Window, ev: MouseEvent) => any) | null;
+declare var onclick: ((this: Window, ev: PointerEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/close_event) */
 declare var onclose: ((this: Window, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/contextlost_event) */

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -10099,7 +10099,7 @@ interface GlobalEventHandlersEventMap {
     "canplay": Event;
     "canplaythrough": Event;
     "change": Event;
-    "click": MouseEvent;
+    "click": PointerEvent;
     "close": Event;
     "compositionend": CompositionEvent;
     "compositionstart": CompositionEvent;
@@ -10244,7 +10244,7 @@ interface GlobalEventHandlers {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/click_event)
      */
-    onclick: ((this: GlobalEventHandlers, ev: MouseEvent) => any) | null;
+    onclick: ((this: GlobalEventHandlers, ev: PointerEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/close_event) */
     onclose: ((this: GlobalEventHandlers, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/contextlost_event) */
@@ -30196,7 +30196,7 @@ declare var onchange: ((this: Window, ev: Event) => any) | null;
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/click_event)
  */
-declare var onclick: ((this: Window, ev: MouseEvent) => any) | null;
+declare var onclick: ((this: Window, ev: PointerEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLDialogElement/close_event) */
 declare var onclose: ((this: Window, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLCanvasElement/contextlost_event) */

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -58,7 +58,7 @@
                         },
                         {
                             "name": "auxclick",
-                            "type": "MouseEvent"
+                            "type": "PointerEvent"
                         },
                         {
                             "name": "beforeinput",
@@ -195,6 +195,10 @@
                         {
                             "name": "dblclick",
                             "type": "MouseEvent"
+                        },
+                        {
+                            "name": "contextmenu",
+                            "type": "PointerEvent"
                         },
                         {
                             "name": "toggle",

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -70,7 +70,7 @@
                         },
                         {
                             "name": "click",
-                            "type": "MouseEvent"
+                            "type": "PointerEvent"
                         },
                         {
                             "name": "compositionstart",
@@ -194,10 +194,6 @@
                         },
                         {
                             "name": "dblclick",
-                            "type": "MouseEvent"
-                        },
-                        {
-                            "name": "contextmenu",
                             "type": "MouseEvent"
                         },
                         {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -66,20 +66,12 @@
                             "type": "AnimationEvent"
                         },
                         {
-                            "name": "auxclick",
-                            "type": "PointerEvent"
-                        },
-                        {
                             "name": "cut",
                             "type": "ClipboardEvent"
                         },
                         {
                             "name": "copy",
                             "type": "ClipboardEvent"
-                        },
-                        {
-                            "name": "contextmenu",
-                            "type": "PointerEvent"
                         },
                         {
                             "name": "paste",


### PR DESCRIPTION
I have converted MouseEvent to PointerEvent in some occurrences.
References:
1- https://w3c.github.io/uievents/#event-type-click
2 - https://caniuse.com/?search=PointerEvent
3 - https://developer.mozilla.org/en-US/docs/Web/API/Element/click_event

Solves:
1- https://github.com/microsoft/TypeScript/issues/60746
2 - https://github.com/microsoft/TypeScript/pull/61647#issuecomment-2848634352