### PR TITLE
feat: add the ability override extended interfaces, fixes HTMLElement onerror type

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -29789,6 +29789,12 @@ interface SVGSVGElement extends SVGGraphicsElement, SVGFitToViewBox, WindowEvent
     unsuspendRedraw(suspendHandleID: number): void;
     /** @deprecated */
     unsuspendRedrawAll(): void;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof SVGSVGElementEventMap>(type: K, listener: (this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGSVGElementEventMap>(type: K, listener: (this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14190,6 +14190,11 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover)
      */
     togglePopover(options?: boolean): boolean;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
     addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -27399,9 +27399,16 @@ interface SVGElementEventMap extends ElementEventMap, GlobalEventHandlersEventMa
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/SVGElement)
  */
-interface SVGElement extends Element, ElementCSSInlineStyle, GlobalEventHandlers, HTMLOrSVGElement {
+interface SVGElement extends Element, ElementCSSInlineStyle, Omit<GlobalEventHandlers, "onerror">, HTMLOrSVGElement {
     /** @deprecated */
     readonly className: any;
+    /**
+     * The error event is fired on an element when a resource failed to load, or can't be used.
+     *  [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)
+     */
+    onerror: (((event: Event) => any) | ((event: UIEvent) => any)) | null;
     /**
      * The **`ownerSVGElement`** property of the SVGElement interface reflects the nearest ancestor svg element.
      *
@@ -27414,6 +27421,12 @@ interface SVGElement extends Element, ElementCSSInlineStyle, GlobalEventHandlers
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/SVGElement/viewportElement)
      */
     readonly viewportElement: SVGElement | null;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14026,7 +14026,7 @@ interface HTMLElementEventMap extends ElementEventMap, GlobalEventHandlersEventM
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement)
  */
-interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEditable, GlobalEventHandlers, HTMLOrSVGElement {
+interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEditable, Omit<GlobalEventHandlers, "onerror">, HTMLOrSVGElement {
     /**
      * The **`HTMLElement.accessKey`** property sets the keystroke which a user can press to jump to a given element.
      *
@@ -14117,6 +14117,13 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetWidth)
      */
     readonly offsetWidth: number;
+    /**
+     * The error event is fired on an element when a resource failed to load, or can't be used.
+     *  [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)
+     */
+    onerror: (((event: Event) => any) | ((event: UIEvent) => any)) | null;
     /**
      * The **`outerText`** property of the HTMLElement interface returns the same value as HTMLElement.innerText.
      *

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14190,6 +14190,7 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover)
      */
     togglePopover(options?: boolean): boolean;
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -29767,6 +29767,12 @@ interface SVGSVGElement extends SVGGraphicsElement, SVGFitToViewBox, WindowEvent
     unsuspendRedraw(suspendHandleID: number): void;
     /** @deprecated */
     unsuspendRedrawAll(): void;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof SVGSVGElementEventMap>(type: K, listener: (this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGSVGElementEventMap>(type: K, listener: (this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -14013,7 +14013,7 @@ interface HTMLElementEventMap extends ElementEventMap, GlobalEventHandlersEventM
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement)
  */
-interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEditable, GlobalEventHandlers, HTMLOrSVGElement {
+interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEditable, Omit<GlobalEventHandlers, "onerror">, HTMLOrSVGElement {
     /**
      * The **`HTMLElement.accessKey`** property sets the keystroke which a user can press to jump to a given element.
      *
@@ -14104,6 +14104,13 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetWidth)
      */
     readonly offsetWidth: number;
+    /**
+     * The error event is fired on an element when a resource failed to load, or can't be used.
+     *  [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)
+     */
+    onerror: (((event: Event) => any) | ((event: UIEvent) => any)) | null;
     /**
      * The **`outerText`** property of the HTMLElement interface returns the same value as HTMLElement.innerText.
      *

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -14177,6 +14177,7 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover)
      */
     togglePopover(options?: boolean): boolean;
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -14177,6 +14177,11 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover)
      */
     togglePopover(options?: boolean): boolean;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
     addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -27377,9 +27377,16 @@ interface SVGElementEventMap extends ElementEventMap, GlobalEventHandlersEventMa
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/SVGElement)
  */
-interface SVGElement extends Element, ElementCSSInlineStyle, GlobalEventHandlers, HTMLOrSVGElement {
+interface SVGElement extends Element, ElementCSSInlineStyle, Omit<GlobalEventHandlers, "onerror">, HTMLOrSVGElement {
     /** @deprecated */
     readonly className: any;
+    /**
+     * The error event is fired on an element when a resource failed to load, or can't be used.
+     *  [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)
+     */
+    onerror: (((event: Event) => any) | ((event: UIEvent) => any)) | null;
     /**
      * The **`ownerSVGElement`** property of the SVGElement interface reflects the nearest ancestor svg element.
      *
@@ -27392,6 +27399,12 @@ interface SVGElement extends Element, ElementCSSInlineStyle, GlobalEventHandlers
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/SVGElement/viewportElement)
      */
     readonly viewportElement: SVGElement | null;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -29789,6 +29789,12 @@ interface SVGSVGElement extends SVGGraphicsElement, SVGFitToViewBox, WindowEvent
     unsuspendRedraw(suspendHandleID: number): void;
     /** @deprecated */
     unsuspendRedrawAll(): void;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof SVGSVGElementEventMap>(type: K, listener: (this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGSVGElementEventMap>(type: K, listener: (this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -14190,6 +14190,11 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover)
      */
     togglePopover(options?: boolean): boolean;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
     addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -27399,9 +27399,16 @@ interface SVGElementEventMap extends ElementEventMap, GlobalEventHandlersEventMa
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/SVGElement)
  */
-interface SVGElement extends Element, ElementCSSInlineStyle, GlobalEventHandlers, HTMLOrSVGElement {
+interface SVGElement extends Element, ElementCSSInlineStyle, Omit<GlobalEventHandlers, "onerror">, HTMLOrSVGElement {
     /** @deprecated */
     readonly className: any;
+    /**
+     * The error event is fired on an element when a resource failed to load, or can't be used.
+     *  [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)
+     */
+    onerror: (((event: Event) => any) | ((event: UIEvent) => any)) | null;
     /**
      * The **`ownerSVGElement`** property of the SVGElement interface reflects the nearest ancestor svg element.
      *
@@ -27414,6 +27421,12 @@ interface SVGElement extends Element, ElementCSSInlineStyle, GlobalEventHandlers
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/SVGElement/viewportElement)
      */
     readonly viewportElement: SVGElement | null;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -14026,7 +14026,7 @@ interface HTMLElementEventMap extends ElementEventMap, GlobalEventHandlersEventM
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement)
  */
-interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEditable, GlobalEventHandlers, HTMLOrSVGElement {
+interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEditable, Omit<GlobalEventHandlers, "onerror">, HTMLOrSVGElement {
     /**
      * The **`HTMLElement.accessKey`** property sets the keystroke which a user can press to jump to a given element.
      *
@@ -14117,6 +14117,13 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/offsetWidth)
      */
     readonly offsetWidth: number;
+    /**
+     * The error event is fired on an element when a resource failed to load, or can't be used.
+     *  [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)
+     */
+    onerror: (((event: Event) => any) | ((event: UIEvent) => any)) | null;
     /**
      * The **`outerText`** property of the HTMLElement interface returns the same value as HTMLElement.innerText.
      *

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -14190,6 +14190,7 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover)
      */
     togglePopover(options?: boolean): boolean;
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -430,6 +430,8 @@
                             }
                         },
                         "addEventListener": {
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener",
+                            "comment": "The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.",
                             "overrideSignatures": [
                                 "addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void"
                             ]

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1293,6 +1293,24 @@
                             "deprecated": true,
                             "name": "className",
                             "type": "any"
+                        },
+                        "onerror": {
+                            "name": "onerror",
+                            "nullable": true,
+                            "overrideType": "((event: Event) => any) | ((event: UIEvent) => any)",
+                            "comment": "The error event is fired on an element when a resource failed to load, or can't be used. \n [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)",
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event"
+                        }
+                    }
+                },
+                "methods": {
+                    "method": {
+                        "addEventListener": {
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener",
+                            "comment": "The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.",
+                            "overrideSignatures": [
+                                "addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void"
+                            ]
                         }
                     }
                 }

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -404,6 +404,13 @@
                             // Blink only as of 2024-11
                             "overrideType": "boolean",
                             "nullable": false
+                        },
+                        "onerror": {
+                            "name": "onerror",
+                            "nullable": true,
+                            "overrideType": "((event: Event) => any) | ((event: UIEvent) => any)",
+                            "comment": "The error event is fired on an element when a resource failed to load, or can't be used. \n [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event)",
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/error_event"
                         }
                     }
                 },

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -428,6 +428,11 @@
                                     ]
                                 }
                             }
+                        },
+                        "addEventListener": {
+                            "overrideSignatures": [
+                                "addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void"
+                            ]
                         }
                     }
                 }
@@ -1235,7 +1240,7 @@
                                             "name": "quality",
                                             "overrideType": "number"
                                         }
-                                    ],
+                                    ]
                                 }
                             }
                         },
