### PR TITLE
remove redundant language in MDN links

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3326,7 +3326,7 @@ interface Attr extends Node {
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Attr/value)
      */
     value: string;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): string;
     set textContent(value: string | null);
 }
@@ -8219,7 +8219,7 @@ interface CharacterData extends Node, ChildNode, NonDocumentTypeChildNode {
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CharacterData/substringData)
      */
     substringData(offset: number, count: number): string;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): string;
     set textContent(value: string | null);
 }
@@ -10680,7 +10680,7 @@ interface Document extends Node, DocumentOrShadowRoot, FontFaceSource, GlobalEve
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/writeln)
      */
     writeln(...text: string[]): void;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): null;
     addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -10707,7 +10707,7 @@ declare var Document: {
 interface DocumentFragment extends Node, NonElementParentNode, ParentNode {
     readonly ownerDocument: Document;
     getElementById(elementId: string): HTMLElement | null;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): string;
     set textContent(value: string | null);
 }
@@ -10786,7 +10786,7 @@ interface DocumentType extends Node, ChildNode {
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/DocumentType/systemId)
      */
     readonly systemId: string;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): null;
 }
 
@@ -11389,7 +11389,7 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/matches)
      */
     webkitMatchesSelector(selectors: string): boolean;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): string;
     set textContent(value: string | null);
     addEventListener<K extends keyof ElementEventMap>(type: K, listener: (this: Element, ev: ElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -3326,7 +3326,7 @@ interface Attr extends Node {
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Attr/value)
      */
     value: string;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): string;
     set textContent(value: string | null);
 }
@@ -8211,7 +8211,7 @@ interface CharacterData extends Node, ChildNode, NonDocumentTypeChildNode {
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CharacterData/substringData)
      */
     substringData(offset: number, count: number): string;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): string;
     set textContent(value: string | null);
 }
@@ -10672,7 +10672,7 @@ interface Document extends Node, DocumentOrShadowRoot, FontFaceSource, GlobalEve
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/writeln)
      */
     writeln(...text: string[]): void;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): null;
     addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -10699,7 +10699,7 @@ declare var Document: {
 interface DocumentFragment extends Node, NonElementParentNode, ParentNode {
     readonly ownerDocument: Document;
     getElementById(elementId: string): HTMLElement | null;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): string;
     set textContent(value: string | null);
 }
@@ -10778,7 +10778,7 @@ interface DocumentType extends Node, ChildNode {
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/DocumentType/systemId)
      */
     readonly systemId: string;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): null;
 }
 
@@ -11379,7 +11379,7 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/matches)
      */
     webkitMatchesSelector(selectors: string): boolean;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): string;
     set textContent(value: string | null);
     addEventListener<K extends keyof ElementEventMap>(type: K, listener: (this: Element, ev: ElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -3326,7 +3326,7 @@ interface Attr extends Node {
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Attr/value)
      */
     value: string;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): string;
     set textContent(value: string | null);
 }
@@ -8219,7 +8219,7 @@ interface CharacterData extends Node, ChildNode, NonDocumentTypeChildNode {
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CharacterData/substringData)
      */
     substringData(offset: number, count: number): string;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): string;
     set textContent(value: string | null);
 }
@@ -10680,7 +10680,7 @@ interface Document extends Node, DocumentOrShadowRoot, FontFaceSource, GlobalEve
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/writeln)
      */
     writeln(...text: string[]): void;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): null;
     addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -10707,7 +10707,7 @@ declare var Document: {
 interface DocumentFragment extends Node, NonElementParentNode, ParentNode {
     readonly ownerDocument: Document;
     getElementById(elementId: string): HTMLElement | null;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): string;
     set textContent(value: string | null);
 }
@@ -10786,7 +10786,7 @@ interface DocumentType extends Node, ChildNode {
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/DocumentType/systemId)
      */
     readonly systemId: string;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): null;
 }
 
@@ -11389,7 +11389,7 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/matches)
      */
     webkitMatchesSelector(selectors: string): boolean;
