### PR TITLE
Accept type argument to getElementById

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -10577,7 +10577,7 @@ interface Document extends Node, DocumentOrShadowRoot, FontFaceSource, GlobalEve
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/exitPointerLock)
      */
     exitPointerLock(): void;
-    getElementById<T = HTMLElement>(elementId: string): T | null;
+    getElementById<T extends HTMLElement = HTMLElement>(elementId: string): T | null;
     /**
      * The **`getElementsByClassName`** method of Document interface returns an array-like object of all child elements which have all of the given class name(s).
      *

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -10569,7 +10569,7 @@ interface Document extends Node, DocumentOrShadowRoot, FontFaceSource, GlobalEve
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/exitPointerLock)
      */
     exitPointerLock(): void;
-    getElementById<T = HTMLElement>(elementId: string): T | null;
+    getElementById<T extends HTMLElement = HTMLElement>(elementId: string): T | null;
     /**
      * The **`getElementsByClassName`** method of Document interface returns an array-like object of all child elements which have all of the given class name(s).
      *

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -10577,7 +10577,7 @@ interface Document extends Node, DocumentOrShadowRoot, FontFaceSource, GlobalEve
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Document/exitPointerLock)
      */
     exitPointerLock(): void;
-    getElementById<T = HTMLElement>(elementId: string): T | null;
+    getElementById<T extends HTMLElement = HTMLElement>(elementId: string): T | null;
     /**
      * The **`getElementsByClassName`** method of Document interface returns an array-like object of all child elements which have all of the given class name(s).
      *

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -654,7 +654,7 @@
                         "getElementById": {
                             "name": "getElementById",
                             "overrideSignatures": [
-                                "getElementById<T = HTMLElement>(elementId: string): T | null"
+                                "getElementById<T extends HTMLElement = HTMLElement>(elementId: string): T | null"
                             ]
                         },
                         "getElementsByTagNameNS": {


### PR DESCRIPTION
This provides an alternative to the common pattern of `document.getElementById("...") as HTMLWhateverElement` which casts away the possibility of `null`, consequently hiding a potential type error.