### PR TITLE
Html element onerror override

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13142,7 +13142,7 @@ interface GlobalEventHandlers {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ended_event) */
     onended: ((this: GlobalEventHandlers, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/error_event) */
-    onerror: OnErrorEventHandler;
+    onerror: DocumentOrGlobalOnErrorHandler;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/focus_event) */
     onfocus: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/formdata_event) */
@@ -39572,7 +39572,7 @@ declare var onemptied: ((this: Window, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ended_event) */
 declare var onended: ((this: Window, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/error_event) */
-declare var onerror: OnErrorEventHandler;
+declare var onerror: DocumentOrGlobalOnErrorHandler;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/focus_event) */
 declare var onfocus: ((this: Window, ev: FocusEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/formdata_event) */
@@ -39849,6 +39849,7 @@ type ConstrainDouble = number | ConstrainDoubleRange;
 type ConstrainULong = number | ConstrainULongRange;
 type CookieList = CookieListItem[];
 type DOMHighResTimeStamp = number;
+type DocumentOrGlobalOnErrorHandler = (((event: Event) => any) | ((event: UIEvent) => any) | OnErrorEventHandlerNonNull) | null;
 type EpochTimeStamp = number;
 type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
 type FileSystemWriteChunkType = BufferSource | Blob | string | WriteParams;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14183,6 +14183,12 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover)
      */
     togglePopover(options?: boolean): boolean;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -27401,6 +27407,12 @@ interface SVGElement extends Element, ElementCSSInlineStyle, GlobalEventHandlers
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/SVGElement/viewportElement)
      */
     readonly viewportElement: SVGElement | null;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -29763,6 +29775,12 @@ interface SVGSVGElement extends SVGGraphicsElement, SVGFitToViewBox, WindowEvent
     unsuspendRedraw(suspendHandleID: number): void;
     /** @deprecated */
     unsuspendRedrawAll(): void;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof SVGSVGElementEventMap>(type: K, listener: (this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGSVGElementEventMap>(type: K, listener: (this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -13131,7 +13131,7 @@ interface GlobalEventHandlers {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ended_event) */
     onended: ((this: GlobalEventHandlers, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/error_event) */
-    onerror: OnErrorEventHandler;
+    onerror: DocumentOrGlobalOnErrorHandler;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/focus_event) */
     onfocus: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/formdata_event) */
@@ -39549,7 +39549,7 @@ declare var onemptied: ((this: Window, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ended_event) */
 declare var onended: ((this: Window, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/error_event) */
-declare var onerror: OnErrorEventHandler;
+declare var onerror: DocumentOrGlobalOnErrorHandler;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/focus_event) */
 declare var onfocus: ((this: Window, ev: FocusEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/formdata_event) */
@@ -39826,6 +39826,7 @@ type ConstrainDouble = number | ConstrainDoubleRange;
 type ConstrainULong = number | ConstrainULongRange;
 type CookieList = CookieListItem[];
 type DOMHighResTimeStamp = number;
+type DocumentOrGlobalOnErrorHandler = (((event: Event) => any) | ((event: UIEvent) => any) | OnErrorEventHandlerNonNull) | null;
 type EpochTimeStamp = number;
 type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
 type FileSystemWriteChunkType = BufferSource | Blob | string | WriteParams;

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -14170,6 +14170,12 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover)
      */
     togglePopover(options?: boolean): boolean;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -27379,6 +27385,12 @@ interface SVGElement extends Element, ElementCSSInlineStyle, GlobalEventHandlers
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/SVGElement/viewportElement)
      */
     readonly viewportElement: SVGElement | null;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -29741,6 +29753,12 @@ interface SVGSVGElement extends SVGGraphicsElement, SVGFitToViewBox, WindowEvent
     unsuspendRedraw(suspendHandleID: number): void;
     /** @deprecated */
     unsuspendRedrawAll(): void;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof SVGSVGElementEventMap>(type: K, listener: (this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGSVGElementEventMap>(type: K, listener: (this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -13142,7 +13142,7 @@ interface GlobalEventHandlers {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ended_event) */
     onended: ((this: GlobalEventHandlers, ev: Event) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/error_event) */
-    onerror: OnErrorEventHandler;
+    onerror: DocumentOrGlobalOnErrorHandler;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/focus_event) */
     onfocus: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/formdata_event) */
@@ -39572,7 +39572,7 @@ declare var onemptied: ((this: Window, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/ended_event) */
 declare var onended: ((this: Window, ev: Event) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/error_event) */
-declare var onerror: OnErrorEventHandler;
+declare var onerror: DocumentOrGlobalOnErrorHandler;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/focus_event) */
 declare var onfocus: ((this: Window, ev: FocusEvent) => any) | null;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLFormElement/formdata_event) */
@@ -39849,6 +39849,7 @@ type ConstrainDouble = number | ConstrainDoubleRange;
 type ConstrainULong = number | ConstrainULongRange;
 type CookieList = CookieListItem[];
 type DOMHighResTimeStamp = number;
+type DocumentOrGlobalOnErrorHandler = (((event: Event) => any) | ((event: UIEvent) => any) | OnErrorEventHandlerNonNull) | null;
 type EpochTimeStamp = number;
 type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
 type FileSystemWriteChunkType = BufferSource | Blob | string | WriteParams;

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -14183,6 +14183,12 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/togglePopover)
      */
     togglePopover(options?: boolean): boolean;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -27401,6 +27407,12 @@ interface SVGElement extends Element, ElementCSSInlineStyle, GlobalEventHandlers
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/SVGElement/viewportElement)
      */
     readonly viewportElement: SVGElement | null;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -29763,6 +29775,12 @@ interface SVGSVGElement extends SVGGraphicsElement, SVGFitToViewBox, WindowEvent
     unsuspendRedraw(suspendHandleID: number): void;
     /** @deprecated */
     unsuspendRedrawAll(): void;
+    /**
+     * The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.
+     *
+     * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
+     */
+    addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void;
     addEventListener<K extends keyof SVGSVGElementEventMap>(type: K, listener: (this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGSVGElementEventMap>(type: K, listener: (this: SVGSVGElement, ev: SVGSVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -1216,6 +1216,12 @@
                 // Full spec at https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill.
                 "name": "AutoFill",
                 "overrideType": "AutoFillBase | `${OptionalPrefixToken<AutoFillSection>}${OptionalPrefixToken<AutoFillAddressKind>}${AutoFillField}${OptionalPostfixToken<AutoFillCredentialField>}`"
+            },
+            {
+                "name": "DocumentOrGlobalOnErrorHandler",
+                "nullable": true,
+                "overrideType": "((event: Event) => any) | ((event: UIEvent) => any) | OnErrorEventHandlerNonNull",
+                "exposed": "Window"
             }
         ]
     }

--- a/inputfiles/knownTypes.json
+++ b/inputfiles/knownTypes.json
@@ -21,6 +21,7 @@
         "CompositeOperationOrAuto",
         "ComputedKeyframe",
         "DisplayCaptureSurfaceType",
+        "DocumentOrGlobalOnErrorHandler",
         "EcdhKeyDeriveParams",
         "EcdsaParams",
         "EcKeyAlgorithm",

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -421,6 +421,14 @@
                                     ]
                                 }
                             }
