### PR TITLE
Return cloneNode as the receiver type

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -26421,7 +26421,7 @@ interface Node extends EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/cloneNode)
      */
-    cloneNode(subtree?: boolean): Node;
+    cloneNode(subtree?: boolean): this;
     /**
      * The **`compareDocumentPosition()`** method of the Node interface reports the position of its argument node relative to the node on which it is called.
      *

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -26397,7 +26397,7 @@ interface Node extends EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/cloneNode)
      */
-    cloneNode(subtree?: boolean): Node;
+    cloneNode(subtree?: boolean): this;
     /**
      * The **`compareDocumentPosition()`** method of the Node interface reports the position of its argument node relative to the node on which it is called.
      *

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -26418,7 +26418,7 @@ interface Node extends EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/cloneNode)
      */
-    cloneNode(subtree?: boolean): Node;
+    cloneNode(subtree?: boolean): this;
     /**
      * The **`compareDocumentPosition()`** method of the Node interface reports the position of its argument node relative to the node on which it is called.
      *

--- a/baselines/ts5.9/dom.generated.d.ts
+++ b/baselines/ts5.9/dom.generated.d.ts
@@ -26418,7 +26418,7 @@ interface Node extends EventTarget {
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Node/cloneNode)
      */
-    cloneNode(subtree?: boolean): Node;
+    cloneNode(subtree?: boolean): this;
     /**
      * The **`compareDocumentPosition()`** method of the Node interface reports the position of its argument node relative to the node on which it is called.
      *

--- a/inputfiles/overridingTypes.jsonc
+++ b/inputfiles/overridingTypes.jsonc
@@ -559,6 +559,13 @@
             "Node": {
                 "methods": {
                     "method": {
+                        "cloneNode": {
+                            "signature": {
+                                "0": {
+                                    "overrideType": "this"
+                                }
+                            }
+                        },
                         "appendChild": {
                             "signature": {
                                 "0": {

--- a/unittests/files/cloneNode.ts
+++ b/unittests/files/cloneNode.ts
@@ -1,0 +1,30 @@
+declare const assertType: <T>() => <T1>(
+  _x: T1,
+) => StrictEqual<T, T1> extends true
+  ? () => void
+  : T1 extends T
+    ? { error: "Left side is not assignable to right side" }
+    : { error: "Right side is not assignable to left side" };
+
+type StrictEqual<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false;
+
+declare const node: Node;
+assertType<Node>()(node.cloneNode())();
+
+const div = document.createElement("div");
+assertType<HTMLDivElement>()(div.cloneNode(true))();
+
+declare const documentFragment: DocumentFragment;
+assertType<DocumentFragment>()(documentFragment.cloneNode())();
+
+declare const elementOrFragment: Element | DocumentFragment;
+assertType<Element | DocumentFragment>()(elementOrFragment.cloneNode())();
+
+class FancyButton extends HTMLButtonElement {}
+declare const fancyButton: FancyButton;
+assertType<FancyButton>()(fancyButton.cloneNode())();
+
+export {};


### PR DESCRIPTION
## Summary

I updated the DOM override for `Node.cloneNode` so the generated DOM libs return the receiver type instead of the base `Node` type. This keeps existing `Node` behavior as `Node`, while preserving exact static types for DOM subtypes and custom element subclasses.

Addresses microsoft/TypeScript#283.

## Why

`cloneNode` returns a clone of the node it is called on, but the current declaration forces callers to cast from `Node` even when the receiver has a more specific static type.

I also checked the prior `cloneNode` overload history before making this change. This patch uses one receiver-type return on `Node` rather than adding per-element overloads.

## Validation

- `npm run test`
- `npx tsc baselines/dom.generated.d.ts <@types/jquery> <@types/tablesorter> --target es2020 --lib es2020 --strict --noEmit --skipLibCheck false --typeRoots <scratch @types>`
- `npx tsc baselines/dom.generated.d.ts --lib es5 --noEmit --diagnostics`

Diagnostics comparison from this branch:

- base: symbols 127252, types 59180, instantiations 86295, memory 220514K, check 2.71s, total 4.07s
- patched: symbols 127573, types 59331, instantiations 86597, memory 223940K, check 2.78s, total 3.86s