### PR TITLE
Manually update to bcd@8.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@eslint/js": "^10",
-        "@mdn/browser-compat-data": "^7.0.0",
+        "@mdn/browser-compat-data": "^8.0.1",
         "@octokit/rest": "^22.0.0",
         "@types/node": "^25.0.3",
         "@types/prettier": "^3.0.0",
@@ -22,7 +22,7 @@
         "@webref/elements": "^2.5.0",
         "@webref/events": "^1.18.6",
         "@webref/idl": "^3.66.2",
-        "bcd-idl-mapper": "^3.0.1",
+        "bcd-idl-mapper": "^3.0.2",
         "cpx2": "^9.0.0",
         "danger": "^13.0.4",
         "eslint": "^10.0.2",
@@ -313,9 +313,9 @@
       }
     },
     "node_modules/@mdn/browser-compat-data": {
-      "version": "7.3.17",
-      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-7.3.17.tgz",
-      "integrity": "sha512-ZtcyRH/psFX4njAEvY898TH/VYknOaeEe2KJdldak4eDsj4MufSY2sXtBJ2IKjZ3jAvLUBRVf8+bv8q2xDHVDg==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-8.0.1.tgz",
+      "integrity": "sha512-po0/NXwUB3bc6DpYfAATqGBVwl4gfqmvWySixcBePwmOLTgsmwnwevRaIbs5glXucQLDpayGbh4C3hKIQr6l2A==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -1200,16 +1200,16 @@
       }
     },
     "node_modules/bcd-idl-mapper": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bcd-idl-mapper/-/bcd-idl-mapper-3.0.1.tgz",
-      "integrity": "sha512-gUdGOJYhxnmyePEnNCTEIJ+kZ3ZAaUC3wkdQDs/RtuuanALmWXRuMjJqeCEh2+c369yo1CwjH2J6To9j+fg2Bg==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcd-idl-mapper/-/bcd-idl-mapper-3.0.2.tgz",
+      "integrity": "sha512-YmGbkQAfwKJChLFtgV9WWBX6dswyB8pMDl7Na7wMkVQmBMDMPqMwLI99QGscqjfdlHX45ENUj0HBROakKSM8Nw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "webidl2": "^24.4.1"
       },
       "peerDependencies": {
-        "@mdn/browser-compat-data": "^6.0.24 || ^7.0.0",
+        "@mdn/browser-compat-data": "^6.0.24 || ^7.0.0 || ^8.0.0",
         "@webref/idl": "^3.65.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "type": "module",
   "devDependencies": {
     "@eslint/js": "^10",
-    "@mdn/browser-compat-data": "^7.0.0",
+    "@mdn/browser-compat-data": "^8.0.1",
     "@octokit/rest": "^22.0.0",
     "@types/node": "^25.0.3",
     "@types/prettier": "^3.0.0",
@@ -54,7 +54,7 @@
     "@webref/elements": "^2.5.0",
     "@webref/events": "^1.18.6",
     "@webref/idl": "^3.66.2",
-    "bcd-idl-mapper": "^3.0.1",
+    "bcd-idl-mapper": "^3.0.2",
     "cpx2": "^9.0.0",
     "danger": "^13.0.4",
     "eslint": "^10.0.2",


### PR DESCRIPTION
This gives no diff, the upstream just made some TS types more strict: https://github.com/mdn/browser-compat-data/releases/tag/v8.0.0