### PR TITLE
Fix incorrect MDN links for requestAnimationFrame/cancelAnimationFrame

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3424,9 +3424,9 @@ declare var AnimationEvent: {
 };
 
 interface AnimationFrameProvider {
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/cancelAnimationFrame) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/cancelAnimationFrame) */
     cancelAnimationFrame(handle: number): void;
-    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/requestAnimationFrame) */
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame) */
     requestAnimationFrame(callback: FrameRequestCallback): number;
 }
 
@@ -42986,9 +42986,9 @@ declare function toString(): string;
  * [MDN Reference](https://developer.mozilla.org/docs/Web/API/EventTarget/dispatchEvent)
  */
 declare function dispatchEvent(event: Event): boolean;
-/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/cancelAnimationFrame) */
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/cancelAnimationFrame) */
 declare function cancelAnimationFrame(handle: number): void;
-/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/Window/requestAnimationFrame) */
+/** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame) */
 declare function requestAnimationFrame(callback: FrameRequestCallback): number;
 /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/abort_event) */
 declare var onabort: ((this: Window, ev: UIEvent) => any) | null;

--- a/inputfiles/mdn.json
+++ b/inputfiles/mdn.json
@@ -5410,9 +5410,9 @@
     "summary": "The DedicatedWorkerGlobalScope object (the Worker global scope) is accessible through the self keyword. Some additional global functions, namespaces objects, and constructors, not typically associated with the worker global scope, but available on it, are listed in the JavaScript Reference. See also: Functions available to workers."
   },
   {
-    "mdn_url": "/en-US/docs/Web/API/DedicatedWorkerGlobalScope/cancelAnimationFrame",
+    "mdn_url": "/en-US/docs/Web/API/Window/cancelAnimationFrame",
     "pageType": "web-api-instance-method",
-    "summary": "The cancelAnimationFrame() method of the DedicatedWorkerGlobalScope interface cancels an animation frame request previously scheduled through a call to requestAnimationFrame()."
+    "summary": "The cancelAnimationFrame() method of the Window interface cancels an animation frame request previously scheduled through a call to requestAnimationFrame()."
   },
   {
     "mdn_url": "/en-US/docs/Web/API/DedicatedWorkerGlobalScope/close",
@@ -5440,9 +5440,9 @@
     "summary": "The postMessage() method of the DedicatedWorkerGlobalScope interface sends a message to the main thread that spawned it."
   },
   {
-    "mdn_url": "/en-US/docs/Web/API/DedicatedWorkerGlobalScope/requestAnimationFrame",
+    "mdn_url": "/en-US/docs/Web/API/Window/requestAnimationFrame",
     "pageType": "web-api-instance-method",
-    "summary": "The requestAnimationFrame() method of the DedicatedWorkerGlobalScope interface tells the browser you wish to perform an animation frame request and call a user-supplied callback function before the next repaint."
+    "summary": "The requestAnimationFrame() method of the Window interface ..."
   },
   {
     "mdn_url": "/en-US/docs/Web/API/DedicatedWorkerGlobalScope/rtctransform_event",


### PR DESCRIPTION
## What does this PR do?
Fixes incorrect MDN reference links for the animation frame APIs in `baselines/dom.generated.d.ts`.
Fixes #2154

## What was wrong?
The JSDoc MDN references for:
- `requestAnimationFrame`
- `cancelAnimationFrame`

were pointing to the `DedicatedWorkerGlobalScope` MDN pages, which is misleading when using these APIs as standard `Window` globals (e.g. `window.requestAnimationFrame(...)`, `window.cancelAnimationFrame(...)`).

## What changed?
Updated the MDN reference URLs to the correct `Window` pages:
- `https://developer.mozilla.org/docs/Web/API/Window/requestAnimationFrame`
- `https://developer.mozilla.org/docs/Web/API/Window/cancelAnimationFrame`

## Impact
This is a documentation/reference-only change:
- ✅ improves IntelliSense / hover tooltips
- ✅ no type signature changes
- ✅ no runtime behavior changes
