### PR TITLE
Fix Element.matches strict narrowing

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14051,9 +14051,12 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/matches)
      */
-    matches<K extends keyof HTMLElementTagNameMap>(selectors: K): this is HTMLElementTagNameMap[K];
-    matches<K extends keyof SVGElementTagNameMap>(selectors: K): this is SVGElementTagNameMap[K];
-    matches<K extends keyof MathMLElementTagNameMap>(selectors: K): this is MathMLElementTagNameMap[K];
+    matches<K extends keyof ElementMatchesMap<HTMLElementTagNameMap, this>>(selectors: K): this is Extract<HTMLElementTagNameMap[K], this>;
+    matches<K extends keyof ElementMatchesMap<SVGElementTagNameMap, this>>(selectors: K): this is Extract<SVGElementTagNameMap[K], this>;
+    matches<K extends keyof ElementMatchesMap<MathMLElementTagNameMap, this>>(selectors: K): this is Extract<MathMLElementTagNameMap[K], this>;
+    matches<K extends keyof HTMLElementTagNameMap>(selectors: K): boolean;
+    matches<K extends keyof SVGElementTagNameMap>(selectors: K): boolean;
+    matches<K extends keyof MathMLElementTagNameMap>(selectors: K): boolean;
     matches(selectors: string): boolean;
     /**
      * The **`releasePointerCapture()`** method of the Element interface releases (stops) pointer capture that was previously set for a specific (PointerEvent) pointer.
@@ -43879,6 +43882,8 @@ interface MathMLElementTagNameMap {
     "munderover": MathMLElement;
     "semantics": MathMLElement;
 }
+
+type ElementMatchesMap<T, U> = { [K in keyof T as T[K] extends U ? U extends T[K] ? never : K : never]: T[K] };
 
 /** @deprecated Directly use HTMLElementTagNameMap or SVGElementTagNameMap as appropriate, instead. */
 type ElementTagNameMap = HTMLElementTagNameMap & Pick<SVGElementTagNameMap, Exclude<keyof SVGElementTagNameMap, keyof HTMLElementTagNameMap>>;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14051,9 +14051,9 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/matches)
      */
-    matches<K extends keyof ElementMatchesMap<HTMLElementTagNameMap, this>>(selectors: K): this is Extract<HTMLElementTagNameMap[K], this>;
-    matches<K extends keyof ElementMatchesMap<SVGElementTagNameMap, this>>(selectors: K): this is Extract<SVGElementTagNameMap[K], this>;
-    matches<K extends keyof ElementMatchesMap<MathMLElementTagNameMap, this>>(selectors: K): this is Extract<MathMLElementTagNameMap[K], this>;
+    matches<K extends keyof HTMLElementTagNameMap & keyof ElementMatchesNarrowingMap<HTMLElementTagNameMap, this>>(selectors: K): this is Extract<HTMLElementTagNameMap[K], this>;
+    matches<K extends keyof SVGElementTagNameMap & keyof ElementMatchesNarrowingMap<SVGElementTagNameMap, this>>(selectors: K): this is Extract<SVGElementTagNameMap[K], this>;
+    matches<K extends keyof MathMLElementTagNameMap & keyof ElementMatchesNarrowingMap<MathMLElementTagNameMap, this>>(selectors: K): this is Extract<MathMLElementTagNameMap[K], this>;
     matches<K extends keyof HTMLElementTagNameMap>(selectors: K): boolean;
     matches<K extends keyof SVGElementTagNameMap>(selectors: K): boolean;
     matches<K extends keyof MathMLElementTagNameMap>(selectors: K): boolean;
@@ -43883,7 +43883,33 @@ interface MathMLElementTagNameMap {
     "semantics": MathMLElement;
 }
 
