### PR TITLE
Improve URLSearchParams constructor type definition

### DIFF
--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -647,21 +647,6 @@
                     ]
                 }
             },
-            "URLSearchParams": {
-                "name": "URLSearchParams",
-                "constructor": {
-                    "signature": {
-                        "0": {
-                            "param": [
-                                {
-                                    "name": "init",
-                                    "additionalTypes": ["URLSearchParams"]
-                                }
-                            ]
-                        }
-                    }
-                }
-            },
             "NodeListOf": {
                 "name": "NodeListOf",
                 "typeParameters": [

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -3842,7 +3842,22 @@
                         }
                     }
                 }
-            }
+            },
+			"URLSearchParams": {
+				"name": "URLSearchParams",
+				"constructor": {
+					"signature": {
+						"0": {
+							"param": [
+								{
+									"name": "init",
+									"overrideType": "string | Iterable<[string, string]> | Record<string, string> | URLSearchParams"
+								}
+							]
+						}
+					}
+				}
+			}
         }
     },
     "dictionaries": {


### PR DESCRIPTION
Overrides the type of `URLSearchParams` init to accept a `Iterable<[string, string]>` instead of `string[][]`. 

[MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams#options)

For example:

```ts
new URLSearchParams(new Set([["name", "ross"]]));
```

is valid, but currently shows an error.

There was an added type of `URLSearchParams` which I figured I should remove and add to the override instead. 

I can't seem to get it to generate, I'm getting a ENOENT error. I don't have files in `/inputfiles/mdn/`