### PR TITLE
Introduce CSSStyleDeclarationBase

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4821,7 +4821,7 @@ interface CSSFontFaceRule extends CSSRule {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSFontFaceRule/style)
      */
-    get style(): CSSStyleProperties;
+    get style(): CSSStyleDeclaration;
     set style(cssText: string);
 }
 
@@ -4991,7 +4991,7 @@ interface CSSKeyframeRule extends CSSRule {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSKeyframeRule/style)
      */
-    get style(): CSSStyleProperties;
+    get style(): CSSStyleDeclaration;
     set style(cssText: string);
 }
 
@@ -5326,7 +5326,7 @@ interface CSSNestedDeclarations extends CSSRule {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSNestedDeclarations/style)
      */
-    get style(): CSSStyleProperties;
+    get style(): CSSStyleDeclaration;
     set style(cssText: string);
 }
 
@@ -7417,7 +7417,7 @@ interface CSSStyleRule extends CSSGroupingRule {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleRule/style)
      */
-    get style(): CSSStyleProperties;
+    get style(): CSSStyleDeclaration;
     set style(cssText: string);
     /**
      * The **`styleMap`** read-only property of the CSSStyleRule interface returns a StylePropertyMap object which provides access to the rule's property-value pairs.
@@ -11461,7 +11461,7 @@ interface ElementCSSInlineStyle {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/attributeStyleMap) */
     readonly attributeStyleMap: StylePropertyMap;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/style) */
-    get style(): CSSStyleProperties;
+    get style(): CSSStyleDeclaration;
     set style(cssText: string);
 }
 
@@ -37358,7 +37358,7 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle)
      */
-    getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleProperties;
+    getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleDeclaration;
     /**
      * The **`getSelection()`** method of the Window interface returns the Selection object associated with the window's document, representing the range of text selected by the user or the current position of the caret.
      *
@@ -39460,7 +39460,7 @@ declare function focus(): void;
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle)
  */
-declare function getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleProperties;
+declare function getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleDeclaration;
 /**
  * The **`getSelection()`** method of the Window interface returns the Selection object associated with the window's document, representing the range of text selected by the user or the current position of the caret.
  *

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5440,7 +5440,7 @@ declare var CSSNumericValue: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPageDescriptors)
  */
-interface CSSPageDescriptors extends CSSStyleDeclaration {
+interface CSSPageDescriptors extends CSSStyleDeclarationBase {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPageDescriptors#margin) */
     margin: string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPageDescriptors#margin-bottom) */
@@ -5518,7 +5518,7 @@ declare var CSSPerspective: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors)
  */
-interface CSSPositionTryDescriptors extends CSSStyleDeclaration {
+interface CSSPositionTryDescriptors extends CSSStyleDeclarationBase {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties) */
     "align-self": string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties) */
@@ -5992,7 +5992,7 @@ declare var CSSStartingStyleRule: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration)
  */
-interface CSSStyleDeclaration {
+interface CSSStyleDeclarationBase {
     /**
      * The **`cssText`** property of the CSSStyleDeclaration interface returns or sets the text of the element's **inline** style declaration only.
      *
@@ -6044,12 +6044,15 @@ interface CSSStyleDeclaration {
     [index: number]: string;
 }
 
+interface CSSStyleDeclaration extends CSSStyleProperties {
+}
+
 declare var CSSStyleDeclaration: {
     prototype: CSSStyleDeclaration;
     new(): CSSStyleDeclaration;
 };
 
-interface CSSStyleProperties extends CSSStyleDeclaration {
+interface CSSStyleProperties extends CSSStyleDeclarationBase {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/accent-color) */
     accentColor: string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-content) */

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -5435,7 +5435,7 @@ declare var CSSNumericValue: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPageDescriptors)
  */
-interface CSSPageDescriptors extends CSSStyleDeclaration {
+interface CSSPageDescriptors extends CSSStyleDeclarationBase {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPageDescriptors#margin) */
     margin: string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPageDescriptors#margin-bottom) */
@@ -5512,7 +5512,7 @@ declare var CSSPerspective: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors)
  */
-interface CSSPositionTryDescriptors extends CSSStyleDeclaration {
+interface CSSPositionTryDescriptors extends CSSStyleDeclarationBase {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties) */
     "align-self": string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties) */
@@ -5985,7 +5985,7 @@ declare var CSSStartingStyleRule: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration)
  */
