### PR TITLE
Fix TypeScript baseline acceptance in CI

### DIFF
--- a/.github/workflows/test_typescript.yml
+++ b/.github/workflows/test_typescript.yml
@@ -39,7 +39,7 @@ jobs:
 
           # Run TypeScript's tests with the new DOM libs, but don't fail
           npm test || true
-          gulp baseline-accept
+          npx hereby baseline-accept
 
           # The git diff now is the difference between tests
           git diff > baseline-changes.diff


### PR DESCRIPTION
When we did the repo migration, I did not bring over the `.gulp.js` shim that the old TS repo had.