@@ -1248,7 +1253,7 @@
                                             "name": "quality",
                                             "overrideType": "number"
                                         }
-                                    ],
+                                    ]
                                 }
                             }
                         }

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -1331,6 +1331,13 @@
                                     "overrideType": "NodeListOf<SVGCircleElement | SVGEllipseElement | SVGImageElement | SVGLineElement | SVGPathElement | SVGPolygonElement | SVGPolylineElement | SVGRectElement | SVGTextElement | SVGUseElement>"
                                 }
                             }
+                        },
+                        "addEventListener": {
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener",
+                            "comment": "The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.",
+                            "overrideSignatures": [
+                                "addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void"
+                            ]
                         }
                     }
                 }

--- a/src/build/emitter.ts
+++ b/src/build/emitter.ts
@@ -46,6 +46,11 @@ const extendConflictsInterfaces: Record<
       GlobalEventHandlers: 'Omit<GlobalEventHandlers, "onerror">',
     },
   },
+  SVGElement: {
+    overrideMap: {
+      GlobalEventHandlers: 'Omit<GlobalEventHandlers, "onerror">',
+    },
+  },
 };
 
 // Namespaces that have been in form of interfaces for years

--- a/unittests/files/eventlistener.ts
+++ b/unittests/files/eventlistener.ts
@@ -7,3 +7,31 @@ document.addEventListener("arbitrary_invalid_event", {
     return ev.returnValue;
   }
 });