-type ElementMatchesMap<T, U> = { [K in keyof T as T[K] extends U ? U extends T[K] ? never : K : never]: T[K] };
+type ElementMatchesNarrowingMap<ElementMap, ElementType> =
+    ElementType extends Element
+        ? Element extends ElementType
+            ? ElementMap
+            : [ElementMatchesBase<ElementType>] extends [never]
+                ? {}
+                : ElementMatchesStrictMap<ElementMap, ElementMatchesBase<ElementType>>
+        : {};
+
+type ElementMatchesBase<ElementType> =
+    HTMLElement extends ElementType
+        ? HTMLElement
+        : SVGElement extends ElementType
+            ? SVGElement
+            : MathMLElement extends ElementType
+                ? MathMLElement
+                : never;
+
+type ElementMatchesStrictMap<ElementMap, BaseElement> = {
+    [Key in keyof ElementMap as (
+        ElementMap[Key] extends BaseElement
+            ? BaseElement extends ElementMap[Key]
+                ? never
+                : Key
+            : never
+    )]: ElementMap[Key];
+};
 
 /** @deprecated Directly use HTMLElementTagNameMap or SVGElementTagNameMap as appropriate, instead. */
 type ElementTagNameMap = HTMLElementTagNameMap & Pick<SVGElementTagNameMap, Exclude<keyof SVGElementTagNameMap, keyof HTMLElementTagNameMap>>;

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -14038,9 +14038,12 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/matches)
      */
-    matches<K extends keyof HTMLElementTagNameMap>(selectors: K): this is HTMLElementTagNameMap[K];
-    matches<K extends keyof SVGElementTagNameMap>(selectors: K): this is SVGElementTagNameMap[K];
-    matches<K extends keyof MathMLElementTagNameMap>(selectors: K): this is MathMLElementTagNameMap[K];
+    matches<K extends keyof ElementMatchesMap<HTMLElementTagNameMap, this>>(selectors: K): this is Extract<HTMLElementTagNameMap[K], this>;
+    matches<K extends keyof ElementMatchesMap<SVGElementTagNameMap, this>>(selectors: K): this is Extract<SVGElementTagNameMap[K], this>;
+    matches<K extends keyof ElementMatchesMap<MathMLElementTagNameMap, this>>(selectors: K): this is Extract<MathMLElementTagNameMap[K], this>;
+    matches<K extends keyof HTMLElementTagNameMap>(selectors: K): boolean;
+    matches<K extends keyof SVGElementTagNameMap>(selectors: K): boolean;
+    matches<K extends keyof MathMLElementTagNameMap>(selectors: K): boolean;
     matches(selectors: string): boolean;
     /**
      * The **`releasePointerCapture()`** method of the Element interface releases (stops) pointer capture that was previously set for a specific (PointerEvent) pointer.
@@ -43853,6 +43856,8 @@ interface MathMLElementTagNameMap {
     "munderover": MathMLElement;
     "semantics": MathMLElement;
 }
+
+type ElementMatchesMap<T, U> = { [K in keyof T as T[K] extends U ? U extends T[K] ? never : K : never]: T[K] };
 
 /** @deprecated Directly use HTMLElementTagNameMap or SVGElementTagNameMap as appropriate, instead. */
 type ElementTagNameMap = HTMLElementTagNameMap & Pick<SVGElementTagNameMap, Exclude<keyof SVGElementTagNameMap, keyof HTMLElementTagNameMap>>;

--- a/baselines/ts5.5/dom.generated.d.ts
+++ b/baselines/ts5.5/dom.generated.d.ts
@@ -14038,9 +14038,9 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/matches)
      */
-    matches<K extends keyof ElementMatchesMap<HTMLElementTagNameMap, this>>(selectors: K): this is Extract<HTMLElementTagNameMap[K], this>;
-    matches<K extends keyof ElementMatchesMap<SVGElementTagNameMap, this>>(selectors: K): this is Extract<SVGElementTagNameMap[K], this>;
-    matches<K extends keyof ElementMatchesMap<MathMLElementTagNameMap, this>>(selectors: K): this is Extract<MathMLElementTagNameMap[K], this>;
+    matches<K extends keyof HTMLElementTagNameMap & keyof ElementMatchesNarrowingMap<HTMLElementTagNameMap, this>>(selectors: K): this is Extract<HTMLElementTagNameMap[K], this>;
+    matches<K extends keyof SVGElementTagNameMap & keyof ElementMatchesNarrowingMap<SVGElementTagNameMap, this>>(selectors: K): this is Extract<SVGElementTagNameMap[K], this>;
+    matches<K extends keyof MathMLElementTagNameMap & keyof ElementMatchesNarrowingMap<MathMLElementTagNameMap, this>>(selectors: K): this is Extract<MathMLElementTagNameMap[K], this>;
     matches<K extends keyof HTMLElementTagNameMap>(selectors: K): boolean;
     matches<K extends keyof SVGElementTagNameMap>(selectors: K): boolean;
     matches<K extends keyof MathMLElementTagNameMap>(selectors: K): boolean;
