### PR TITLE
Bump @webref/idl from 3.68.4 to 3.69.0

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -627,7 +627,7 @@ interface EffectTiming {
 }
 
 interface ElementCreationOptions {
-    customElementRegistry?: CustomElementRegistry;
+    customElementRegistry?: CustomElementRegistry | null;
     is?: string;
 }
 
@@ -27025,7 +27025,7 @@ interface RTCEncodedVideoFrame {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/type)
      */
-    readonly type: RTCEncodedVideoFrameType;
+    readonly type: EncodedVideoChunkType;
     /**
      * The **`getMetadata()`** method of the RTCEncodedVideoFrame interface returns an object containing the metadata associated with the frame.
      *
@@ -42080,7 +42080,6 @@ type RTCDataChannelState = "closed" | "closing" | "connecting" | "open";
 type RTCDegradationPreference = "balanced" | "maintain-framerate" | "maintain-resolution";
 type RTCDtlsRole = "client" | "server" | "unknown";
 type RTCDtlsTransportState = "closed" | "connected" | "connecting" | "failed" | "new";
-type RTCEncodedVideoFrameType = "delta" | "empty" | "key";
 type RTCErrorDetailType = "data-channel-failure" | "dtls-failure" | "fingerprint-failure" | "hardware-encoder-error" | "hardware-encoder-not-available" | "sctp-failure" | "sdp-syntax-error";
 type RTCIceCandidateType = "host" | "prflx" | "relay" | "srflx";
 type RTCIceComponent = "rtcp" | "rtp";

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -624,7 +624,7 @@ interface EffectTiming {
 }
 
 interface ElementCreationOptions {
-    customElementRegistry?: CustomElementRegistry;
+    customElementRegistry?: CustomElementRegistry | null;
     is?: string;
 }
 
@@ -27001,7 +27001,7 @@ interface RTCEncodedVideoFrame {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/type)
      */
-    readonly type: RTCEncodedVideoFrameType;
+    readonly type: EncodedVideoChunkType;
     /**
      * The **`getMetadata()`** method of the RTCEncodedVideoFrame interface returns an object containing the metadata associated with the frame.
      *
@@ -42054,7 +42054,6 @@ type RTCDataChannelState = "closed" | "closing" | "connecting" | "open";
 type RTCDegradationPreference = "balanced" | "maintain-framerate" | "maintain-resolution";
 type RTCDtlsRole = "client" | "server" | "unknown";
 type RTCDtlsTransportState = "closed" | "connected" | "connecting" | "failed" | "new";
-type RTCEncodedVideoFrameType = "delta" | "empty" | "key";
 type RTCErrorDetailType = "data-channel-failure" | "dtls-failure" | "fingerprint-failure" | "hardware-encoder-error" | "hardware-encoder-not-available" | "sctp-failure" | "sdp-syntax-error";
 type RTCIceCandidateType = "host" | "prflx" | "relay" | "srflx";
 type RTCIceComponent = "rtcp" | "rtp";

--- a/baselines/ts5.5/webworker.generated.d.ts
+++ b/baselines/ts5.5/webworker.generated.d.ts
@@ -7462,7 +7462,7 @@ interface RTCEncodedVideoFrame {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/type)
      */
-    readonly type: RTCEncodedVideoFrameType;
+    readonly type: EncodedVideoChunkType;
     /**
      * The **`getMetadata()`** method of the RTCEncodedVideoFrame interface returns an object containing the metadata associated with the frame.
      *
@@ -13502,7 +13502,6 @@ type PredefinedColorSpace = "display-p3" | "srgb";
 type PremultiplyAlpha = "default" | "none" | "premultiply";
 type PushEncryptionKeyName = "auth" | "p256dh";
 type RTCDataChannelState = "closed" | "closing" | "connecting" | "open";
-type RTCEncodedVideoFrameType = "delta" | "empty" | "key";
 type ReadableStreamReaderMode = "byob";
 type ReadableStreamType = "bytes";
 type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "same-origin" | "strict-origin" | "strict-origin-when-cross-origin" | "unsafe-url";

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -624,7 +624,7 @@ interface EffectTiming {
 }
 
 interface ElementCreationOptions {
-    customElementRegistry?: CustomElementRegistry;
+    customElementRegistry?: CustomElementRegistry | null;
     is?: string;
 }
 
@@ -27022,7 +27022,7 @@ interface RTCEncodedVideoFrame {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/type)
      */
