### PR TITLE
Add `"until-found"` to `HTMLElement.hidden`

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -15996,7 +15996,7 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
      */
-    hidden: boolean;
+    hidden: boolean | "until-found";
     /**
      * The HTMLElement property **`inert`** reflects the value of the element's inert attribute. It is a boolean value that, when present, makes the browser "ignore" user input events for the element, including focus events and events from assistive technologies. The browser may also ignore page search and text selection in the element. This can be useful when building UIs such as modals where you would want to "trap" the focus inside the modal when it's visible.
      *

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -15980,7 +15980,7 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
      */
-    hidden: boolean;
+    hidden: boolean | "until-found";
     /**
      * The HTMLElement property **`inert`** reflects the value of the element's inert attribute. It is a boolean value that, when present, makes the browser "ignore" user input events for the element, including focus events and events from assistive technologies. The browser may also ignore page search and text selection in the element. This can be useful when building UIs such as modals where you would want to "trap" the focus inside the modal when it's visible.
      *

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -15993,7 +15993,7 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
      */
-    hidden: boolean;
+    hidden: boolean | "until-found";
     /**
      * The HTMLElement property **`inert`** reflects the value of the element's inert attribute. It is a boolean value that, when present, makes the browser "ignore" user input events for the element, including focus events and events from assistive technologies. The browser may also ignore page search and text selection in the element. This can be useful when building UIs such as modals where you would want to "trap" the focus inside the modal when it's visible.
      *

--- a/baselines/ts5.9/dom.generated.d.ts
+++ b/baselines/ts5.9/dom.generated.d.ts
@@ -15993,7 +15993,7 @@ interface HTMLElement extends Element, ElementCSSInlineStyle, ElementContentEdit
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLElement/hidden)
      */
-    hidden: boolean;
+    hidden: boolean | "until-found";
     /**
      * The HTMLElement property **`inert`** reflects the value of the element's inert attribute. It is a boolean value that, when present, makes the browser "ignore" user input events for the element, including focus events and events from assistive technologies. The browser may also ignore page search and text selection in the element. This can be useful when building UIs such as modals where you would want to "trap" the focus inside the modal when it's visible.
      *

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -308,9 +308,7 @@
                 "properties": {
                     "property": {
                         "hidden": {
-                            // https://github.com/whatwg/html/pull/7475
-                            // Blink only as of 2024-11
-                            "overrideType": "boolean",
+                            "overrideType": "boolean | \"until-found\"",
                             "nullable": false
                         }
                     }


### PR DESCRIPTION
Rebase of #1670 

This has now got support from Chrome and Firefox: https://caniuse.com/wf-hidden-until-found

Safari support has been merged: https://webkit.org/b/238266