+
+const divElement: HTMLElement = document.createElement("div");
+
+
+divElement.addEventListener(
+  "click",
+  (event: Event) => {
+    if (event) {
+      return;
+    }
+  },
+  false,
+);
+
+divElement.addEventListener(
+  "click",
+  (event: Event) => {
+  if (event) {
+      return;
+    }
+  }
+);
+
+divElement.addEventListener("beep", (event: UIEvent) => {
+  if (event) {
+    return;
+  }
+});

--- a/unittests/files/eventlistener.ts
+++ b/unittests/files/eventlistener.ts
@@ -35,3 +35,30 @@ divElement.addEventListener("beep", (event: UIEvent) => {
     return;
   }
 });
+
+const svgElement = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+
+svgElement.addEventListener(
+  "click",
+  (event: Event) => {
+    if (event) {
+      return;
+    }
+  },
+  false,
+);
+
+svgElement.addEventListener(
+  "click",
+  (event: Event) => {
+    if (event) {
+      return;
+    }
+  }
+);
+
+svgElement.addEventListener("beep", (event: UIEvent) => {
+  if (event) {
+    return;
+  }
+});

--- a/unittests/files/onerror.ts
+++ b/unittests/files/onerror.ts
@@ -1,0 +1,35 @@
+/**
+ * window.onerror works as intended with global event handler
+ */
+window.onerror = (message, src, lineno, colno, error) => {
+  if (message && src && lineno && colno && error) {
+    return;
+  }
+};
+
+
+const div: HTMLElement = document.createElement("div");
+
+
+/**
+ * HTMLElement.onerror works with a single event arg, UIEvent
+ */
+div.onerror = (event: UIEvent) => {
+  if (event) {
+    return;
+  }
+};
+/**
+ * HTMLElement.onerror works with a single event arg, Event
+ */
+div.onerror = (event: Event) => {
+  if (event) {
+    return;
+  }
+};
+
+
+/**
+ * HTMLElement onerror is nullable
+ */
+div.onerror = null;

--- a/unittests/files/onerror.ts
+++ b/unittests/files/onerror.ts
@@ -7,7 +7,6 @@ window.onerror = (message, src, lineno, colno, error) => {
   }
 };
 
-
 const div: HTMLElement = document.createElement("div");
 
 
@@ -29,8 +28,33 @@ div.onerror = (event: Event) => {
   }
 };
 
-
 /**
  * HTMLElement onerror is nullable
  */
 div.onerror = null;
+
+
+const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+
+/**
+ * SVGElement.onerror works with a single event arg, UIEvent
+ */
+svg.onerror = (event: UIEvent) => {
+  if (event) {
+    return;
+  }
+};
+
+/**
+ * SVGElement.onerror works with a single event arg, Event
+ */
+svg.onerror = (event: Event) => {
+  if (event) {
+    return;
+  }
+};
+
+/**
+ * SVGElement onerror is nullable
+ */
+svg.onerror = null;

--- a/unittests/files/onerror.ts
+++ b/unittests/files/onerror.ts
@@ -19,6 +19,7 @@ div.onerror = (event: UIEvent) => {
     return;
   }
 };
+
 /**
  * HTMLElement.onerror works with a single event arg, Event
  */


### PR DESCRIPTION
## Description
This PR started as a fix for [this TypeScript issue](https://github.com/Microsoft/TypeScript/issues/62075). To handle it, I needed to update how the `emitter.ts` handled generating interfaces.

The `HTMLElement` extends the `GlobalEventHandlers.onerror` property. I didn't want to blow away the whole type to handle this fix. I thought something more flexible would make fixes like this scalable. 
I was looking at 
```ts
const extendConflictsBaseTypes: Record<
  string,
  { extendType: string[]; memberNames: Set<string> }
> = {
  HTMLCollection: {
    extendType: ["HTMLFormControlsCollection"],
    memberNames: new Set(["namedItem"]),
  },
};
```
and thought that is where I could add the flexibity by adding a new key but I didn't want to break any existing functionality or misuse a type.

I added 
```ts
const extendConflictsInterfaces: Record<
  string,
  { overrideMap: Record<string, string> }
> = {
  HTMLElement: {
    overrideMap: {
      GlobalEventHandlers: 'Omit<GlobalEventHandlers, "onerror">',
    },
  },
};
```

It allows you to define a type and override its interfaces when unique cases arise.

I've included fixes for `HTMLElement` and `SvgElement`. If these changes are approved but we'd like to split the PR up into discrete chunks that's no problem. I'm also open to other approaches so if there's a more obvious place to bring this in I can update the PR. 