-    readonly type: RTCEncodedVideoFrameType;
+    readonly type: EncodedVideoChunkType;
     /**
      * The **`getMetadata()`** method of the RTCEncodedVideoFrame interface returns an object containing the metadata associated with the frame.
      *
@@ -42077,7 +42077,6 @@ type RTCDataChannelState = "closed" | "closing" | "connecting" | "open";
 type RTCDegradationPreference = "balanced" | "maintain-framerate" | "maintain-resolution";
 type RTCDtlsRole = "client" | "server" | "unknown";
 type RTCDtlsTransportState = "closed" | "connected" | "connecting" | "failed" | "new";
-type RTCEncodedVideoFrameType = "delta" | "empty" | "key";
 type RTCErrorDetailType = "data-channel-failure" | "dtls-failure" | "fingerprint-failure" | "hardware-encoder-error" | "hardware-encoder-not-available" | "sctp-failure" | "sdp-syntax-error";
 type RTCIceCandidateType = "host" | "prflx" | "relay" | "srflx";
 type RTCIceComponent = "rtcp" | "rtp";

--- a/baselines/ts5.6/webworker.generated.d.ts
+++ b/baselines/ts5.6/webworker.generated.d.ts
@@ -7462,7 +7462,7 @@ interface RTCEncodedVideoFrame {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/type)
      */
-    readonly type: RTCEncodedVideoFrameType;
+    readonly type: EncodedVideoChunkType;
     /**
      * The **`getMetadata()`** method of the RTCEncodedVideoFrame interface returns an object containing the metadata associated with the frame.
      *
@@ -13502,7 +13502,6 @@ type PredefinedColorSpace = "display-p3" | "srgb";
 type PremultiplyAlpha = "default" | "none" | "premultiply";
 type PushEncryptionKeyName = "auth" | "p256dh";
 type RTCDataChannelState = "closed" | "closing" | "connecting" | "open";
-type RTCEncodedVideoFrameType = "delta" | "empty" | "key";
 type ReadableStreamReaderMode = "byob";
 type ReadableStreamType = "bytes";
 type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "same-origin" | "strict-origin" | "strict-origin-when-cross-origin" | "unsafe-url";

--- a/baselines/ts5.9/dom.generated.d.ts
+++ b/baselines/ts5.9/dom.generated.d.ts
@@ -624,7 +624,7 @@ interface EffectTiming {
 }
 
 interface ElementCreationOptions {
-    customElementRegistry?: CustomElementRegistry;
+    customElementRegistry?: CustomElementRegistry | null;
     is?: string;
 }
 
@@ -27022,7 +27022,7 @@ interface RTCEncodedVideoFrame {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/type)
      */
-    readonly type: RTCEncodedVideoFrameType;
+    readonly type: EncodedVideoChunkType;
     /**
      * The **`getMetadata()`** method of the RTCEncodedVideoFrame interface returns an object containing the metadata associated with the frame.
      *
@@ -42077,7 +42077,6 @@ type RTCDataChannelState = "closed" | "closing" | "connecting" | "open";
 type RTCDegradationPreference = "balanced" | "maintain-framerate" | "maintain-resolution";
 type RTCDtlsRole = "client" | "server" | "unknown";
 type RTCDtlsTransportState = "closed" | "connected" | "connecting" | "failed" | "new";
-type RTCEncodedVideoFrameType = "delta" | "empty" | "key";
 type RTCErrorDetailType = "data-channel-failure" | "dtls-failure" | "fingerprint-failure" | "hardware-encoder-error" | "hardware-encoder-not-available" | "sctp-failure" | "sdp-syntax-error";
 type RTCIceCandidateType = "host" | "prflx" | "relay" | "srflx";
 type RTCIceComponent = "rtcp" | "rtp";

--- a/baselines/ts5.9/webworker.generated.d.ts
+++ b/baselines/ts5.9/webworker.generated.d.ts
@@ -7462,7 +7462,7 @@ interface RTCEncodedVideoFrame {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/type)
      */
