### PR TITLE
Add SecurityPolicyViolationEvent & securitypolicyviolation to WorkerG…

### DIFF
--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -10779,6 +10779,7 @@ interface WorkerGlobalScopeEventMap {
     "offline": Event;
     "online": Event;
     "rejectionhandled": PromiseRejectionEvent;
+    "securitypolicyviolation": SecurityPolicyViolationEvent;
     "unhandledrejection": PromiseRejectionEvent;
 }
 
@@ -10810,6 +10811,8 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
     ononline: ((this: WorkerGlobalScope, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
     onrejectionhandled: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+    onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
     onunhandledrejection: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
     /**
@@ -11543,6 +11546,8 @@ declare var onoffline: ((this: ServiceWorkerGlobalScope, ev: Event) => any) | nu
 declare var ononline: ((this: ServiceWorkerGlobalScope, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
 declare var onrejectionhandled: ((this: ServiceWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+declare var onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
 declare var onunhandledrejection: ((this: ServiceWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
 /**

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -10318,6 +10318,7 @@ interface WorkerGlobalScopeEventMap {
     "offline": Event;
     "online": Event;
     "rejectionhandled": PromiseRejectionEvent;
+    "securitypolicyviolation": SecurityPolicyViolationEvent;
     "unhandledrejection": PromiseRejectionEvent;
 }
 
@@ -10349,6 +10350,8 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
     ononline: ((this: WorkerGlobalScope, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
     onrejectionhandled: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+    onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
     onunhandledrejection: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
     /**
@@ -11233,6 +11236,8 @@ declare var onoffline: ((this: SharedWorkerGlobalScope, ev: Event) => any) | nul
 declare var ononline: ((this: SharedWorkerGlobalScope, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
 declare var onrejectionhandled: ((this: SharedWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+declare var onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
 declare var onunhandledrejection: ((this: SharedWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
 /**

--- a/baselines/ts5.5/serviceworker.generated.d.ts
+++ b/baselines/ts5.5/serviceworker.generated.d.ts
@@ -10779,6 +10779,7 @@ interface WorkerGlobalScopeEventMap {
     "offline": Event;
     "online": Event;
     "rejectionhandled": PromiseRejectionEvent;
+    "securitypolicyviolation": SecurityPolicyViolationEvent;
     "unhandledrejection": PromiseRejectionEvent;
 }
 
@@ -10810,6 +10811,8 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
     ononline: ((this: WorkerGlobalScope, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
     onrejectionhandled: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+    onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
     onunhandledrejection: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
     /**
@@ -11543,6 +11546,8 @@ declare var onoffline: ((this: ServiceWorkerGlobalScope, ev: Event) => any) | nu
 declare var ononline: ((this: ServiceWorkerGlobalScope, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
 declare var onrejectionhandled: ((this: ServiceWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+declare var onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
 declare var onunhandledrejection: ((this: ServiceWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
 /**

--- a/baselines/ts5.5/sharedworker.generated.d.ts
+++ b/baselines/ts5.5/sharedworker.generated.d.ts
@@ -10318,6 +10318,7 @@ interface WorkerGlobalScopeEventMap {
     "offline": Event;
     "online": Event;
     "rejectionhandled": PromiseRejectionEvent;
+    "securitypolicyviolation": SecurityPolicyViolationEvent;
     "unhandledrejection": PromiseRejectionEvent;
 }
 
@@ -10349,6 +10350,8 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
     ononline: ((this: WorkerGlobalScope, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
     onrejectionhandled: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+    onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
     onunhandledrejection: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
     /**
@@ -11233,6 +11236,8 @@ declare var onoffline: ((this: SharedWorkerGlobalScope, ev: Event) => any) | nul
 declare var ononline: ((this: SharedWorkerGlobalScope, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
 declare var onrejectionhandled: ((this: SharedWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+declare var onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
 declare var onunhandledrejection: ((this: SharedWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
 /**

--- a/baselines/ts5.5/webworker.generated.d.ts
+++ b/baselines/ts5.5/webworker.generated.d.ts
@@ -12246,6 +12246,7 @@ interface WorkerGlobalScopeEventMap {
     "offline": Event;
     "online": Event;
     "rejectionhandled": PromiseRejectionEvent;
+    "securitypolicyviolation": SecurityPolicyViolationEvent;
     "unhandledrejection": PromiseRejectionEvent;
 }
 
@@ -12277,6 +12278,8 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
     ononline: ((this: WorkerGlobalScope, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
     onrejectionhandled: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+    onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
     onunhandledrejection: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
     /**
@@ -13192,6 +13195,8 @@ declare var onoffline: ((this: DedicatedWorkerGlobalScope, ev: Event) => any) | 
 declare var ononline: ((this: DedicatedWorkerGlobalScope, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
 declare var onrejectionhandled: ((this: DedicatedWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+declare var onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
 declare var onunhandledrejection: ((this: DedicatedWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
 /**

--- a/baselines/ts5.6/serviceworker.generated.d.ts
+++ b/baselines/ts5.6/serviceworker.generated.d.ts
@@ -10779,6 +10779,7 @@ interface WorkerGlobalScopeEventMap {
     "offline": Event;
     "online": Event;
     "rejectionhandled": PromiseRejectionEvent;
+    "securitypolicyviolation": SecurityPolicyViolationEvent;
     "unhandledrejection": PromiseRejectionEvent;
 }
 
@@ -10810,6 +10811,8 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
     ononline: ((this: WorkerGlobalScope, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
     onrejectionhandled: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+    onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
     onunhandledrejection: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
     /**
@@ -11543,6 +11546,8 @@ declare var onoffline: ((this: ServiceWorkerGlobalScope, ev: Event) => any) | nu
 declare var ononline: ((this: ServiceWorkerGlobalScope, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
 declare var onrejectionhandled: ((this: ServiceWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+declare var onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
 declare var onunhandledrejection: ((this: ServiceWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
 /**

--- a/baselines/ts5.6/sharedworker.generated.d.ts
+++ b/baselines/ts5.6/sharedworker.generated.d.ts
@@ -10318,6 +10318,7 @@ interface WorkerGlobalScopeEventMap {
     "offline": Event;
     "online": Event;
     "rejectionhandled": PromiseRejectionEvent;
+    "securitypolicyviolation": SecurityPolicyViolationEvent;
     "unhandledrejection": PromiseRejectionEvent;
 }
 
@@ -10349,6 +10350,8 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
     ononline: ((this: WorkerGlobalScope, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
     onrejectionhandled: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+    onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
     onunhandledrejection: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
     /**
@@ -11233,6 +11236,8 @@ declare var onoffline: ((this: SharedWorkerGlobalScope, ev: Event) => any) | nul
 declare var ononline: ((this: SharedWorkerGlobalScope, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
 declare var onrejectionhandled: ((this: SharedWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+declare var onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
 declare var onunhandledrejection: ((this: SharedWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
 /**

--- a/baselines/ts5.6/webworker.generated.d.ts
+++ b/baselines/ts5.6/webworker.generated.d.ts
@@ -12246,6 +12246,7 @@ interface WorkerGlobalScopeEventMap {
     "offline": Event;
     "online": Event;
     "rejectionhandled": PromiseRejectionEvent;
+    "securitypolicyviolation": SecurityPolicyViolationEvent;
     "unhandledrejection": PromiseRejectionEvent;
 }
 
@@ -12277,6 +12278,8 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
     ononline: ((this: WorkerGlobalScope, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
     onrejectionhandled: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+    onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
     onunhandledrejection: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
     /**
@@ -13192,6 +13195,8 @@ declare var onoffline: ((this: DedicatedWorkerGlobalScope, ev: Event) => any) | 
 declare var ononline: ((this: DedicatedWorkerGlobalScope, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
 declare var onrejectionhandled: ((this: DedicatedWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+declare var onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
 declare var onunhandledrejection: ((this: DedicatedWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
 /**

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -12246,6 +12246,7 @@ interface WorkerGlobalScopeEventMap {
     "offline": Event;
     "online": Event;
     "rejectionhandled": PromiseRejectionEvent;
+    "securitypolicyviolation": SecurityPolicyViolationEvent;
     "unhandledrejection": PromiseRejectionEvent;
 }
 
@@ -12277,6 +12278,8 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
     ononline: ((this: WorkerGlobalScope, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
     onrejectionhandled: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+    onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
     onunhandledrejection: ((this: WorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
     /**
@@ -13192,6 +13195,8 @@ declare var onoffline: ((this: DedicatedWorkerGlobalScope, ev: Event) => any) | 
 declare var ononline: ((this: DedicatedWorkerGlobalScope, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/rejectionhandled_event) */
 declare var onrejectionhandled: ((this: DedicatedWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event) */
+declare var onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/unhandledrejection_event) */
 declare var onunhandledrejection: ((this: DedicatedWorkerGlobalScope, ev: PromiseRejectionEvent) => any) | null;
 /**

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -3195,6 +3195,11 @@
             "WorkerGlobalScope": {
                 "properties": {
                     "property": {
+                        "onsecuritypolicyviolation": {
+                            "name": "onsecuritypolicyviolation",
+                            "overrideType": "((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null",
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event"
+                        },
                         "self": {
                             "overrideType": "WorkerGlobalScope & typeof globalThis"
                         }
@@ -3205,6 +3210,10 @@
                         {
                             "name": "error",
                             "type": "ErrorEvent"
+                        },
+                        {
+                            "name": "securitypolicyviolation",
+                            "type": "SecurityPolicyViolationEvent"
                         }
                     ]
                 }


### PR DESCRIPTION
# Add missing `securitypolicyviolation` event to WorkerGlobalScope

## Summary
This PR adds the missing `securitypolicyviolation` event API to `WorkerGlobalScope` in the TypeScript DOM lib generator, completing the CSP violation reporting support for Web Workers.

## Specifications Compliance
W3C CSP Level 3: [Report Violation](https://w3c.github.io/webappsec-csp/#report-violation)
MDN Documentation: [WorkerGlobalScope securitypolicyviolation event](https://developer.mozilla.org/docs/Web/API/WorkerGlobalScope/securitypolicyviolation_event)


## Implementation Details
The implementation adds:
```typescript
interface WorkerGlobalScopeEventMap {
    // ... existing events
    "securitypolicyviolation": SecurityPolicyViolationEvent;
}

interface WorkerGlobalScope extends EventTarget {
    // ... existing properties
    onsecuritypolicyviolation: ((this: WorkerGlobalScope, ev: SecurityPolicyViolationEvent) => any) | null;
}
```