@@ -43857,7 +43857,33 @@ interface MathMLElementTagNameMap {
     "semantics": MathMLElement;
 }
 
-type ElementMatchesMap<T, U> = { [K in keyof T as T[K] extends U ? U extends T[K] ? never : K : never]: T[K] };
+type ElementMatchesNarrowingMap<ElementMap, ElementType> =
+    ElementType extends Element
+        ? Element extends ElementType
+            ? ElementMap
+            : [ElementMatchesBase<ElementType>] extends [never]
+                ? {}
+                : ElementMatchesStrictMap<ElementMap, ElementMatchesBase<ElementType>>
+        : {};
+
+type ElementMatchesBase<ElementType> =
+    HTMLElement extends ElementType
+        ? HTMLElement
+        : SVGElement extends ElementType
+            ? SVGElement
+            : MathMLElement extends ElementType
+                ? MathMLElement
+                : never;
+
+type ElementMatchesStrictMap<ElementMap, BaseElement> = {
+    [Key in keyof ElementMap as (
+        ElementMap[Key] extends BaseElement
+            ? BaseElement extends ElementMap[Key]
+                ? never
+                : Key
+            : never
+    )]: ElementMap[Key];
+};
 
 /** @deprecated Directly use HTMLElementTagNameMap or SVGElementTagNameMap as appropriate, instead. */
 type ElementTagNameMap = HTMLElementTagNameMap & Pick<SVGElementTagNameMap, Exclude<keyof SVGElementTagNameMap, keyof HTMLElementTagNameMap>>;

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -14048,9 +14048,12 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/matches)
      */
-    matches<K extends keyof HTMLElementTagNameMap>(selectors: K): this is HTMLElementTagNameMap[K];
-    matches<K extends keyof SVGElementTagNameMap>(selectors: K): this is SVGElementTagNameMap[K];
-    matches<K extends keyof MathMLElementTagNameMap>(selectors: K): this is MathMLElementTagNameMap[K];
+    matches<K extends keyof ElementMatchesMap<HTMLElementTagNameMap, this>>(selectors: K): this is Extract<HTMLElementTagNameMap[K], this>;
+    matches<K extends keyof ElementMatchesMap<SVGElementTagNameMap, this>>(selectors: K): this is Extract<SVGElementTagNameMap[K], this>;
+    matches<K extends keyof ElementMatchesMap<MathMLElementTagNameMap, this>>(selectors: K): this is Extract<MathMLElementTagNameMap[K], this>;
+    matches<K extends keyof HTMLElementTagNameMap>(selectors: K): boolean;
+    matches<K extends keyof SVGElementTagNameMap>(selectors: K): boolean;
+    matches<K extends keyof MathMLElementTagNameMap>(selectors: K): boolean;
     matches(selectors: string): boolean;
     /**
      * The **`releasePointerCapture()`** method of the Element interface releases (stops) pointer capture that was previously set for a specific (PointerEvent) pointer.
@@ -43876,6 +43879,8 @@ interface MathMLElementTagNameMap {
     "munderover": MathMLElement;
     "semantics": MathMLElement;
 }
+
+type ElementMatchesMap<T, U> = { [K in keyof T as T[K] extends U ? U extends T[K] ? never : K : never]: T[K] };
 
 /** @deprecated Directly use HTMLElementTagNameMap or SVGElementTagNameMap as appropriate, instead. */
 type ElementTagNameMap = HTMLElementTagNameMap & Pick<SVGElementTagNameMap, Exclude<keyof SVGElementTagNameMap, keyof HTMLElementTagNameMap>>;