-interface CSSStyleDeclaration {
+interface CSSStyleDeclarationBase {
     /**
      * The **`cssText`** property of the CSSStyleDeclaration interface returns or sets the text of the element's **inline** style declaration only.
      *
@@ -6037,12 +6037,15 @@ interface CSSStyleDeclaration {
     [index: number]: string;
 }
 
+interface CSSStyleDeclaration extends CSSStyleProperties {
+}
+
 declare var CSSStyleDeclaration: {
     prototype: CSSStyleDeclaration;
     new(): CSSStyleDeclaration;
 };
 
-interface CSSStyleProperties extends CSSStyleDeclaration {
+interface CSSStyleProperties extends CSSStyleDeclarationBase {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/accent-color) */
     accentColor: string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-content) */

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -4821,7 +4821,7 @@ interface CSSFontFaceRule extends CSSRule {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSFontFaceRule/style)
      */
-    readonly style: CSSStyleProperties;
+    readonly style: CSSStyleDeclaration;
 }
 
 declare var CSSFontFaceRule: {
@@ -4989,7 +4989,7 @@ interface CSSKeyframeRule extends CSSRule {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSKeyframeRule/style)
      */
-    readonly style: CSSStyleProperties;
+    readonly style: CSSStyleDeclaration;
 }
 
 declare var CSSKeyframeRule: {
@@ -5322,7 +5322,7 @@ interface CSSNestedDeclarations extends CSSRule {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSNestedDeclarations/style)
      */
-    readonly style: CSSStyleProperties;
+    readonly style: CSSStyleDeclaration;
 }
 
 declare var CSSNestedDeclarations: {
@@ -7410,7 +7410,7 @@ interface CSSStyleRule extends CSSGroupingRule {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleRule/style)
      */
-    readonly style: CSSStyleProperties;
+    readonly style: CSSStyleDeclaration;
     /**
      * The **`styleMap`** read-only property of the CSSStyleRule interface returns a StylePropertyMap object which provides access to the rule's property-value pairs.
      *
@@ -11451,7 +11451,7 @@ interface ElementCSSInlineStyle {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/attributeStyleMap) */
     readonly attributeStyleMap: StylePropertyMap;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/style) */
-    readonly style: CSSStyleProperties;
+    readonly style: CSSStyleDeclaration;
 }
 
 interface ElementContentEditable {
@@ -37335,7 +37335,7 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle)
      */
-    getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleProperties;
+    getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleDeclaration;
     /**
      * The **`getSelection()`** method of the Window interface returns the Selection object associated with the window's document, representing the range of text selected by the user or the current position of the caret.
      *
@@ -39437,7 +39437,7 @@ declare function focus(): void;
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle)
  */
-declare function getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleProperties;
+declare function getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleDeclaration;
 /**
  * The **`getSelection()`** method of the Window interface returns the Selection object associated with the window's document, representing the range of text selected by the user or the current position of the caret.
  *

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -4821,7 +4821,7 @@ interface CSSFontFaceRule extends CSSRule {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSFontFaceRule/style)
      */
-    get style(): CSSStyleProperties;
+    get style(): CSSStyleDeclaration;
     set style(cssText: string);
 }
 
@@ -4991,7 +4991,7 @@ interface CSSKeyframeRule extends CSSRule {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSKeyframeRule/style)
      */
-    get style(): CSSStyleProperties;
+    get style(): CSSStyleDeclaration;
     set style(cssText: string);
 }
 
@@ -5326,7 +5326,7 @@ interface CSSNestedDeclarations extends CSSRule {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSNestedDeclarations/style)
      */
-    get style(): CSSStyleProperties;
+    get style(): CSSStyleDeclaration;
     set style(cssText: string);
 }
 
@@ -7417,7 +7417,7 @@ interface CSSStyleRule extends CSSGroupingRule {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleRule/style)
      */
-    get style(): CSSStyleProperties;
+    get style(): CSSStyleDeclaration;
     set style(cssText: string);
     /**
      * The **`styleMap`** read-only property of the CSSStyleRule interface returns a StylePropertyMap object which provides access to the rule's property-value pairs.
@@ -11461,7 +11461,7 @@ interface ElementCSSInlineStyle {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/attributeStyleMap) */
     readonly attributeStyleMap: StylePropertyMap;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/style) */
-    get style(): CSSStyleProperties;
+    get style(): CSSStyleDeclaration;
     set style(cssText: string);
 }
 
@@ -37358,7 +37358,7 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle)
      */
-    getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleProperties;
+    getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleDeclaration;
     /**
      * The **`getSelection()`** method of the Window interface returns the Selection object associated with the window's document, representing the range of text selected by the user or the current position of the caret.
      *
@@ -39460,7 +39460,7 @@ declare function focus(): void;
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/getComputedStyle)
  */