-    readonly type: RTCEncodedVideoFrameType;
+    readonly type: EncodedVideoChunkType;
     /**
      * The **`getMetadata()`** method of the RTCEncodedVideoFrame interface returns an object containing the metadata associated with the frame.
      *
@@ -13502,7 +13502,6 @@ type PredefinedColorSpace = "display-p3" | "srgb";
 type PremultiplyAlpha = "default" | "none" | "premultiply";
 type PushEncryptionKeyName = "auth" | "p256dh";
 type RTCDataChannelState = "closed" | "closing" | "connecting" | "open";
-type RTCEncodedVideoFrameType = "delta" | "empty" | "key";
 type ReadableStreamReaderMode = "byob";
 type ReadableStreamType = "bytes";
 type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "same-origin" | "strict-origin" | "strict-origin-when-cross-origin" | "unsafe-url";

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -7465,7 +7465,7 @@ interface RTCEncodedVideoFrame {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/RTCEncodedVideoFrame/type)
      */
-    readonly type: RTCEncodedVideoFrameType;
+    readonly type: EncodedVideoChunkType;
     /**
      * The **`getMetadata()`** method of the RTCEncodedVideoFrame interface returns an object containing the metadata associated with the frame.
      *
@@ -13505,7 +13505,6 @@ type PredefinedColorSpace = "display-p3" | "srgb";
 type PremultiplyAlpha = "default" | "none" | "premultiply";
 type PushEncryptionKeyName = "auth" | "p256dh";
 type RTCDataChannelState = "closed" | "closing" | "connecting" | "open";
-type RTCEncodedVideoFrameType = "delta" | "empty" | "key";
 type ReadableStreamReaderMode = "byob";
 type ReadableStreamType = "bytes";
 type ReferrerPolicy = "" | "no-referrer" | "no-referrer-when-downgrade" | "origin" | "origin-when-cross-origin" | "same-origin" | "strict-origin" | "strict-origin-when-cross-origin" | "unsafe-url";

--- a/inputfiles/patches/html-canvas.kdl
+++ b/inputfiles/patches/html-canvas.kdl
@@ -1,32 +1,40 @@
 enum GlobalCompositeOperation {
-    source-over
-    source-in
-    source-out
-    source-atop
-    destination-over
-    destination-in
-    destination-out
-    destination-atop
-    lighter
-    copy
-    xor
-    multiply
-    screen
-    overlay
-    darken
-    lighten
-    color-dodge
-    color-burn
-    hard-light
-    soft-light
-    difference
-    exclusion
-    hue
-    saturation
-    color
-    luminosity
+  source-over
+  source-in
+  source-out
+  source-atop
+  destination-over
+  destination-in
+  destination-out
+  destination-atop
+  lighter
+  copy
+  xor
+  multiply
+  screen
+  overlay
+  darken
+  lighten
+  color-dodge
+  color-burn
+  hard-light
+  soft-light
+  difference
+  exclusion
+  hue
+  saturation
+  color
+  luminosity
 }
 
 interface-mixin CanvasCompositing {
-    property globalCompositeOperation type=GlobalCompositeOperation
+  property globalCompositeOperation type=GlobalCompositeOperation
+}
+
+removals {
+  // Blink only as of 2025-12
+  enum PredefinedColorSpace {
+    srgb-linear
+    display-p3-linear
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1239,9 +1239,9 @@
       "license": "MIT"
     },
     "node_modules/@webref/idl": {
-      "version": "3.68.4",
-      "resolved": "https://registry.npmjs.org/@webref/idl/-/idl-3.68.4.tgz",
-      "integrity": "sha512-ZGbqsa2+idpUEAkiJK+xEySbNk6UJUNf+ZO+DMGrBurBGAjErQocJzhx6wsk1GqBgvZvwvKvgIAXuEe3x+Uqiw==",
+      "version": "3.69.0",
+      "resolved": "https://registry.npmjs.org/@webref/idl/-/idl-3.69.0.tgz",
+      "integrity": "sha512-LRVSPlp3llSvXcB2jRW0Hr8WucUYzflSi5DnI3cya419D3iqSQHFT8HfQEqZzE+3W2/edWW8ToOqYEGkmydckg==",
       "dev": true,
       "license": "MIT",
       "peer": true,


### PR DESCRIPTION
Closes #2261 

`EncodedVideoFrameType` has no `"empty"` that was in `RTCEncodedVideoFrameType`, but per https://github.com/w3c/webrtc-encoded-transform/pull/287 it was never really used anywhere. Callers should simply remove the option.