### PR TITLE
Make URLPatternResult properties mandatory

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2384,15 +2384,15 @@ interface URLPatternOptions {
 }
 
 interface URLPatternResult {
-    hash?: URLPatternComponentResult;
-    hostname?: URLPatternComponentResult;
-    inputs?: URLPatternInput[];
-    password?: URLPatternComponentResult;
-    pathname?: URLPatternComponentResult;
-    port?: URLPatternComponentResult;
-    protocol?: URLPatternComponentResult;
-    search?: URLPatternComponentResult;
-    username?: URLPatternComponentResult;
+    hash: URLPatternComponentResult;
+    hostname: URLPatternComponentResult;
+    inputs: URLPatternInput[];
+    password: URLPatternComponentResult;
+    pathname: URLPatternComponentResult;
+    port: URLPatternComponentResult;
+    protocol: URLPatternComponentResult;
+    search: URLPatternComponentResult;
+    username: URLPatternComponentResult;
 }
 
 interface UnderlyingByteSource {

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -761,15 +761,15 @@ interface URLPatternOptions {
 }
 
 interface URLPatternResult {
-    hash?: URLPatternComponentResult;
-    hostname?: URLPatternComponentResult;
-    inputs?: URLPatternInput[];
-    password?: URLPatternComponentResult;
-    pathname?: URLPatternComponentResult;
-    port?: URLPatternComponentResult;
-    protocol?: URLPatternComponentResult;
-    search?: URLPatternComponentResult;
-    username?: URLPatternComponentResult;
+    hash: URLPatternComponentResult;
+    hostname: URLPatternComponentResult;
+    inputs: URLPatternInput[];
+    password: URLPatternComponentResult;
+    pathname: URLPatternComponentResult;
+    port: URLPatternComponentResult;
+    protocol: URLPatternComponentResult;
+    search: URLPatternComponentResult;
+    username: URLPatternComponentResult;
 }
 
 interface UnderlyingByteSource {

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -691,15 +691,15 @@ interface URLPatternOptions {
 }
 
 interface URLPatternResult {
-    hash?: URLPatternComponentResult;
-    hostname?: URLPatternComponentResult;
-    inputs?: URLPatternInput[];
-    password?: URLPatternComponentResult;
-    pathname?: URLPatternComponentResult;
-    port?: URLPatternComponentResult;
-    protocol?: URLPatternComponentResult;
-    search?: URLPatternComponentResult;
-    username?: URLPatternComponentResult;
+    hash: URLPatternComponentResult;
+    hostname: URLPatternComponentResult;
+    inputs: URLPatternInput[];
+    password: URLPatternComponentResult;
+    pathname: URLPatternComponentResult;
+    port: URLPatternComponentResult;
+    protocol: URLPatternComponentResult;
+    search: URLPatternComponentResult;
+    username: URLPatternComponentResult;
 }
 
 interface UnderlyingByteSource {

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -2384,15 +2384,15 @@ interface URLPatternOptions {
 }
 
 interface URLPatternResult {
-    hash?: URLPatternComponentResult;
-    hostname?: URLPatternComponentResult;
-    inputs?: URLPatternInput[];
-    password?: URLPatternComponentResult;
-    pathname?: URLPatternComponentResult;
-    port?: URLPatternComponentResult;
-    protocol?: URLPatternComponentResult;
-    search?: URLPatternComponentResult;
-    username?: URLPatternComponentResult;
+    hash: URLPatternComponentResult;
+    hostname: URLPatternComponentResult;
+    inputs: URLPatternInput[];
+    password: URLPatternComponentResult;
+    pathname: URLPatternComponentResult;
+    port: URLPatternComponentResult;
+    protocol: URLPatternComponentResult;
+    search: URLPatternComponentResult;
+    username: URLPatternComponentResult;
 }
 
 interface UnderlyingByteSource {

--- a/baselines/ts5.5/serviceworker.generated.d.ts
+++ b/baselines/ts5.5/serviceworker.generated.d.ts
@@ -761,15 +761,15 @@ interface URLPatternOptions {
 }
 
 interface URLPatternResult {
-    hash?: URLPatternComponentResult;
-    hostname?: URLPatternComponentResult;
-    inputs?: URLPatternInput[];
-    password?: URLPatternComponentResult;
-    pathname?: URLPatternComponentResult;
-    port?: URLPatternComponentResult;
-    protocol?: URLPatternComponentResult;
-    search?: URLPatternComponentResult;
-    username?: URLPatternComponentResult;
+    hash: URLPatternComponentResult;
+    hostname: URLPatternComponentResult;
+    inputs: URLPatternInput[];
+    password: URLPatternComponentResult;
+    pathname: URLPatternComponentResult;
+    port: URLPatternComponentResult;
+    protocol: URLPatternComponentResult;
+    search: URLPatternComponentResult;
+    username: URLPatternComponentResult;
 }
 
 interface UnderlyingByteSource {

--- a/baselines/ts5.5/sharedworker.generated.d.ts
+++ b/baselines/ts5.5/sharedworker.generated.d.ts
@@ -691,15 +691,15 @@ interface URLPatternOptions {
 }
 
 interface URLPatternResult {
-    hash?: URLPatternComponentResult;
-    hostname?: URLPatternComponentResult;
-    inputs?: URLPatternInput[];
-    password?: URLPatternComponentResult;
-    pathname?: URLPatternComponentResult;
-    port?: URLPatternComponentResult;
-    protocol?: URLPatternComponentResult;
-    search?: URLPatternComponentResult;
-    username?: URLPatternComponentResult;
+    hash: URLPatternComponentResult;
+    hostname: URLPatternComponentResult;
+    inputs: URLPatternInput[];
+    password: URLPatternComponentResult;
+    pathname: URLPatternComponentResult;
+    port: URLPatternComponentResult;
+    protocol: URLPatternComponentResult;
+    search: URLPatternComponentResult;
+    username: URLPatternComponentResult;
 }
 
 interface UnderlyingByteSource {

--- a/baselines/ts5.5/webworker.generated.d.ts
+++ b/baselines/ts5.5/webworker.generated.d.ts
@@ -905,15 +905,15 @@ interface URLPatternOptions {
 }
 
 interface URLPatternResult {
-    hash?: URLPatternComponentResult;
-    hostname?: URLPatternComponentResult;
-    inputs?: URLPatternInput[];
-    password?: URLPatternComponentResult;
-    pathname?: URLPatternComponentResult;
-    port?: URLPatternComponentResult;
-    protocol?: URLPatternComponentResult;
-    search?: URLPatternComponentResult;
-    username?: URLPatternComponentResult;
+    hash: URLPatternComponentResult;
+    hostname: URLPatternComponentResult;
+    inputs: URLPatternInput[];
+    password: URLPatternComponentResult;
+    pathname: URLPatternComponentResult;
+    port: URLPatternComponentResult;
+    protocol: URLPatternComponentResult;
+    search: URLPatternComponentResult;
+    username: URLPatternComponentResult;
 }
 
 interface UnderlyingByteSource {

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -2384,15 +2384,15 @@ interface URLPatternOptions {
 }
 
 interface URLPatternResult {
-    hash?: URLPatternComponentResult;
-    hostname?: URLPatternComponentResult;
-    inputs?: URLPatternInput[];
-    password?: URLPatternComponentResult;
-    pathname?: URLPatternComponentResult;
-    port?: URLPatternComponentResult;
-    protocol?: URLPatternComponentResult;
-    search?: URLPatternComponentResult;
-    username?: URLPatternComponentResult;
+    hash: URLPatternComponentResult;
+    hostname: URLPatternComponentResult;
+    inputs: URLPatternInput[];
+    password: URLPatternComponentResult;
+    pathname: URLPatternComponentResult;
+    port: URLPatternComponentResult;
+    protocol: URLPatternComponentResult;
+    search: URLPatternComponentResult;
+    username: URLPatternComponentResult;
 }
 
 interface UnderlyingByteSource {

--- a/baselines/ts5.6/serviceworker.generated.d.ts
+++ b/baselines/ts5.6/serviceworker.generated.d.ts
@@ -761,15 +761,15 @@ interface URLPatternOptions {
 }
 
 interface URLPatternResult {
-    hash?: URLPatternComponentResult;
-    hostname?: URLPatternComponentResult;
-    inputs?: URLPatternInput[];
-    password?: URLPatternComponentResult;
-    pathname?: URLPatternComponentResult;
-    port?: URLPatternComponentResult;
-    protocol?: URLPatternComponentResult;
-    search?: URLPatternComponentResult;
-    username?: URLPatternComponentResult;
+    hash: URLPatternComponentResult;
+    hostname: URLPatternComponentResult;
+    inputs: URLPatternInput[];
+    password: URLPatternComponentResult;
+    pathname: URLPatternComponentResult;
+    port: URLPatternComponentResult;
+    protocol: URLPatternComponentResult;
+    search: URLPatternComponentResult;
+    username: URLPatternComponentResult;
 }
 
 interface UnderlyingByteSource {

--- a/baselines/ts5.6/sharedworker.generated.d.ts
+++ b/baselines/ts5.6/sharedworker.generated.d.ts
@@ -691,15 +691,15 @@ interface URLPatternOptions {
 }
 
 interface URLPatternResult {
-    hash?: URLPatternComponentResult;
-    hostname?: URLPatternComponentResult;
-    inputs?: URLPatternInput[];
-    password?: URLPatternComponentResult;
-    pathname?: URLPatternComponentResult;
-    port?: URLPatternComponentResult;
-    protocol?: URLPatternComponentResult;
-    search?: URLPatternComponentResult;
-    username?: URLPatternComponentResult;
+    hash: URLPatternComponentResult;
+    hostname: URLPatternComponentResult;
+    inputs: URLPatternInput[];
+    password: URLPatternComponentResult;
+    pathname: URLPatternComponentResult;
+    port: URLPatternComponentResult;
+    protocol: URLPatternComponentResult;
+    search: URLPatternComponentResult;
+    username: URLPatternComponentResult;
 }
 
 interface UnderlyingByteSource {

--- a/baselines/ts5.6/webworker.generated.d.ts
+++ b/baselines/ts5.6/webworker.generated.d.ts
@@ -905,15 +905,15 @@ interface URLPatternOptions {
 }
 
 interface URLPatternResult {
-    hash?: URLPatternComponentResult;
-    hostname?: URLPatternComponentResult;
-    inputs?: URLPatternInput[];
-    password?: URLPatternComponentResult;
-    pathname?: URLPatternComponentResult;
-    port?: URLPatternComponentResult;
-    protocol?: URLPatternComponentResult;
-    search?: URLPatternComponentResult;
-    username?: URLPatternComponentResult;
+    hash: URLPatternComponentResult;
+    hostname: URLPatternComponentResult;
+    inputs: URLPatternInput[];
+    password: URLPatternComponentResult;
+    pathname: URLPatternComponentResult;
+    port: URLPatternComponentResult;
+    protocol: URLPatternComponentResult;
+    search: URLPatternComponentResult;
+    username: URLPatternComponentResult;
 }
 
 interface UnderlyingByteSource {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -905,15 +905,15 @@ interface URLPatternOptions {
 }
 
 interface URLPatternResult {
-    hash?: URLPatternComponentResult;
-    hostname?: URLPatternComponentResult;
-    inputs?: URLPatternInput[];
-    password?: URLPatternComponentResult;
-    pathname?: URLPatternComponentResult;
-    port?: URLPatternComponentResult;
-    protocol?: URLPatternComponentResult;
-    search?: URLPatternComponentResult;
-    username?: URLPatternComponentResult;
+    hash: URLPatternComponentResult;
+    hostname: URLPatternComponentResult;
+    inputs: URLPatternInput[];
+    password: URLPatternComponentResult;
+    pathname: URLPatternComponentResult;
+    port: URLPatternComponentResult;
+    protocol: URLPatternComponentResult;
+    search: URLPatternComponentResult;
+    username: URLPatternComponentResult;
 }
 
 interface UnderlyingByteSource {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -3947,6 +3947,39 @@
             },
             "WebAssemblyInstantiatedSource": {
                 "legacyNamespace": "WebAssembly"
+            },
+            "URLPatternResult": {
+                "members": {
+                    "member": {
+                        "inputs": {
+                            "required": true
+                        },
+                        "protocol": {
+                            "required": true
+                        },
+                        "username": {
+                            "required": true
+                        },
+                        "password": {
+                            "required": true
+                        },
+                        "hostname": {
+                            "required": true
+                        },
+                        "port": {
+                            "required": true
+                        },
+                        "pathname": {
+                            "required": true
+                        },
+                        "search": {
+                            "required": true
+                        },
+                        "hash": {
+                            "required": true
+                        }
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
One of those cases where a "return value" dictionary is being generated as an interface with optional properties.

These aren't explicitly marked as `required` in the IDL, but are mandatorily assigned in the URLPattern spec. Having these as optional properties in TS is just going to be a usability headache.

Refs: https://urlpattern.spec.whatwg.org/#url-pattern-match
Refs: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73799#discussion_r2396093936