### PR TITLE
Adjust @webref/events listAll return type

### DIFF
--- a/src/build/webref/events.ts
+++ b/src/build/webref/events.ts
@@ -6,7 +6,7 @@ export async function getInterfaceToEventMap(): Promise<
 > {
   const all = await listAll();
   const map = new Map<string, Map<string, string>>();
-  for (const item of Object.values(all)) {
+  for (const item of all) {
     const { targets } = item;
     for (const target of targets) {
       addToNestedMap(map, target.target, item.type, item.interface);

--- a/src/build/webref/webref-events.d.ts
+++ b/src/build/webref/webref-events.d.ts
@@ -15,5 +15,5 @@ declare module "@webref/events" {
     targets: Target[];
     interface: string;
   }
-  function listAll(): Promise<Record<string, Item>>;
+  function listAll(): Promise<Array<Item>>;
 }


### PR DESCRIPTION
The return type of `listAll` was an object, while in fact it returns an array. See the `events.json` file on npm for reference in version [1.18.6](https://www.npmjs.com/package/@webref/events/v/1.18.6?activeTab=code) as well as in the [latest version](https://www.npmjs.com/package/@webref/events/v/1.19.1?activeTab=code).