### PR TITLE
fix: add CSSStyleValue to Keyframe index signatures

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1386,7 +1386,7 @@ interface Keyframe {
     composite?: CompositeOperationOrAuto;
     easing?: string;
     offset?: number | null;
-    [property: string]: string | number | null | undefined;
+    [property: string]: string | number | CSSStyleValue | null | undefined;
 }
 
 interface KeyframeAnimationOptions extends KeyframeEffectOptions {
@@ -2006,7 +2006,7 @@ interface PropertyIndexedKeyframes {
     composite?: CompositeOperationOrAuto | CompositeOperationOrAuto[];
     easing?: string | string[];
     offset?: number | (number | null)[];
-    [property: string]: string | string[] | number | null | (number | null)[] | undefined;
+    [property: string]: string | string[] | number | CSSStyleValue | CSSStyleValue[] | null | (number | null)[] | undefined;
 }
 
 interface PublicKeyCredentialCreationOptions {

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -1383,7 +1383,7 @@ interface Keyframe {
     composite?: CompositeOperationOrAuto;
     easing?: string;
     offset?: number | null;
-    [property: string]: string | number | null | undefined;
+    [property: string]: string | number | CSSStyleValue | null | undefined;
 }
 
 interface KeyframeAnimationOptions extends KeyframeEffectOptions {
@@ -2003,7 +2003,7 @@ interface PropertyIndexedKeyframes {
     composite?: CompositeOperationOrAuto | CompositeOperationOrAuto[];
     easing?: string | string[];
     offset?: number | (number | null)[];
-    [property: string]: string | string[] | number | null | (number | null)[] | undefined;
+    [property: string]: string | string[] | number | CSSStyleValue | CSSStyleValue[] | null | (number | null)[] | undefined;
 }
 
 interface PublicKeyCredentialCreationOptions {

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -1383,7 +1383,7 @@ interface Keyframe {
     composite?: CompositeOperationOrAuto;
     easing?: string;
     offset?: number | null;
-    [property: string]: string | number | null | undefined;
+    [property: string]: string | number | CSSStyleValue | null | undefined;
 }
 
 interface KeyframeAnimationOptions extends KeyframeEffectOptions {
@@ -2003,7 +2003,7 @@ interface PropertyIndexedKeyframes {
     composite?: CompositeOperationOrAuto | CompositeOperationOrAuto[];
     easing?: string | string[];
     offset?: number | (number | null)[];
-    [property: string]: string | string[] | number | null | (number | null)[] | undefined;
+    [property: string]: string | string[] | number | CSSStyleValue | CSSStyleValue[] | null | (number | null)[] | undefined;
 }
 
 interface PublicKeyCredentialCreationOptions {

--- a/baselines/ts5.9/dom.generated.d.ts
+++ b/baselines/ts5.9/dom.generated.d.ts
@@ -1383,7 +1383,7 @@ interface Keyframe {
     composite?: CompositeOperationOrAuto;
     easing?: string;
     offset?: number | null;
-    [property: string]: string | number | null | undefined;
+    [property: string]: string | number | CSSStyleValue | null | undefined;
 }
 
 interface KeyframeAnimationOptions extends KeyframeEffectOptions {
@@ -2003,7 +2003,7 @@ interface PropertyIndexedKeyframes {
     composite?: CompositeOperationOrAuto | CompositeOperationOrAuto[];
     easing?: string | string[];
     offset?: number | (number | null)[];
-    [property: string]: string | string[] | number | null | (number | null)[] | undefined;
+    [property: string]: string | string[] | number | CSSStyleValue | CSSStyleValue[] | null | (number | null)[] | undefined;
 }
 
 interface PublicKeyCredentialCreationOptions {

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -2923,13 +2923,13 @@
             "BaseKeyframe": {
                 "name": "Keyframe",
                 "overrideIndexSignatures": [
-                    "[property: string]: string | number | null | undefined"
+                    "[property: string]: string | number | CSSStyleValue | null | undefined"
                 ]
             },
             "BasePropertyIndexedKeyframe": {
                 "name": "PropertyIndexedKeyframes",
                 "overrideIndexSignatures": [
-                    "[property: string]: string | string[] | number | null | (number | null)[] | undefined"
+                    "[property: string]: string | string[] | number | CSSStyleValue | CSSStyleValue[] | null | (number | null)[] | undefined"
                 ]
             },
             "BaseComputedKeyframe": {


### PR DESCRIPTION
## Summary

- Adds `CSSStyleValue` to the `Keyframe` and `PropertyIndexedKeyframes` index signatures
- Enables passing CSS Typed Object Model values directly to `element.animate()`, `KeyframeEffect()`, and `setKeyframes()`

## Problem

The Web Animations API supports passing CSS Typed OM values (e.g., `CSSUnitValue`, `CSSKeywordValue`, `CSSTransformValue`) to animation keyframes. This is valid at runtime:

```typescript
element.animate([
  { transform: new CSSTranslate(CSS.px(0), CSS.px(0)) },
  { transform: new CSSTranslate(CSS.px(100), CSS.px(100)) }
], { duration: 500 });
```

However, the current `Keyframe` interface only accepts `string | number | null | undefined` in its index signature, causing a TypeScript error for this valid usage.

## Changes

**`inputfiles/overridingTypes.jsonc`:**
- `Keyframe`: `[property: string]: string | number | CSSStyleValue | null | undefined`
- `PropertyIndexedKeyframes`: `[property: string]: string | string[] | number | CSSStyleValue | CSSStyleValue[] | null | (number | null)[] | undefined`

`ComputedKeyframe` is intentionally left unchanged — `getKeyframes()` returns computed string values, not `CSSStyleValue` objects.

## Motivation

- The `KeyframeAnimationOptions` interface already uses `CSSNumericValue | CSSKeywordValue` for `rangeStart`/`rangeEnd`, showing these types are recognized for animations
- [CSS Typed OM Level 1](https://www.w3.org/TR/css-typed-om-1/) is widely supported in modern browsers
- MDN documents [CSSStyleValue as valid for keyframe properties](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Typed_OM_API)

Fixes microsoft/TypeScript#63325