--- a/baselines/ts5.6/dom.generated.d.ts
+++ b/baselines/ts5.6/dom.generated.d.ts
@@ -14048,9 +14048,9 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/matches)
      */
-    matches<K extends keyof ElementMatchesMap<HTMLElementTagNameMap, this>>(selectors: K): this is Extract<HTMLElementTagNameMap[K], this>;
-    matches<K extends keyof ElementMatchesMap<SVGElementTagNameMap, this>>(selectors: K): this is Extract<SVGElementTagNameMap[K], this>;
-    matches<K extends keyof ElementMatchesMap<MathMLElementTagNameMap, this>>(selectors: K): this is Extract<MathMLElementTagNameMap[K], this>;
+    matches<K extends keyof HTMLElementTagNameMap & keyof ElementMatchesNarrowingMap<HTMLElementTagNameMap, this>>(selectors: K): this is Extract<HTMLElementTagNameMap[K], this>;
+    matches<K extends keyof SVGElementTagNameMap & keyof ElementMatchesNarrowingMap<SVGElementTagNameMap, this>>(selectors: K): this is Extract<SVGElementTagNameMap[K], this>;
+    matches<K extends keyof MathMLElementTagNameMap & keyof ElementMatchesNarrowingMap<MathMLElementTagNameMap, this>>(selectors: K): this is Extract<MathMLElementTagNameMap[K], this>;
     matches<K extends keyof HTMLElementTagNameMap>(selectors: K): boolean;
     matches<K extends keyof SVGElementTagNameMap>(selectors: K): boolean;
     matches<K extends keyof MathMLElementTagNameMap>(selectors: K): boolean;
@@ -43880,7 +43880,33 @@ interface MathMLElementTagNameMap {
     "semantics": MathMLElement;
 }
 
-type ElementMatchesMap<T, U> = { [K in keyof T as T[K] extends U ? U extends T[K] ? never : K : never]: T[K] };
+type ElementMatchesNarrowingMap<ElementMap, ElementType> =
+    ElementType extends Element
+        ? Element extends ElementType
+            ? ElementMap
+            : [ElementMatchesBase<ElementType>] extends [never]
+                ? {}
+                : ElementMatchesStrictMap<ElementMap, ElementMatchesBase<ElementType>>
+        : {};
+
+type ElementMatchesBase<ElementType> =
+    HTMLElement extends ElementType
+        ? HTMLElement
+        : SVGElement extends ElementType
+            ? SVGElement
+            : MathMLElement extends ElementType
+                ? MathMLElement
+                : never;
+
+type ElementMatchesStrictMap<ElementMap, BaseElement> = {
+    [Key in keyof ElementMap as (
+        ElementMap[Key] extends BaseElement
+            ? BaseElement extends ElementMap[Key]
+                ? never
+                : Key
+            : never
+    )]: ElementMap[Key];
+};
 
 /** @deprecated Directly use HTMLElementTagNameMap or SVGElementTagNameMap as appropriate, instead. */
 type ElementTagNameMap = HTMLElementTagNameMap & Pick<SVGElementTagNameMap, Exclude<keyof SVGElementTagNameMap, keyof HTMLElementTagNameMap>>;

--- a/baselines/ts5.9/dom.generated.d.ts
+++ b/baselines/ts5.9/dom.generated.d.ts
@@ -14048,9 +14048,12 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/matches)
      */