+                        },
+                        "addEventListener": {
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener",
+                            "comment": "The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.",
+                            "overrideSignatures": [
+                                "addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void"
+                            ]
+
                         }
                     }
                 }
@@ -1281,6 +1289,18 @@
                             "type": "any"
                         }
                     }
+                },
+                "methods": {
+                    "method": {
+                        "addEventListener": {
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener",
+                            "comment": "The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.",
+                            "overrideSignatures": [
+                                "addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void"
+                            ]
+
+                        }
+                    }
                 }
             },
             "SVGSVGElement": {
@@ -1299,6 +1319,14 @@
                                     "overrideType": "NodeListOf<SVGCircleElement | SVGEllipseElement | SVGImageElement | SVGLineElement | SVGPathElement | SVGPolygonElement | SVGPolylineElement | SVGRectElement | SVGTextElement | SVGUseElement>"
                                 }
                             }
+                        },
+                        "addEventListener": {
+                            "mdnUrl": "https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener",
+                            "comment": "The addEventListener() method of the EventTarget interface sets up a function that will be called whenever the specified event is delivered to the target.",
+                            "overrideSignatures": [
+                                "addEventListener(type: string, listener: ((event: Event) => void) | ((event: UIEvent) => void)): void"
+                            ]
+
                         }
                     }
                 }

