### PR TITLE
Add linguist support for KDL and jsonc files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -62,13 +62,8 @@
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
 
-
 ###############################################################################
-# Show KDL in the language stats 
-###############################################################################
-*.kdl linguist-detectable
-
-###############################################################################
-# Show JSONC in the language stats 
+# Show manual patches in the language stats 
 ###############################################################################
 *.jsonc linguist-detectable
+*.kdl linguist-detectable


### PR DESCRIPTION
This adds KDL to the list of languages. Check https://github.com/bashamega/TypeScript-DOM-lib-generator

Got this idea from https://github.com/mdn/content/pull/14123