### PR TITLE
Set bot identity for create-pull-request commits

### DIFF
--- a/.github/workflows/update-core-deps.yml
+++ b/.github/workflows/update-core-deps.yml
@@ -69,5 +69,7 @@ jobs:
         with:
           commit-message: "🤖 Update core dependencies"
           title: "Update core dependencies"
+          author: "typescript-automation[bot] <290192711+typescript-automation[bot]@users.noreply.github.com>"
+          committer: "typescript-automation[bot] <290192711+typescript-automation[bot]@users.noreply.github.com>"
           branch: update-core-deps
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Without explicit author/committer, create-pull-request uses the workflow trigger's identity.