-    matches<K extends keyof HTMLElementTagNameMap>(selectors: K): this is HTMLElementTagNameMap[K];
-    matches<K extends keyof SVGElementTagNameMap>(selectors: K): this is SVGElementTagNameMap[K];
-    matches<K extends keyof MathMLElementTagNameMap>(selectors: K): this is MathMLElementTagNameMap[K];
+    matches<K extends keyof ElementMatchesMap<HTMLElementTagNameMap, this>>(selectors: K): this is Extract<HTMLElementTagNameMap[K], this>;
+    matches<K extends keyof ElementMatchesMap<SVGElementTagNameMap, this>>(selectors: K): this is Extract<SVGElementTagNameMap[K], this>;
+    matches<K extends keyof ElementMatchesMap<MathMLElementTagNameMap, this>>(selectors: K): this is Extract<MathMLElementTagNameMap[K], this>;
+    matches<K extends keyof HTMLElementTagNameMap>(selectors: K): boolean;
+    matches<K extends keyof SVGElementTagNameMap>(selectors: K): boolean;
+    matches<K extends keyof MathMLElementTagNameMap>(selectors: K): boolean;
     matches(selectors: string): boolean;
     /**
      * The **`releasePointerCapture()`** method of the Element interface releases (stops) pointer capture that was previously set for a specific (PointerEvent) pointer.
@@ -43876,6 +43879,8 @@ interface MathMLElementTagNameMap {
     "munderover": MathMLElement;
     "semantics": MathMLElement;
 }
+
+type ElementMatchesMap<T, U> = { [K in keyof T as T[K] extends U ? U extends T[K] ? never : K : never]: T[K] };
 
 /** @deprecated Directly use HTMLElementTagNameMap or SVGElementTagNameMap as appropriate, instead. */
 type ElementTagNameMap = HTMLElementTagNameMap & Pick<SVGElementTagNameMap, Exclude<keyof SVGElementTagNameMap, keyof HTMLElementTagNameMap>>;

