### PR TITLE
Remove redundant SVGStyleElement override

### DIFF
--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -636,16 +636,6 @@
                     ]
                 }
             },
-            "SVGStyleElement": {
-                "properties": {
-                    "property": {
-                        "disabled": {
-                            "name": "disabled",
-                            "type": "boolean"
-                        }
-                    }
-                }
-            },
             "LinkError": {
                 "name": "LinkError",
                 "extends": "Error",


### PR DESCRIPTION
This is now in the IDL, and the emitter is warning about the duplicate property.