### PR TITLE
Remove .d.ts post-process in deploy+migrate scripts

### DIFF
--- a/deploy/createTypesPackages.js
+++ b/deploy/createTypesPackages.js
@@ -134,7 +134,6 @@ const go = async () => {
     });
 
     prependAutoImports(pkg, packagePath);
-    postProcessDTSFiles(pkg, packagePath);
 
     // Setup the files in the repo
     const newPkgJSON = await updatePackageJSON(pkg, packagePath);
@@ -264,30 +263,6 @@ function relativeUrl(from, to) {
     relative.startsWith("./")
     ? relative
     : `./${relative}`;
-}
-
-/**
- * Handles any post-processing we do for deployment.
- * @param {Package} pkg
- * @param {URL} packagePath
- */
-export function postProcessDTSFiles(pkg, packagePath) {
-  iterateThroughFiles((content) => {
-    return content.replace(
-      "abort(reason?: any): AbortSignal;",
-      "// abort(reason?: any): AbortSignal; - To be re-added in the future",
-    );
-  });
-
-  /** @param {(str:string) => string} contentReplacer */
-  function iterateThroughFiles(contentReplacer) {
-    pkg.files.forEach((fileRef) => {
-      const dtsFileURL = new URL(fileRef.to, packagePath);
-      let dtsContent = fs.readFileSync(dtsFileURL, "utf-8");
-      dtsContent = contentReplacer(dtsContent);
-      fs.writeFileSync(dtsFileURL, dtsContent);
-    });
-  }
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/deploy/migrate.js
+++ b/deploy/migrate.js
@@ -7,8 +7,6 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 
-import { postProcessDTSFiles } from "./createTypesPackages.js";
-
 const maybeTSWorkingDir = [process.argv[2], "../TypeScript", "TypeScript"];
 const tscWD = maybeTSWorkingDir.find((wd) => existsSync(wd));
 
@@ -20,13 +18,6 @@ if (!tscWD)
 const generatedFiles = readdirSync("generated");
 const filesToSend = generatedFiles.filter(
   (file) => file.includes("dom.") || file.includes("webworker."),
-);
-
-const generatedDir = new URL("../generated/", import.meta.url);
-postProcessDTSFiles(
-  /** @type {any} */
-  ({ files: filesToSend.map((f) => ({ to: f })) }),
-  generatedDir,
 );
 
 filesToSend.forEach((file) => {


### PR DESCRIPTION
It has not been needed for years but I never noticed because I forgot about these scripts and never used them.

This means that the types packages used for overriding the default DOM types have had AbortSignal.abort incorrectly disabled all this time, but it's rarely used (only a few repos per million at Google, at least), so nobody ever complained about it.

In theory we could need the post-processing capability in the future, but it's trivial to bring back or to write again. That's why I deleted it outright.