--- a/baselines/ts5.9/dom.generated.d.ts
+++ b/baselines/ts5.9/dom.generated.d.ts
@@ -14048,9 +14048,9 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, NonDocumentTyp
      *
      * [MDN Reference](https://developer.mozilla.org/docs/Web/API/Element/matches)
      */
-    matches<K extends keyof ElementMatchesMap<HTMLElementTagNameMap, this>>(selectors: K): this is Extract<HTMLElementTagNameMap[K], this>;
-    matches<K extends keyof ElementMatchesMap<SVGElementTagNameMap, this>>(selectors: K): this is Extract<SVGElementTagNameMap[K], this>;
-    matches<K extends keyof ElementMatchesMap<MathMLElementTagNameMap, this>>(selectors: K): this is Extract<MathMLElementTagNameMap[K], this>;
+    matches<K extends keyof HTMLElementTagNameMap & keyof ElementMatchesNarrowingMap<HTMLElementTagNameMap, this>>(selectors: K): this is Extract<HTMLElementTagNameMap[K], this>;
+    matches<K extends keyof SVGElementTagNameMap & keyof ElementMatchesNarrowingMap<SVGElementTagNameMap, this>>(selectors: K): this is Extract<SVGElementTagNameMap[K], this>;
+    matches<K extends keyof MathMLElementTagNameMap & keyof ElementMatchesNarrowingMap<MathMLElementTagNameMap, this>>(selectors: K): this is Extract<MathMLElementTagNameMap[K], this>;
     matches<K extends keyof HTMLElementTagNameMap>(selectors: K): boolean;
     matches<K extends keyof SVGElementTagNameMap>(selectors: K): boolean;
     matches<K extends keyof MathMLElementTagNameMap>(selectors: K): boolean;
@@ -43880,7 +43880,33 @@ interface MathMLElementTagNameMap {
     "semantics": MathMLElement;
 }
 
-type ElementMatchesMap<T, U> = { [K in keyof T as T[K] extends U ? U extends T[K] ? never : K : never]: T[K] };
+type ElementMatchesNarrowingMap<ElementMap, ElementType> =
+    ElementType extends Element
+        ? Element extends ElementType
+            ? ElementMap
+            : [ElementMatchesBase<ElementType>] extends [never]
+                ? {}
+                : ElementMatchesStrictMap<ElementMap, ElementMatchesBase<ElementType>>
+        : {};
+
+type ElementMatchesBase<ElementType> =
+    HTMLElement extends ElementType
+        ? HTMLElement
+        : SVGElement extends ElementType
+            ? SVGElement
+            : MathMLElement extends ElementType
+                ? MathMLElement
+                : never;
+
+type ElementMatchesStrictMap<ElementMap, BaseElement> = {
+    [Key in keyof ElementMap as (
+        ElementMap[Key] extends BaseElement
+            ? BaseElement extends ElementMap[Key]
+                ? never
+                : Key
+            : never
+    )]: ElementMap[Key];
+};
 
 /** @deprecated Directly use HTMLElementTagNameMap or SVGElementTagNameMap as appropriate, instead. */
 type ElementTagNameMap = HTMLElementTagNameMap & Pick<SVGElementTagNameMap, Exclude<keyof SVGElementTagNameMap, keyof HTMLElementTagNameMap>>;

--- a/src/build/emitter.ts
+++ b/src/build/emitter.ts
@@ -645,7 +645,7 @@ export function emitWebIdl(
       const paramName = m.signature[0].param![0].name;
       for (const mapName of tagNameMapNames) {
         printer.printLine(
-          `matches<K extends keyof ElementMatchesMap<${mapName}, this>>(${paramName}: K): this is Extract<${mapName}[K], this>;`,
+          `matches<K extends keyof ${mapName} & keyof ElementMatchesNarrowingMap<${mapName}, this>>(${paramName}: K): this is Extract<${mapName}[K], this>;`,
         );
       }
       for (const mapName of tagNameMapNames) {
@@ -722,8 +722,62 @@ export function emitWebIdl(
 
   function emitElementMatchesMap() {
     printer.printLine(
-      "type ElementMatchesMap<T, U> = { [K in keyof T as T[K] extends U ? U extends T[K] ? never : K : never]: T[K] };",
+      "type ElementMatchesNarrowingMap<ElementMap, ElementType> =",
     );
+    printer.increaseIndent();
+    printer.printLine("ElementType extends Element");
+    printer.increaseIndent();
+    printer.printLine("? Element extends ElementType");
+    printer.increaseIndent();
+    printer.printLine("? ElementMap");
+    printer.printLine(": [ElementMatchesBase<ElementType>] extends [never]");
+    printer.increaseIndent();
+    printer.printLine("? {}");
+    printer.printLine(
+      ": ElementMatchesStrictMap<ElementMap, ElementMatchesBase<ElementType>>",
+    );
+    printer.decreaseIndent();
+    printer.decreaseIndent();
+    printer.printLine(": {};");
+    printer.decreaseIndent();
+    printer.decreaseIndent();
+    printer.printLine("");
+    printer.printLine("type ElementMatchesBase<ElementType> =");
+    printer.increaseIndent();
+    printer.printLine("HTMLElement extends ElementType");
+    printer.increaseIndent();
+    printer.printLine("? HTMLElement");
+    printer.printLine(": SVGElement extends ElementType");
+    printer.increaseIndent();
+    printer.printLine("? SVGElement");
+    printer.printLine(": MathMLElement extends ElementType");
+    printer.increaseIndent();
+    printer.printLine("? MathMLElement");
+    printer.printLine(": never;");
+    printer.decreaseIndent();
+    printer.decreaseIndent();
+    printer.decreaseIndent();
+    printer.decreaseIndent();
+    printer.printLine("");
+    printer.printLine(
+      "type ElementMatchesStrictMap<ElementMap, BaseElement> = {",
+    );
+    printer.increaseIndent();
+    printer.printLine("[Key in keyof ElementMap as (");
+    printer.increaseIndent();
+    printer.printLine("ElementMap[Key] extends BaseElement");
+    printer.increaseIndent();
+    printer.printLine("? BaseElement extends ElementMap[Key]");
+    printer.increaseIndent();
+    printer.printLine("? never");
+    printer.printLine(": Key");
+    printer.decreaseIndent();
+    printer.printLine(": never");
+    printer.decreaseIndent();
+    printer.decreaseIndent();
+    printer.printLine(")]: ElementMap[Key];");
+    printer.decreaseIndent();
+    printer.printLine("};");
     printer.printLine("");
   }
 

--- a/src/build/emitter.ts
+++ b/src/build/emitter.ts
@@ -645,7 +645,12 @@ export function emitWebIdl(
       const paramName = m.signature[0].param![0].name;
       for (const mapName of tagNameMapNames) {
         printer.printLine(
-          `matches<K extends keyof ${mapName}>(${paramName}: K): this is ${mapName}[K];`,
+          `matches<K extends keyof ElementMatchesMap<${mapName}, this>>(${paramName}: K): this is Extract<${mapName}[K], this>;`,
+        );
+      }
+      for (const mapName of tagNameMapNames) {
+        printer.printLine(
+          `matches<K extends keyof ${mapName}>(${paramName}: K): boolean;`,
         );
       }
       printer.printLine(`matches(${paramName}: string): boolean;`);
@@ -711,6 +716,13 @@ export function emitWebIdl(
     );
     printer.printLine(
       "type ElementTagNameMap = HTMLElementTagNameMap & Pick<SVGElementTagNameMap, Exclude<keyof SVGElementTagNameMap, keyof HTMLElementTagNameMap>>;",
+    );
+    printer.printLine("");
+  }
+
+  function emitElementMatchesMap() {
+    printer.printLine(
+      "type ElementMatchesMap<T, U> = { [K in keyof T as T[K] extends U ? U extends T[K] ? never : K : never]: T[K] };",
     );
     printer.printLine("");
   }
@@ -1664,6 +1676,7 @@ export function emitWebIdl(
         "MathMLElementTagNameMap",
         tagNameToEleName.mathMLResult,
       );
+      emitElementMatchesMap();
       emitDeprecatedHTMLOrSVGElementTagNameMap();
       emitNamedConstructors();
     }

--- a/unittests/files/matches.ts
+++ b/unittests/files/matches.ts
@@ -1,0 +1,19 @@
+declare const element: Element;
+declare const htmlElement: HTMLElement;
+declare const htmlTableCellElement: HTMLTableCellElement;
+
+if (element.matches("dt")) {
+  const narrowed: HTMLElement = element;
+}
+
+if (!htmlElement.matches("dt")) {
+  htmlElement.id;
+}
+
+if (htmlElement.matches("td")) {
+  const narrowed: HTMLTableCellElement = htmlElement;
+}
+
+if (!htmlTableCellElement.matches("th")) {
+  htmlTableCellElement.id;
+}

--- a/unittests/files/matches.ts
+++ b/unittests/files/matches.ts
@@ -1,5 +1,6 @@
 declare const element: Element;
 declare const htmlElement: HTMLElement;
+declare const htmlDivElement: HTMLDivElement;
 declare const htmlTableCellElement: HTMLTableCellElement;
 
 if (element.matches("dt")) {
@@ -12,6 +13,19 @@ if (!htmlElement.matches("dt")) {
 
 if (htmlElement.matches("td")) {
   const narrowed: HTMLTableCellElement = htmlElement;
+}
+
+if (htmlElement.matches("div")) {
+  const narrowed: HTMLDivElement = htmlElement;
+}
+
+if (!htmlDivElement.matches("div")) {
+  htmlDivElement.id;
+}
+
+if (htmlDivElement.matches("object")) {
+  // @ts-expect-error HTMLDivElement should not narrow to HTMLObjectElement.
+  const narrowed: HTMLObjectElement = htmlDivElement;
 }
 
 if (!htmlTableCellElement.matches("th")) {


### PR DESCRIPTION
Fixes microsoft/TypeScript#63497.

This follows the direction discussed in that issue: `matches()` should only act as a type guard when the selected tag's element type is a strict subtype of the current receiver type. For tags that map back to the same receiver type, it should still be accepted but return `boolean`, so the false branch does not narrow the receiver to `never`.

## Summary
- restrict `Element.matches()` type-predicate overloads to strict subtype matches
- keep tag-name boolean overloads for same-type matches
- regenerate DOM baselines
- add a compile-only regression fixture for the reported false-branch `never` behavior

## Validation
- `npm run generate`
- `npm test`
- focused local TypeScript probe: the current baseline produced `Property 'id' does not exist on type 'never'`; the patched baseline compiles cleanly