-    /** [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/textContent) */
     get textContent(): string;
     set textContent(value: string | null);
     addEventListener<K extends keyof ElementEventMap>(type: K, listener: (this: Element, ev: ElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;

--- a/deploy/readmes/audioworklet.md
+++ b/deploy/readmes/audioworklet.md
@@ -2,7 +2,7 @@
 
 > The AudioWorklet interface of the Web Audio API is used to supply custom audio processing scripts that execute in a separate thread to provide very low latency audio processing. The worklet's code is run in the AudioWorkletGlobalScope global execution context, using a separate Web Audio thread which is shared by the worklet and other audio nodes.
 
-From [MDN Web Docs: AudioWorklet](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorklet)
+From [MDN Web Docs: AudioWorklet](https://developer.mozilla.org/docs/Web/API/AudioWorklet)
 
 This package contains type definitions which will set up the global environment for your TypeScript project to match the runtime environment of an Audio Worklet. The APIs inside `@types/audioworklet` are [generated from](https://github.com/microsoft/TypeScript-DOM-lib-generator/) the specifications for [Web Audio](https://webaudio.github.io/web-audio-api/).
 

--- a/deploy/readmes/serviceworker.md
+++ b/deploy/readmes/serviceworker.md
@@ -2,7 +2,7 @@
 
 > Service workers essentially act as proxy servers that sit between web applications, the browser, and the network (when available). They are intended, among other things, to enable the creation of effective offline experiences, intercept network requests and take appropriate action based on whether the network is available, and update assets residing on the server. They will also allow access to push notifications and background sync APIs.
 
-From [MDN Web Docs: Service Worker API](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API)
+From [MDN Web Docs: Service Worker API](https://developer.mozilla.org/docs/Web/API/Service_Worker_API)
 
 This package contains type definitions which will set up the global environment for your TypeScript project to match the runtime environment of a Service Worker. The APIs inside `@types/serviceworker` are [generated from](https://github.com/microsoft/TypeScript-DOM-lib-generator/) the specifications for JavaScript. Given the size and state of constant change in web browsers, `@types/serviceworker` only has APIs which have passed a certain level of standardization and are available in at least two of the most popular browser engines.
 

--- a/deploy/readmes/sharedworker.md
+++ b/deploy/readmes/sharedworker.md
@@ -2,7 +2,7 @@
 
 > The SharedWorker interface represents a specific kind of worker that can be accessed from several browsing contexts, such as several windows, iframes or even workers. They implement an interface different than dedicated workers and have a different global scope, `SharedWorkerGlobalScope`.
 
-From [MDN Web Docs: SharedWorker API](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker)
+From [MDN Web Docs: SharedWorker API](https://developer.mozilla.org/docs/Web/API/SharedWorker)
 
 This package contains type definitions which will set up the global environment for your TypeScript project to match the runtime environment of a Web Worker. The APIs inside `@types/sharedworker` are [generated from](https://github.com/microsoft/TypeScript-DOM-lib-generator/) the specifications for JavaScript.
 

--- a/deploy/readmes/webworker.md
+++ b/deploy/readmes/webworker.md
@@ -2,7 +2,7 @@
 
 > The Worker interface of the Web Workers API represents a background task that can be created via script, which can send messages back to its creator. Creating a worker is done by calling the `Worker("path/to/worker/script")` constructor.
 
-From [MDN Web Docs: Worker API](https://developer.mozilla.org/en-US/docs/Web/API/Worker)
+From [MDN Web Docs: Worker API](https://developer.mozilla.org/docs/Web/API/Worker)
 
 This package contains type definitions which will set up the global environment for your TypeScript project to match the runtime environment of a Web Worker. The APIs inside `@types/webworker` are [generated from](https://github.com/microsoft/TypeScript-DOM-lib-generator/) the specifications for JavaScript.
 

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -357,7 +357,7 @@
                             }
                         },
                         "textContent": {
-                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent",
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Node/textContent",
                             "overrideSignatures": [
                                 "get textContent(): string",
                                 "set textContent(value: string | null)"
@@ -792,7 +792,7 @@
                 "methods": {
                     "method": {
                         "textContent": {
-                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent",
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Node/textContent",
                             "overrideSignatures": [
                                 "get textContent(): string",
                                 "set textContent(value: string | null)"
@@ -815,7 +815,7 @@
                 "methods": {
                     "method": {
                         "textContent": {
-                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent",
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Node/textContent",
                             "overrideSignatures": [
                                 "get textContent(): string",
                                 "set textContent(value: string | null)"
@@ -847,7 +847,7 @@
                 "methods": {
                     "method": {
                         "textContent": {
-                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent",
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Node/textContent",
                             "overrideSignatures": [
                                 "get textContent(): null"
                             ]

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -696,7 +696,7 @@
                             }
                         },
                         "textContent": {
-                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent",
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Node/textContent",
                             "overrideSignatures": [
                                 "get textContent(): null"
                             ]
@@ -768,7 +768,7 @@
                             ]
                         },
                         "textContent": {
-                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent",
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Node/textContent",
                             "overrideSignatures": [
                                 "get textContent(): string",
                                 "set textContent(value: string | null)"

--- a/inputfiles/patches/permissions.kdl
+++ b/inputfiles/patches/permissions.kdl
@@ -2,22 +2,22 @@
 // https://w3c.github.io/powerful-features-registry/#registry-table-of-powerful-features
 // Please add a feature only when it's supported by multiple engines.
 enum PermissionName {
-    // Full support: https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API#browser_compatibility
+    // Full support: https://developer.mozilla.org/docs/Web/API/Permissions_API#browser_compatibility
     camera
-    // Full support: https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API#browser_compatibility
+    // Full support: https://developer.mozilla.org/docs/Web/API/Geolocation_API#browser_compatibility
     geolocation
-    // Full support: https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API#browser_compatibility
+    // Full support: https://developer.mozilla.org/docs/Web/API/Permissions_API#browser_compatibility
     microphone
-    // Gecko and Blink: https://developer.mozilla.org/en-US/docs/Web/API/Web_MIDI_API#browser_compatibility
+    // Gecko and Blink: https://developer.mozilla.org/docs/Web/API/Web_MIDI_API#browser_compatibility
     midi
-    // Full support: https://developer.mozilla.org/en-US/docs/Web/API/Notifications_API#browser_compatibility
+    // Full support: https://developer.mozilla.org/docs/Web/API/Notifications_API#browser_compatibility
     notifications
-    // Gecko and Blink: https://developer.mozilla.org/en-US/docs/Web/API/Storage_API#browser_compatibility
+    // Gecko and Blink: https://developer.mozilla.org/docs/Web/API/Storage_API#browser_compatibility
     persistent-storage
-    // Full support: https://developer.mozilla.org/en-US/docs/Web/API/Push_API#browser_compatibility
+    // Full support: https://developer.mozilla.org/docs/Web/API/Push_API#browser_compatibility
     push
-    // Full support: https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API#browser_compatibility
+    // Full support: https://developer.mozilla.org/docs/Web/API/Screen_Wake_Lock_API#browser_compatibility
     screen-wake-lock
-    // Full support: https://developer.mozilla.org/en-US/docs/Web/API/Storage_Access_API#browser_compatibility
+    // Full support: https://developer.mozilla.org/docs/Web/API/Storage_Access_API#browser_compatibility
     storage-access
 }


### PR DESCRIPTION
fixes #2102 
I have removed the `en-US/` part in the URL since it is redundant, and also this makes it consistent with the auto-generated comments.