-declare function getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleProperties;
+declare function getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleDeclaration;
 /**
  * The **`getSelection()`** method of the Window interface returns the Selection object associated with the window's document, representing the range of text selected by the user or the current position of the caret.
  *

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -5440,7 +5440,7 @@ declare var CSSNumericValue: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPageDescriptors)
  */
-interface CSSPageDescriptors extends CSSStyleDeclaration {
+interface CSSPageDescriptors extends CSSStyleDeclarationBase {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPageDescriptors#margin) */
     margin: string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPageDescriptors#margin-bottom) */
@@ -5518,7 +5518,7 @@ declare var CSSPerspective: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors)
  */
-interface CSSPositionTryDescriptors extends CSSStyleDeclaration {
+interface CSSPositionTryDescriptors extends CSSStyleDeclarationBase {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties) */
     "align-self": string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSPositionTryDescriptors#instance_properties) */
@@ -5992,7 +5992,7 @@ declare var CSSStartingStyleRule: {
  *
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/CSSStyleDeclaration)
  */
-interface CSSStyleDeclaration {
+interface CSSStyleDeclarationBase {
     /**
      * The **`cssText`** property of the CSSStyleDeclaration interface returns or sets the text of the element's **inline** style declaration only.
      *
@@ -6044,12 +6044,15 @@ interface CSSStyleDeclaration {
     [index: number]: string;
 }
 
+interface CSSStyleDeclaration extends CSSStyleProperties {
+}
+
 declare var CSSStyleDeclaration: {
     prototype: CSSStyleDeclaration;
     new(): CSSStyleDeclaration;
 };
 
-interface CSSStyleProperties extends CSSStyleDeclaration {
+interface CSSStyleProperties extends CSSStyleDeclarationBase {
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/accent-color) */
     accentColor: string;
     /** [MDN Reference](https://developer.mozilla.org/docs/Web/CSS/align-content) */

--- a/inputfiles/patches/cssom.kdl
+++ b/inputfiles/patches/cssom.kdl
@@ -1,0 +1,7 @@
+// CSSStyleDeclaration spec change broke a bunch of DT packages.
+// This tries to make existing usages work while still keeping the new
+// CSSStyleProperties.
+
+interface CSSStyleDeclaration \
+  forward=CSSStyleDeclarationBase \
+  forwardExtends=CSSStyleProperties

--- a/inputfiles/patches/cssom.kdl
+++ b/inputfiles/patches/cssom.kdl
@@ -5,3 +5,5 @@
 interface CSSStyleDeclaration \
   forward=CSSStyleDeclarationBase \
   forwardExtends=CSSStyleProperties
+
+interface CSSStyleProperties replaceReference=CSSStyleDeclaration

--- a/src/build/emitter.ts
+++ b/src/build/emitter.ts
@@ -765,7 +765,7 @@ export function emitWebIdl(
   }
 
   function emitCallBackInterface(i: Browser.Interface) {
-    const methods = mapToArray(i.methods.method);
+    const methods = mapToArray(i.methods?.method);
     const m = methods[0];
     const overload = m.signature[0];
     const paramsString = overload.param ? paramsToString(overload.param) : "";
@@ -1284,6 +1284,13 @@ export function emitWebIdl(
       return extendConflictsBaseTypes[iName] ? `${iName}Base` : iName;
     }
 
+    function processExtends(iName: string) {
+      if (allInterfacesMap[iName]?.forward) {
+        return allInterfacesMap[iName].forward;
+      }
+      return processIName(iName);
+    }
+
     function processMixinName(mixinName: string) {
       if (allInterfacesMap[mixinName].typeParameters?.length === 1) {
         return `${mixinName}<${i.name}>`;
@@ -1291,7 +1298,7 @@ export function emitWebIdl(
       return mixinName;
     }
 
-    const processedIName = processIName(i.name);
+    const processedIName = i.forward ?? processIName(i.name);
 
     if (processedIName !== i.name) {
       printer.printLineToStack(
@@ -1311,7 +1318,7 @@ export function emitWebIdl(
     const finalExtends = [i.extends || "Object"]
       .concat(getImplementList(i.name).map(processMixinName))
       .filter((i) => i !== "Object")
-      .map(processIName);
+      .map(processExtends);
 
     if (finalExtends.length) {
       printer.print(` extends ${assertUnique(finalExtends).join(", ")}`);
@@ -1457,6 +1464,14 @@ export function emitWebIdl(
     printer.decreaseIndent();
     printer.printLine("}");
     printer.printLine("");
+
+    if (i.forward) {
+      emitInterface({
+        name: i.name,
+        extends: i.forwardExtends,
+        constructor: undefined,
+      });
+    }
 
     if (!printer.stackIsEmpty()) {
       printer.printStackContent();

--- a/src/build/emitter.ts
+++ b/src/build/emitter.ts
@@ -472,15 +472,18 @@ export function emitWebIdl(
     if (baseTypeConversionMap.has(objDomType)) {
       return baseTypeConversionMap.get(objDomType)!;
     }
-    // Name of an interface / enum / dict. Just return itself
+    if (allInterfacesMap[objDomType]) {
+      return allInterfacesMap[objDomType].replaceReference ?? objDomType;
+    }
+    // Name of an alias / callback / enum / dict. Just return itself
     if (
-      allInterfacesMap[objDomType] ||
       allLegacyWindowAliases.includes(objDomType) ||
       allCallbackFunctionsMap[objDomType] ||
       allDictionariesMap[objDomType] ||
       allEnumsMap[objDomType]
-    )
+    ) {
       return objDomType;
+    }
     // Name of a type alias. Just return itself
     if (allTypedefsMap[objDomType]) return objDomType;
 

--- a/src/build/patches.ts
+++ b/src/build/patches.ts
@@ -183,6 +183,12 @@ function handleMixinandInterfaces(
     methods: { method },
     ...optionalMember("extends", "string", node.properties?.extends),
     ...optionalMember("overrideThis", "string", node.properties?.overrideThis),
+    ...optionalMember("forward", "string", node.properties?.forward),
+    ...optionalMember(
+      "forwardExtends",
+      "string",
+      node.properties?.forwardExtends,
+    ),
     ...handleTypeParameters(node.properties?.typeParameters),
     ...interfaceObject,
   } as DeepPartial<Interface>;

--- a/src/build/patches.ts
+++ b/src/build/patches.ts
@@ -189,6 +189,11 @@ function handleMixinandInterfaces(
       "string",
       node.properties?.forwardExtends,
     ),
+    ...optionalMember(
+      "replaceReference",
+      "string",
+      node.properties?.replaceReference,
+    ),
     ...handleTypeParameters(node.properties?.typeParameters),
     ...interfaceObject,
   } as DeepPartial<Interface>;

--- a/src/build/types.ts
+++ b/src/build/types.ts
@@ -151,11 +151,15 @@ export interface Interface {
   mixin?: boolean;
   namespace?: boolean;
   extends?: string;
+  // forward the interface members to another, while keeping the current name.
+  forward?: string;
+  // "extends" for the original interface, in case `forward: true`.
+  forwardExtends?: string;
   comment?: string;
   constants?: {
     constant: Record<string, Constant>;
   };
-  methods: {
+  methods?: {
     method: Record<string, Method>;
   };
   events?: {

--- a/src/build/types.ts
+++ b/src/build/types.ts
@@ -155,6 +155,8 @@ export interface Interface {
   forward?: string;
   // "extends" for the original interface, in case `forward: true`.
   forwardExtends?: string;
+  // replaces references from methods and properties
+  replaceReference?: string;
   comment?: string;
   constants?: {
     constant: Record<string, Constant>;

--- a/src/build/widlprocess.ts
+++ b/src/build/widlprocess.ts
@@ -191,7 +191,7 @@ function convertInterfaceCommon(
       }
     } else if (member.type === "operation") {
       const operation = convertOperation(member, result.exposed);
-      const { method } = result.methods;
+      const { method } = result.methods!;
       if (!member.name) {
         result.anonymousMethods!.method.push(operation);
       } else if (method.hasOwnProperty(member.name)) {
@@ -433,7 +433,7 @@ function convertNamespace(
       );
     } else if (member.type === "operation" && member.idlType) {
       const operation = convertOperation(member, result.exposed);
-      const { method } = result.methods;
+      const { method } = result.methods!;
       if (method[member.name!]) {
         method[member.name!].signature.push(...operation.signature);
       } else {

--- a/unittests/files/css-style.ts
+++ b/unittests/files/css-style.ts
@@ -5,3 +5,5 @@ const foo = { width: "10px" } as CSSStyleDeclaration;
 foo.height = "20px";
 
 document.body.style.width = "10px";
+
+const bar: CSSStyleDeclaration = document.body.style;

--- a/unittests/files/css-style.ts
+++ b/unittests/files/css-style.ts
@@ -1,0 +1,7 @@
+// This should be CSSStyleProperties as of 2025,
+// but a decade-usage of CSSStyleDeclaration blocks it
+
+const foo = { width: "10px" } as CSSStyleDeclaration;
+foo.height = "20px";
+
+document.body.style.width = "10px";


### PR DESCRIPTION
This should reduce DT breakage. But note that this would make `CSSPageDescriptors extends CSSStyleDeclaration` to `false`. Authors would need to use CSSStyleDeclarationBase for that.