--- a/inputfiles/patches/events.kdl
+++ b/inputfiles/patches/events.kdl
@@ -74,7 +74,7 @@ interface-mixin GlobalEventHandlers {
   event transitionstart type=TransitionEvent
   event transitionend type=TransitionEvent
   event transitioncancel type=TransitionEvent
-  property onerror overrideType=OnErrorEventHandler
+  property onerror overrideType=DocumentOrGlobalOnErrorHandler
 }
 
 interface-mixin MessageEventTarget {

--- a/src/build/expose.ts
+++ b/src/build/expose.ts
@@ -88,7 +88,9 @@ export function getExposedTypes(
 
   if (webidl.typedefs) {
     const referenced = webidl.typedefs.typedef.filter(
-      (t) => knownIDLTypes.has(t.name) || forceKnownTypesLogged.has(t.name),
+      (t) =>
+        (knownIDLTypes.has(t.name) || forceKnownTypesLogged.has(t.name)) &&
+        exposesTo(t, target),
     );
     const { exposed, removed } = filterTypedefs(referenced, unexposedTypes);
     removed.forEach((s) => unexposedTypes.add(s));

--- a/src/build/types.ts
+++ b/src/build/types.ts
@@ -227,6 +227,7 @@ export interface TypeDef extends Typed {
   deprecated?: boolean;
   legacyNamespace?: string;
   typeParameters?: TypeParameter[];
+  exposed?: string;
 }
 
 export interface Dictionary {

--- a/unittests/files/eventlistener.ts
+++ b/unittests/files/eventlistener.ts
@@ -3,7 +3,55 @@ document.addEventListener("arbitrary_invalid_event", (ev) => {
 });
 
 document.addEventListener("arbitrary_invalid_event", {
-  handleEvent(ev)  {
+  handleEvent(ev) {
     return ev.returnValue;
+  },
+});
+const divElement: HTMLElement = document.createElement("div");
+
+
+divElement.addEventListener(
+  "click",
+  (event: Event) => {
+    if (event) {
+      return;
+    }
+  },
+  false,
+);
+
+divElement.addEventListener("click", (event: Event) => {
+  if (event) {
+    return;
+  }
+});
+
+divElement.addEventListener("beep", (event: UIEvent) => {
+  if (event) {
+    return;
+  }
+});
+
+const svgElement = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+
+svgElement.addEventListener(
+  "click",
+  (event: Event) => {
+    if (event) {
+      return;
+    }
+  },
+  false,
+);
+
+svgElement.addEventListener("click", (event: Event) => {
+  if (event) {
+    return;
+  }
+});
+
+svgElement.addEventListener("beep", (event: UIEvent) => {
+  if (event) {
+    return;
   }
 });

--- a/unittests/files/onerror.ts
+++ b/unittests/files/onerror.ts
@@ -1,0 +1,59 @@
+/**
+ * window.onerror works as intended with global event handler
+ */
+window.onerror = (message, src, lineno, colno, error) => {
+  if (message && src && lineno && colno && error) {
+    return;
+  }
+};
+
+const div: HTMLElement = document.createElement("div");
+
+
+/**
+ * HTMLElement.onerror works with a single event arg, UIEvent
+ */
+div.onerror = (event: UIEvent) => {
+  if (event) {
+    return;
+  }
+};
+
+/**
+ * HTMLElement.onerror works with a single event arg, Event
+ */
+div.onerror = (event: Event) => {
+  if (event) {
+    return;
+  }
+};
+
+/**
+ * HTMLElement onerror is nullable
+ */
+div.onerror = null;
+
+const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+
+/**
+ * SVGElement.onerror works with a single event arg, UIEvent
+ */
+svg.onerror = (event: UIEvent) => {
+  if (event) {
+    return;
+  }
+};
+
+/**
+ * SVGElement.onerror works with a single event arg, Event
+ */
+svg.onerror = (event: Event) => {
+  if (event) {
+    return;
+  }
+};
+
+/**
+ * SVGElement onerror is nullable
+ */
+svg.onerror = null;


### PR DESCRIPTION
This PR fixes [this Typescript issue](https://github.com/Microsoft/TypeScript/issues/62075). 

Originally, I created this [PR](https://github.com/soda-sorcery/dark-star/commit/878220f214a374b4ba0f73591631260e60036511), but closed it as the that approach wasn't ideal. Using `Omit<GlobalEventHandlers, 'onerror'>` isn't the correct path and creates a whole slew of new problems due to how event handlers are mapped to different elements during the emit phase. (if you're curious to see what exactly I ran into, I can push up a separate PR).

What this change does:
- Introduces a new type `DocumentOrGlobalOnErrorHandler` which extends the `OnErrorEventHandlerNonNull` type with `HTMLElement` specific handlers. This allow us to be backwards compatible.

- This did require a change to both `types.ts` and `emitter.ts` so that `exposed` was accounted for when creating a new typedef. I needed the new `DocumentOrGlobalOnErrorHandler` to only be exposed on the dom library. 

- the `onerror` of `GlobalEventHandlers` cannot be overridden by the `overrideType.ts` file. I tried to a few times, in both mixin-ins and interfaces. It turns out it has to be overidden in the `patches/events.kdl` file.


Let me know if I missed anything or another approach would be better. I think this threads the needle nicely as it works only on `dom` elements and still provides both the global and `HTMLElement `specific `onerror` handling types. 