### PR TITLE
Migrate VideoFrameBufferInit to KDL

### DIFF
--- a/inputfiles/patches/webcodecs.kdl
+++ b/inputfiles/patches/webcodecs.kdl
@@ -31,4 +31,11 @@ removals {
     linear      // Blink only as of 2022-10
     pq          // Blink only as of 2022-10
   }
+
+  dictionary VideoFrameBufferInit {
+    member flip         // Blink only as of 2025-12
+    member metadata     // No implementation as of 2025-12. Linked to VideoFrame.metadata()
+    member rotation     // Blink only as of 2025-12
+    member transfer     // Blink only as of 2025-12
+  }
 }

--- a/inputfiles/removedTypes.jsonc
+++ b/inputfiles/removedTypes.jsonc
@@ -382,16 +382,6 @@
                         "rotation": null // No implementation as of 2024-11
                     }
                 }
-            },
-            "VideoFrameBufferInit": {
-                "members": {
-                    "member": {
-                        "flip": null, // No implementation as of 2024-11
-                        "metadata": null, // No implementation as of 2024-04. Linked to VideoFrame.metadata()
-                        "rotation": null, // No implementation as of 2024-11
-                        "transfer": null // Blink only as of 2024-11
-                    }
-                }
             }
         }
     },


### PR DESCRIPTION
Blink:https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/webcodecs/video_frame_buffer_init.idl?q=VideoFrameBufferInit%20file:idl