### PR TITLE
Add Element.setHTML() to addedTypes

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2694,6 +2694,10 @@ interface SecurityPolicyViolationEventInit extends EventInit {
     violatedDirective?: string;
 }
 
+interface SetHTMLOptions {
+    sanitizer?: Sanitizer | SanitizerConfig | SanitizerPresets;
+}
+
 interface ShadowRootInit {
     clonable?: boolean;
     customElementRegistry?: CustomElementRegistry | null;
@@ -13999,6 +14003,12 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/setAttributeNodeNS)
      */
     setAttributeNodeNS(attr: Attr): Attr | null;
+    /**
+     * The **`setHTML()`** method of the Element interface provides an XSS-safe method to parse and sanitize a string of HTML and insert it into the DOM as a subtree of the element.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/setHTML)
+     */
+    setHTML(html: string, options?: SetHTMLOptions): void;
     /**
      * The **`setHTMLUnsafe()`** method of the Element interface is used to parse HTML input into a DocumentFragment, optionally filtering out unwanted elements and attributes, and those that don't belong in the context, and then using it to replace the element's subtree in the DOM.
      *

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -2691,6 +2691,10 @@ interface SecurityPolicyViolationEventInit extends EventInit {
     violatedDirective?: string;
 }
 
+interface SetHTMLOptions {
+    sanitizer?: Sanitizer | SanitizerConfig | SanitizerPresets;
+}
+
 interface ShadowRootInit {
     clonable?: boolean;
     customElementRegistry?: CustomElementRegistry | null;
@@ -13986,6 +13990,12 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/setAttributeNodeNS)
      */
     setAttributeNodeNS(attr: Attr): Attr | null;
+    /**
+     * The **`setHTML()`** method of the Element interface provides an XSS-safe method to parse and sanitize a string of HTML and insert it into the DOM as a subtree of the element.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/setHTML)
+     */
+    setHTML(html: string, options?: SetHTMLOptions): void;
     /**
      * The **`setHTMLUnsafe()`** method of the Element interface is used to parse HTML input into a DocumentFragment, optionally filtering out unwanted elements and attributes, and those that don't belong in the context, and then using it to replace the element's subtree in the DOM.
      *

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -2691,6 +2691,10 @@ interface SecurityPolicyViolationEventInit extends EventInit {
     violatedDirective?: string;
 }
 
+interface SetHTMLOptions {
+    sanitizer?: Sanitizer | SanitizerConfig | SanitizerPresets;
+}
+
 interface ShadowRootInit {
     clonable?: boolean;
     customElementRegistry?: CustomElementRegistry | null;
@@ -13996,6 +14000,12 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/setAttributeNodeNS)
      */
     setAttributeNodeNS(attr: Attr): Attr | null;
+    /**
+     * The **`setHTML()`** method of the Element interface provides an XSS-safe method to parse and sanitize a string of HTML and insert it into the DOM as a subtree of the element.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/setHTML)
+     */
+    setHTML(html: string, options?: SetHTMLOptions): void;
     /**
      * The **`setHTMLUnsafe()`** method of the Element interface is used to parse HTML input into a DocumentFragment, optionally filtering out unwanted elements and attributes, and those that don't belong in the context, and then using it to replace the element's subtree in the DOM.
      *

--- a/baselines/ts5.9/dom.generated.d.ts
+++ b/baselines/ts5.9/dom.generated.d.ts
@@ -2691,6 +2691,10 @@ interface SecurityPolicyViolationEventInit extends EventInit {
     violatedDirective?: string;
 }
 
+interface SetHTMLOptions {
+    sanitizer?: Sanitizer | SanitizerConfig | SanitizerPresets;
+}
+
 interface ShadowRootInit {
     clonable?: boolean;
     customElementRegistry?: CustomElementRegistry | null;
@@ -13996,6 +14000,12 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/setAttributeNodeNS)
      */
     setAttributeNodeNS(attr: Attr): Attr | null;
+    /**
+     * The **`setHTML()`** method of the Element interface provides an XSS-safe method to parse and sanitize a string of HTML and insert it into the DOM as a subtree of the element.
+     *
+     * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/setHTML)
+     */
+    setHTML(html: string, options?: SetHTMLOptions): void;
     /**
      * The **`setHTMLUnsafe()`** method of the Element interface is used to parse HTML input into a DocumentFragment, optionally filtering out unwanted elements and attributes, and those that don't belong in the context, and then using it to replace the element's subtree in the DOM.
      *

--- a/inputfiles/addedTypes.jsonc
+++ b/inputfiles/addedTypes.jsonc
@@ -213,6 +213,26 @@
                                 "get textContent(): string",
                                 "set textContent(value: string | null)"
                             ]
+                        },
+                        "setHTML": {
+                            "name": "setHTML",
+                            "mdnUrl": "https://developer.mozilla.org/docs/Web/API/Element/setHTML",
+                            "signature": [
+                                {
+                                    "param": [
+                                        {
+                                            "name": "html",
+                                            "type": "DOMString"
+                                        },
+                                        {
+                                            "name": "options",
+                                            "type": "SetHTMLOptions",
+                                            "optional": true
+                                        }
+                                    ],
+                                    "type": "undefined"
+                                }
+                            ]
                         }
                     }
                 },


### PR DESCRIPTION
The setHTML() method is defined in the Sanitizer API spec (https://wicg.github.io/sanitizer-api/) but is currently missing from @webref/idl, as setHTML has not migrated over to the WHATWG spec yet.

However, there's already 2 engine support, Chrome 146+ (Blink) and Firefox 148+ (Gecko), meeting the 2-engine requirement. https://developer.mozilla.org/en-US/docs/Web/API/Element/setHTML

